### PR TITLE
Adds product pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,7 @@ yarn-error.log*
 
 # vscode
 .vscode
+
+# takeshape
+.graphqlconfig
+.takeshaperc

--- a/.takeshape/pattern/schema.json
+++ b/.takeshape/pattern/schema.json
@@ -6,9 +6,7 @@
   "created": "2021-06-08T13:12:26.923Z",
   "updated": "2022-03-24T21:28:00.915Z",
   "defaultLocale": "en-us",
-  "locales": [
-    "en-us"
-  ],
+  "locales": ["en-us"],
   "workflows": {},
   "forms": {
     "Profile": {
@@ -33,14 +31,7 @@
             "widget": "singleLineText"
           }
         },
-        "order": [
-          "id",
-          "name",
-          "email",
-          "bio",
-          "avatar",
-          "stripeCustomerId"
-        ]
+        "order": ["id", "name", "email", "bio", "avatar", "stripeCustomerId"]
       }
     }
   },
@@ -111,6 +102,19 @@
       },
       "description": "Fetch Stripe products from the API Index.",
       "args": "TSListArgs<Stripe_Product>"
+    },
+    "getIndexedProduct": {
+      "shape": "Stripe_Product",
+      "resolver": {
+        "shapeName": "Stripe_Product",
+        "name": "takeshape:queryApiIndex",
+        "service": "takeshape:local",
+        "options": {
+          "indexedShape": "Stripe_Product"
+        }
+      },
+      "description": "Fetch Stripe products from the API Index.",
+      "args": "TSGetArgs<Stripe_Product>"
     },
     "getMyProfile": {
       "shape": "Profile",
@@ -273,13 +277,7 @@
           },
           "status": {
             "type": "string",
-            "enum": [
-              "draft",
-              "open",
-              "paid",
-              "uncollectable",
-              "void"
-            ]
+            "enum": ["draft", "open", "paid", "uncollectable", "void"]
           },
           "limit": {
             "type": "number"
@@ -363,10 +361,7 @@
                 [
                   "filter",
                   {
-                    "predicate": [
-                      "status",
-                      "succeeded"
-                    ]
+                    "predicate": ["status", "succeeded"]
                   }
                 ]
               ]
@@ -609,9 +604,7 @@
             "type": "string"
           }
         },
-        "required": [
-          "id"
-        ]
+        "required": ["id"]
       }
     }
   },
@@ -1064,9 +1057,7 @@
             "type": "string"
           }
         },
-        "required": [
-          "subscriptionId"
-        ]
+        "required": ["subscriptionId"]
       }
     },
     "createMyCheckoutSession": {
@@ -1170,11 +1161,7 @@
           },
           "mode": {
             "type": "string",
-            "enum": [
-              "payment",
-              "subscription",
-              "setup"
-            ]
+            "enum": ["payment", "subscription", "setup"]
           },
           "lineItems": {
             "type": "array",
@@ -1191,10 +1178,7 @@
             }
           }
         },
-        "required": [
-          "lineItems",
-          "redirectUrl"
-        ]
+        "required": ["lineItems", "redirectUrl"]
       }
     },
     "updateProfile": {
@@ -1373,9 +1357,7 @@
             "description": "",
             "$ref": "#/shapes/TSRelationship/schema",
             "@relationship": {
-              "shapeIds": [
-                "ASSET"
-              ]
+              "shapeIds": ["ASSET"]
             },
             "title": "Avatar",
             "@mapping": "takeshape:local:Profile.k0Ha4O7oV"

--- a/.takeshape/pattern/schema.json
+++ b/.takeshape/pattern/schema.json
@@ -103,19 +103,6 @@
       "description": "Fetch Stripe products from the API Index.",
       "args": "TSListArgs<Stripe_Product>"
     },
-    "getIndexedProduct": {
-      "shape": "Stripe_Product",
-      "resolver": {
-        "shapeName": "Stripe_Product",
-        "name": "takeshape:queryApiIndex",
-        "service": "takeshape:local",
-        "options": {
-          "indexedShape": "Stripe_Product"
-        }
-      },
-      "description": "Fetch Stripe products from the API Index.",
-      "args": "TSGetArgs<Stripe_Product>"
-    },
     "getMyProfile": {
       "shape": "Profile",
       "resolver": {

--- a/components/products.jsx
+++ b/components/products.jsx
@@ -1,7 +1,9 @@
 import { useState } from 'react';
+import NextLink from 'next/link';
 import {
   Grid,
   Box,
+  Link,
   Card,
   Heading,
   Paragraph,
@@ -143,39 +145,49 @@ export const ProductCard = ({ product }) => {
 
   return (
     <Card sx={{ height: '100%' }}>
-      <Flex sx={{ height: '100%', flexDirection: 'column' }}>
-        <Box>
-          <ProductImage images={images} />
+      <Flex sx={{ height: '100%', flexDirection: 'row', flexWrap: 'wrap' }}>
+        <Box sx={{ flex: '1 1 24em', minWidth: '8em' }}>
+          <NextLink href={`/product/${product.id}`} passHref>
+            <Link>
+              <ProductImage images={images} />
+            </Link>
+          </NextLink>
         </Box>
-        <Box>
-          <Heading>{name}</Heading>
-        </Box>
-        <Box sx={{ flexGrow: 1 }}>
-          <Paragraph>{description}</Paragraph>
-        </Box>
-        <Box>
-          <ProductPrice price={price} />
+        <Flex sx={{ flex: '1 1 24em', flexDirection: 'column', justifyContent: 'space-between' }}>
+          <Box sx={{ flexGrow: 0 }}>
+            <Heading>
+              <NextLink href={`/product/${product.id}`} passHref>
+                <Link sx={{ color: 'inherit' }}>{name}</Link>
+              </NextLink>
+            </Heading>
+          </Box>
+          <Box sx={{ flexGrow: 1 }}>
+            <Paragraph>{description}</Paragraph>
+          </Box>
+          <Box>
+            <ProductPrice price={price} />
 
-          {oneTimePayment && recurringPayments.length ? (
-            <ProductPaymentToggle purchaseType={purchaseType} onChange={handleUpdatePurchaseType} />
-          ) : null}
+            {oneTimePayment && recurringPayments.length ? (
+              <ProductPaymentToggle purchaseType={purchaseType} onChange={handleUpdatePurchaseType} />
+            ) : null}
 
-          {recurringPayments.length ? (
-            <ProductRecurringSelect
-              currentPrice={price}
-              recurringPayments={recurringPayments}
-              onChange={handleUpdateRecurring}
-            />
-          ) : null}
+            {recurringPayments.length ? (
+              <ProductRecurringSelect
+                currentPrice={price}
+                recurringPayments={recurringPayments}
+                onChange={handleUpdateRecurring}
+              />
+            ) : null}
 
-          <Box>Quantity</Box>
-          <Grid columns={[2]}>
-            <ProductQuantitySelect onChange={handleUpdateQuantity} />
-            <Button type="button" onClick={handleAddToCart}>
-              <small>ADD TO CART</small>
-            </Button>
-          </Grid>
-        </Box>
+            <Box>Quantity</Box>
+            <Grid columns={[2]}>
+              <ProductQuantitySelect onChange={handleUpdateQuantity} />
+              <Button type="button" onClick={handleAddToCart}>
+                <small>ADD TO CART</small>
+              </Button>
+            </Grid>
+          </Box>
+        </Flex>
       </Flex>
     </Card>
   );

--- a/lib/queries.ts
+++ b/lib/queries.ts
@@ -1,8 +1,15 @@
 import { gql } from '@apollo/client';
+import { Stripe_Product } from './takeshape/types';
+
+export interface StripeProducts {
+  products: {
+    items: Stripe_Product[];
+  };
+}
 
 export const GetStripeProducts = gql`
   query GetStripeProductsQuery {
-    products: getIndexedProductList(where: {active: {eq: true}}) {
+    products: getIndexedProductList(where: { active: { eq: true } }) {
       items {
         id
         name
@@ -16,6 +23,34 @@ export const GetStripeProducts = gql`
             interval
             intervalCount: interval_count
           }
+        }
+      }
+    }
+  }
+`;
+
+export interface GetStripeProductArgs {
+  id: string;
+}
+
+export type GetStripeProductQuery = {
+  product: Stripe_Product;
+};
+
+export const GetStripeProduct = gql`
+  query GetStripeProductQuery($id: String!) {
+    product: Stripe_getProduct(id: $id) {
+      id
+      name
+      description
+      images
+      prices {
+        id
+        unitAmount: unit_amount
+        currency
+        recurring {
+          interval
+          intervalCount: interval_count
         }
       }
     }

--- a/lib/takeshape/types.d.ts
+++ b/lib/takeshape/types.d.ts
@@ -1,0 +1,11473 @@
+export type Maybe<T> = T | null;
+export type InputMaybe<T> = Maybe<T>;
+export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
+export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
+/** All built-in and custom scalars, mapped to their actual values */
+export type Scalars = {
+  ID: string;
+  String: string;
+  Boolean: boolean;
+  Int: number;
+  Float: number;
+  /** The `JSON` scalar type represents JSON values as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf). */
+  JSON: any;
+  /** The `JSONObject` scalar type represents JSON objects as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf). */
+  JSONObject: any;
+};
+
+/** Root of the Schema */
+export type Query = {
+  __typename?: 'Query';
+  taxonomySuggest?: Maybe<TsSuggestionPaginatedList>;
+  /** List Versions for a piece of content */
+  getContentVersion?: Maybe<TsVersionResponse>;
+  /** List Versions for a piece of content */
+  getContentVersionList?: Maybe<TsVersionsPaginatedList>;
+  /** Get a Asset by ID */
+  getAsset?: Maybe<Asset>;
+  /** Returns a list Asset in natural order. */
+  getAssetList?: Maybe<AssetPaginatedList>;
+  /** Get a TsStaticSite by ID */
+  getTsStaticSite?: Maybe<TsStaticSite>;
+  /** Returns a list TsStaticSite in natural order. */
+  getTsStaticSiteList?: Maybe<TsStaticSitePaginatedList>;
+  /** Fetch Stripe products from the API Index. */
+  getIndexedProductList?: Maybe<Stripe_ProductPaginatedList>;
+  /** Get my profile */
+  getMyProfile?: Maybe<Profile>;
+  /** Get my subscriptions */
+  getMySubscriptions?: Maybe<Array<Maybe<Stripe_Subscription>>>;
+  /** Get my invoices */
+  getMyInvoices?: Maybe<Array<Maybe<Stripe_Invoice>>>;
+  /** Get my payments */
+  getMyPayments?: Maybe<Array<Maybe<Stripe_PaymentIntent>>>;
+  /** Get Stripe products. */
+  getStripeProducts?: Maybe<Stripe_ListProductsResponse>;
+  /** Get a profile by ID */
+  getProfile?: Maybe<Profile>;
+  /** Returns a list of profiles in natural order. */
+  getProfileList?: Maybe<ProfilePaginatedList>;
+  /** <p>Returns a list of your products. The products are returned sorted by creation date, with the most recently created products appearing first.</p> */
+  Stripe_listProducts?: Maybe<Stripe_ListProductsResponse>;
+  /** <p>Retrieves the details of an existing product. Supply the unique product ID from either a product creation request or the product list, and Stripe will return the corresponding product information.</p> */
+  Stripe_getProduct?: Maybe<Stripe_Product>;
+  searchAssetIndex?: Maybe<AssetSearchResults>;
+  searchTsStaticSiteIndex?: Maybe<TsStaticSiteSearchResults>;
+  searchProfileIndex?: Maybe<ProfileSearchResults>;
+  search?: Maybe<TsSearchableSearchResults>;
+  withContext?: Maybe<WithContext>;
+};
+
+
+/** Root of the Schema */
+export type QueryTaxonomySuggestArgs = {
+  shapeNames?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  shapeIds?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  contentTypeNames?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  contentTypeIds?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  terms?: InputMaybe<Scalars['String']>;
+  locale?: InputMaybe<Scalars['String']>;
+  enableLocaleFallback?: InputMaybe<Scalars['Boolean']>;
+  from?: InputMaybe<Scalars['Int']>;
+  size?: InputMaybe<Scalars['Int']>;
+  filter?: InputMaybe<Scalars['JSON']>;
+  sort?: InputMaybe<Array<InputMaybe<TsSearchSort>>>;
+};
+
+
+/** Root of the Schema */
+export type QueryGetContentVersionArgs = {
+  id: Scalars['ID'];
+  version: Scalars['Int'];
+  locale?: InputMaybe<Scalars['String']>;
+  enableLocaleFallback?: InputMaybe<Scalars['Boolean']>;
+};
+
+
+/** Root of the Schema */
+export type QueryGetContentVersionListArgs = {
+  id: Scalars['ID'];
+  from?: InputMaybe<Scalars['Int']>;
+  size?: InputMaybe<Scalars['Int']>;
+};
+
+
+/** Root of the Schema */
+export type QueryGetAssetArgs = {
+  _id: Scalars['ID'];
+  locale?: InputMaybe<Scalars['String']>;
+  enableLocaleFallback?: InputMaybe<Scalars['Boolean']>;
+};
+
+
+/** Root of the Schema */
+export type QueryGetAssetListArgs = {
+  terms?: InputMaybe<Scalars['String']>;
+  from?: InputMaybe<Scalars['Int']>;
+  size?: InputMaybe<Scalars['Int']>;
+  filter?: InputMaybe<Scalars['JSONObject']>;
+  sort?: InputMaybe<Array<InputMaybe<TsSearchSortInput>>>;
+  locale?: InputMaybe<Scalars['String']>;
+  enableLocaleFallback?: InputMaybe<Scalars['Boolean']>;
+  onlyEnabled?: InputMaybe<Scalars['Boolean']>;
+  where?: InputMaybe<TsWhereAssetInput>;
+};
+
+
+/** Root of the Schema */
+export type QueryGetTsStaticSiteArgs = {
+  _id: Scalars['ID'];
+  locale?: InputMaybe<Scalars['String']>;
+  enableLocaleFallback?: InputMaybe<Scalars['Boolean']>;
+};
+
+
+/** Root of the Schema */
+export type QueryGetTsStaticSiteListArgs = {
+  terms?: InputMaybe<Scalars['String']>;
+  from?: InputMaybe<Scalars['Int']>;
+  size?: InputMaybe<Scalars['Int']>;
+  filter?: InputMaybe<Scalars['JSONObject']>;
+  sort?: InputMaybe<Array<InputMaybe<TsSearchSortInput>>>;
+  locale?: InputMaybe<Scalars['String']>;
+  enableLocaleFallback?: InputMaybe<Scalars['Boolean']>;
+  onlyEnabled?: InputMaybe<Scalars['Boolean']>;
+  where?: InputMaybe<TsWhereTsStaticSiteInput>;
+};
+
+
+/** Root of the Schema */
+export type QueryGetIndexedProductListArgs = {
+  terms?: InputMaybe<Scalars['String']>;
+  from?: InputMaybe<Scalars['Int']>;
+  size?: InputMaybe<Scalars['Int']>;
+  filter?: InputMaybe<Scalars['JSONObject']>;
+  sort?: InputMaybe<Array<InputMaybe<TsSearchSortInput>>>;
+  locale?: InputMaybe<Scalars['String']>;
+  enableLocaleFallback?: InputMaybe<Scalars['Boolean']>;
+  onlyEnabled?: InputMaybe<Scalars['Boolean']>;
+  where?: InputMaybe<TsWhereStripeProductInput>;
+};
+
+
+/** Root of the Schema */
+export type QueryGetMySubscriptionsArgs = {
+  expand?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+};
+
+
+/** Root of the Schema */
+export type QueryGetMyInvoicesArgs = {
+  expand?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  status?: InputMaybe<Scalars['String']>;
+  limit?: InputMaybe<Scalars['Float']>;
+  created?: InputMaybe<Scalars['JSON']>;
+  startingAfter?: InputMaybe<Scalars['String']>;
+};
+
+
+/** Root of the Schema */
+export type QueryGetMyPaymentsArgs = {
+  expand?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  limit?: InputMaybe<Scalars['Float']>;
+  created?: InputMaybe<Scalars['JSON']>;
+  startingAfter?: InputMaybe<Scalars['String']>;
+  endingBefore?: InputMaybe<Scalars['String']>;
+};
+
+
+/** Root of the Schema */
+export type QueryGetProfileArgs = {
+  _id: Scalars['ID'];
+  locale?: InputMaybe<Scalars['String']>;
+  enableLocaleFallback?: InputMaybe<Scalars['Boolean']>;
+};
+
+
+/** Root of the Schema */
+export type QueryGetProfileListArgs = {
+  terms?: InputMaybe<Scalars['String']>;
+  from?: InputMaybe<Scalars['Int']>;
+  size?: InputMaybe<Scalars['Int']>;
+  filter?: InputMaybe<Scalars['JSONObject']>;
+  sort?: InputMaybe<Array<InputMaybe<TsSearchSortInput>>>;
+  locale?: InputMaybe<Scalars['String']>;
+  enableLocaleFallback?: InputMaybe<Scalars['Boolean']>;
+  onlyEnabled?: InputMaybe<Scalars['Boolean']>;
+  where?: InputMaybe<TsWhereProfileInput>;
+};
+
+
+/** Root of the Schema */
+export type QueryStripe_ListProductsArgs = {
+  active?: InputMaybe<Scalars['Boolean']>;
+  created?: InputMaybe<Scalars['JSON']>;
+  ending_before?: InputMaybe<Scalars['String']>;
+  expand?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  ids?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  limit?: InputMaybe<Scalars['Int']>;
+  shippable?: InputMaybe<Scalars['Boolean']>;
+  starting_after?: InputMaybe<Scalars['String']>;
+  url?: InputMaybe<Scalars['String']>;
+};
+
+
+/** Root of the Schema */
+export type QueryStripe_GetProductArgs = {
+  expand?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  id: Scalars['String'];
+};
+
+
+/** Root of the Schema */
+export type QuerySearchAssetIndexArgs = {
+  terms?: InputMaybe<Scalars['String']>;
+  from?: InputMaybe<Scalars['Int']>;
+  size?: InputMaybe<Scalars['Int']>;
+  filter?: InputMaybe<Scalars['JSONObject']>;
+  sort?: InputMaybe<Array<InputMaybe<TsSearchSortInput>>>;
+  locale?: InputMaybe<Scalars['String']>;
+  enableLocaleFallback?: InputMaybe<Scalars['Boolean']>;
+  where?: InputMaybe<TsWhereAssetInput>;
+};
+
+
+/** Root of the Schema */
+export type QuerySearchTsStaticSiteIndexArgs = {
+  terms?: InputMaybe<Scalars['String']>;
+  from?: InputMaybe<Scalars['Int']>;
+  size?: InputMaybe<Scalars['Int']>;
+  filter?: InputMaybe<Scalars['JSONObject']>;
+  sort?: InputMaybe<Array<InputMaybe<TsSearchSortInput>>>;
+  locale?: InputMaybe<Scalars['String']>;
+  enableLocaleFallback?: InputMaybe<Scalars['Boolean']>;
+  where?: InputMaybe<TsWhereTsStaticSiteInput>;
+};
+
+
+/** Root of the Schema */
+export type QuerySearchProfileIndexArgs = {
+  terms?: InputMaybe<Scalars['String']>;
+  from?: InputMaybe<Scalars['Int']>;
+  size?: InputMaybe<Scalars['Int']>;
+  filter?: InputMaybe<Scalars['JSONObject']>;
+  sort?: InputMaybe<Array<InputMaybe<TsSearchSortInput>>>;
+  locale?: InputMaybe<Scalars['String']>;
+  enableLocaleFallback?: InputMaybe<Scalars['Boolean']>;
+  where?: InputMaybe<TsWhereProfileInput>;
+};
+
+
+/** Root of the Schema */
+export type QuerySearchArgs = {
+  terms?: InputMaybe<Scalars['String']>;
+  from?: InputMaybe<Scalars['Int']>;
+  size?: InputMaybe<Scalars['Int']>;
+  filter?: InputMaybe<Scalars['JSONObject']>;
+  sort?: InputMaybe<Array<InputMaybe<TsSearchSortInput>>>;
+  locale?: InputMaybe<Scalars['String']>;
+  enableLocaleFallback?: InputMaybe<Scalars['Boolean']>;
+  shapeNames?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  shapeIds?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  contentTypeNames?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  contentTypeIds?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  where?: InputMaybe<TsWhereInput>;
+};
+
+
+/** Root of the Schema */
+export type QueryWithContextArgs = {
+  locale?: InputMaybe<Scalars['String']>;
+  enableLocaleFallback?: InputMaybe<Scalars['Boolean']>;
+};
+
+export type TsSuggestionPaginatedList = {
+  __typename?: 'TSSuggestionPaginatedList';
+  items?: Maybe<Array<Maybe<TsSuggestion>>>;
+  total?: Maybe<Scalars['Int']>;
+};
+
+export type TsSuggestion = {
+  __typename?: 'TSSuggestion';
+  _id?: Maybe<Scalars['ID']>;
+  _shapeId?: Maybe<Scalars['ID']>;
+  _shapeName?: Maybe<Scalars['String']>;
+  text?: Maybe<Scalars['String']>;
+  summary?: Maybe<Scalars['String']>;
+};
+
+export type TsSearchSort = {
+  field: Scalars['String'];
+  /** "asc" for ascending or "desc" for descending */
+  order: Scalars['String'];
+};
+
+export type TsVersionResponse = {
+  __typename?: 'TSVersionResponse';
+  content?: Maybe<Scalars['JSONObject']>;
+  schema?: Maybe<Scalars['JSONObject']>;
+};
+
+export type TsVersionsPaginatedList = {
+  __typename?: 'TSVersionsPaginatedList';
+  items?: Maybe<Array<Maybe<TsVersion>>>;
+  total?: Maybe<Scalars['Int']>;
+  from?: Maybe<Scalars['Int']>;
+  size?: Maybe<Scalars['Int']>;
+};
+
+export type TsVersion = {
+  __typename?: 'TSVersion';
+  id?: Maybe<Scalars['String']>;
+  version?: Maybe<Scalars['Int']>;
+  status?: Maybe<Scalars['String']>;
+  enabled?: Maybe<Scalars['Boolean']>;
+  color?: Maybe<Scalars['String']>;
+  updatedAt?: Maybe<Scalars['String']>;
+  updatedBy?: Maybe<TsProjectMember>;
+  item?: Maybe<TsVersionResponse>;
+};
+
+
+export type TsVersionItemArgs = {
+  locale?: InputMaybe<Scalars['String']>;
+  enableLocaleFallback?: InputMaybe<Scalars['Boolean']>;
+};
+
+export type TsProjectMember = {
+  __typename?: 'TSProjectMember';
+  id?: Maybe<Scalars['ID']>;
+  email?: Maybe<Scalars['String']>;
+  fullName?: Maybe<Scalars['String']>;
+  role?: Maybe<Scalars['String']>;
+  avatarPath?: Maybe<Scalars['String']>;
+};
+
+export type Asset = TsSearchable & {
+  __typename?: 'Asset';
+  title?: Maybe<Scalars['String']>;
+  description?: Maybe<Scalars['String']>;
+  filename: Scalars['String'];
+  caption?: Maybe<Scalars['JSON']>;
+  captionHtml?: Maybe<Scalars['String']>;
+  credit?: Maybe<Scalars['JSON']>;
+  creditHtml?: Maybe<Scalars['String']>;
+  path: Scalars['String'];
+  mimeType?: Maybe<Scalars['String']>;
+  sourceUrl?: Maybe<Scalars['String']>;
+  uploadStatus?: Maybe<Scalars['String']>;
+  _shapeId?: Maybe<Scalars['String']>;
+  _id?: Maybe<Scalars['ID']>;
+  _version?: Maybe<Scalars['Int']>;
+  _shapeName?: Maybe<Scalars['String']>;
+  _createdAt?: Maybe<Scalars['String']>;
+  _createdBy?: Maybe<TsUser>;
+  _updatedAt?: Maybe<Scalars['String']>;
+  _updatedBy?: Maybe<TsUser>;
+  _schemaVersion?: Maybe<Scalars['Float']>;
+  /** @deprecated Use _status instead */
+  _enabled?: Maybe<Scalars['Boolean']>;
+  /** @deprecated Use a custom date field instead */
+  _enabledAt?: Maybe<Scalars['String']>;
+  _status?: Maybe<DefaultWorkflow>;
+  _contentTypeId?: Maybe<Scalars['String']>;
+  _contentTypeName?: Maybe<Scalars['String']>;
+  /** @deprecated Use path instead */
+  s3Key?: Maybe<Scalars['String']>;
+  searchSummary?: Maybe<Scalars['String']>;
+};
+
+
+export type AssetCaptionHtmlArgs = {
+  imageConfig?: InputMaybe<Scalars['JSON']>;
+  images?: InputMaybe<TsImagesConfig>;
+  classPrefix?: InputMaybe<Scalars['String']>;
+  headerIdPrefix?: InputMaybe<Scalars['String']>;
+};
+
+
+export type AssetCreditHtmlArgs = {
+  imageConfig?: InputMaybe<Scalars['JSON']>;
+  images?: InputMaybe<TsImagesConfig>;
+  classPrefix?: InputMaybe<Scalars['String']>;
+  headerIdPrefix?: InputMaybe<Scalars['String']>;
+};
+
+export type TsSearchable = {
+  _id?: Maybe<Scalars['ID']>;
+  _shapeId?: Maybe<Scalars['String']>;
+  searchSummary?: Maybe<Scalars['String']>;
+};
+
+export type TsImagesConfig = {
+  /** Default image parameters. See https://docs.imgix.com/apis/url  */
+  default?: InputMaybe<Scalars['JSON']>;
+  /** Small image parameters. See https://docs.imgix.com/apis/url  */
+  small?: InputMaybe<Scalars['JSON']>;
+  /** Medium image parameters. See https://docs.imgix.com/apis/url  */
+  medium?: InputMaybe<Scalars['JSON']>;
+  /** Large image parameters. See https://docs.imgix.com/apis/url  */
+  large?: InputMaybe<Scalars['JSON']>;
+};
+
+export type TsUser = {
+  __typename?: 'TSUser';
+  id: Scalars['String'];
+  email: Scalars['String'];
+  fullName: Scalars['String'];
+  avatarPath?: Maybe<Scalars['String']>;
+};
+
+export enum DefaultWorkflow {
+  Disabled = 'disabled',
+  Enabled = 'enabled'
+}
+
+export type AssetPaginatedList = {
+  __typename?: 'AssetPaginatedList';
+  items: Array<Asset>;
+  total: Scalars['Int'];
+};
+
+export type TsSearchSortInput = {
+  field: Scalars['String'];
+  /** "asc" for ascending or "desc" for descending */
+  order: Scalars['String'];
+};
+
+export type TsWhereAssetInput = {
+  title?: InputMaybe<TsWhereStringInput>;
+  description?: InputMaybe<TsWhereStringInput>;
+  filename?: InputMaybe<TsWhereStringInput>;
+  caption?: InputMaybe<TsWhereDraftjsInput>;
+  credit?: InputMaybe<TsWhereDraftjsInput>;
+  path?: InputMaybe<TsWhereStringInput>;
+  mimeType?: InputMaybe<TsWhereStringInput>;
+  sourceUrl?: InputMaybe<TsWhereStringInput>;
+  uploadStatus?: InputMaybe<TsWhereStringInput>;
+  _shapeId?: InputMaybe<TsWhereIdInput>;
+  _id?: InputMaybe<TsWhereIdInput>;
+  _version?: InputMaybe<TsWhereIntegerInput>;
+  _shapeName?: InputMaybe<TsWhereStringInput>;
+  _createdAt?: InputMaybe<TsWhereDateInput>;
+  _updatedAt?: InputMaybe<TsWhereDateInput>;
+  _schemaVersion?: InputMaybe<TsWhereNumberInput>;
+  _status?: InputMaybe<TsWhereWorkflowInput>;
+  _contentTypeId?: InputMaybe<TsWhereIdInput>;
+  _contentTypeName?: InputMaybe<TsWhereStringInput>;
+  s3Key?: InputMaybe<TsWhereStringInput>;
+  AND?: InputMaybe<Array<InputMaybe<TsWhereAssetInput>>>;
+  OR?: InputMaybe<Array<InputMaybe<TsWhereAssetInput>>>;
+  NOT?: InputMaybe<TsWhereAssetInput>;
+};
+
+export type TsWhereStringInput = {
+  /** Exact match */
+  eq?: InputMaybe<Scalars['String']>;
+  /** Array of possible exact match values. */
+  in?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  /** Full text searching with fuzzy matching. */
+  match?: InputMaybe<Scalars['String']>;
+  /** Regular expression string matching. Use of * wildcards could degrade performance. */
+  regexp?: InputMaybe<Scalars['String']>;
+};
+
+export type TsWhereDraftjsInput = {
+  /** Full text searching with fuzzy matching. */
+  match?: InputMaybe<Scalars['String']>;
+};
+
+export type TsWhereIdInput = {
+  /** Exact match */
+  eq?: InputMaybe<Scalars['String']>;
+  /** Array of possible exact match values. */
+  in?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+};
+
+export type TsWhereIntegerInput = {
+  /** Exact match */
+  eq?: InputMaybe<Scalars['Int']>;
+  /** Less than */
+  lt?: InputMaybe<Scalars['Int']>;
+  /** Less than or equal */
+  lte?: InputMaybe<Scalars['Int']>;
+  /** Greater than */
+  gt?: InputMaybe<Scalars['Int']>;
+  /** Greater than or equal */
+  gte?: InputMaybe<Scalars['Int']>;
+  /** Array of possible exact match values. */
+  in?: InputMaybe<Array<InputMaybe<Scalars['Int']>>>;
+};
+
+export type TsWhereDateInput = {
+  /** Exact match */
+  eq?: InputMaybe<Scalars['String']>;
+  /** Less than */
+  lt?: InputMaybe<Scalars['String']>;
+  /** Less than or equal */
+  lte?: InputMaybe<Scalars['String']>;
+  /** Greater than */
+  gt?: InputMaybe<Scalars['String']>;
+  /** Greater than or equal */
+  gte?: InputMaybe<Scalars['String']>;
+};
+
+export type TsWhereNumberInput = {
+  /** Exact match */
+  eq?: InputMaybe<Scalars['Float']>;
+  /** Less than */
+  lt?: InputMaybe<Scalars['Float']>;
+  /** Less than or equal */
+  lte?: InputMaybe<Scalars['Float']>;
+  /** Greater than */
+  gt?: InputMaybe<Scalars['Float']>;
+  /** Greater than or equal */
+  gte?: InputMaybe<Scalars['Float']>;
+  /** Array of possible exact match values. */
+  in?: InputMaybe<Array<InputMaybe<Scalars['Float']>>>;
+};
+
+export type TsWhereWorkflowInput = {
+  /** Exact match */
+  eq?: InputMaybe<Scalars['String']>;
+  /** Less than */
+  lt?: InputMaybe<Scalars['String']>;
+  /** Less than or equal */
+  lte?: InputMaybe<Scalars['String']>;
+  /** Greater than */
+  gt?: InputMaybe<Scalars['String']>;
+  /** Greater than or equal */
+  gte?: InputMaybe<Scalars['String']>;
+  /** Array of possible exact match values. */
+  in?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+};
+
+export type TsStaticSite = TsSearchable & {
+  __typename?: 'TsStaticSite';
+  title: Scalars['String'];
+  baseUrl?: Maybe<Scalars['String']>;
+  provider: Scalars['String'];
+  idKey?: Maybe<Scalars['String']>;
+  secretKey?: Maybe<Scalars['String']>;
+  destination: Scalars['String'];
+  privateAcl?: Maybe<Scalars['Boolean']>;
+  environmentVariables?: Maybe<Array<Maybe<TsStaticSiteEnvironmentVariables>>>;
+  triggers?: Maybe<Array<Maybe<TsStaticSiteTriggers>>>;
+  templateHash?: Maybe<Scalars['String']>;
+  _shapeId?: Maybe<Scalars['String']>;
+  _id?: Maybe<Scalars['ID']>;
+  _version?: Maybe<Scalars['Int']>;
+  _shapeName?: Maybe<Scalars['String']>;
+  _createdAt?: Maybe<Scalars['String']>;
+  _createdBy?: Maybe<TsUser>;
+  _updatedAt?: Maybe<Scalars['String']>;
+  _updatedBy?: Maybe<TsUser>;
+  _schemaVersion?: Maybe<Scalars['Float']>;
+  /** @deprecated Use _status instead */
+  _enabled?: Maybe<Scalars['Boolean']>;
+  /** @deprecated Use a custom date field instead */
+  _enabledAt?: Maybe<Scalars['String']>;
+  _status?: Maybe<DefaultWorkflow>;
+  _contentTypeId?: Maybe<Scalars['String']>;
+  _contentTypeName?: Maybe<Scalars['String']>;
+  searchSummary?: Maybe<Scalars['String']>;
+};
+
+export type TsStaticSiteEnvironmentVariables = {
+  __typename?: 'TsStaticSiteEnvironmentVariables';
+  name?: Maybe<Scalars['String']>;
+  value?: Maybe<Scalars['String']>;
+};
+
+export type TsStaticSiteTriggers = {
+  __typename?: 'TsStaticSiteTriggers';
+  contentTypeId?: Maybe<Scalars['String']>;
+  status?: Maybe<Scalars['String']>;
+};
+
+export type TsStaticSitePaginatedList = {
+  __typename?: 'TsStaticSitePaginatedList';
+  items: Array<TsStaticSite>;
+  total: Scalars['Int'];
+};
+
+export type TsWhereTsStaticSiteInput = {
+  title?: InputMaybe<TsWhereStringInput>;
+  baseUrl?: InputMaybe<TsWhereStringInput>;
+  provider?: InputMaybe<TsWhereStringInput>;
+  idKey?: InputMaybe<TsWhereStringInput>;
+  destination?: InputMaybe<TsWhereStringInput>;
+  privateAcl?: InputMaybe<TsWhereBooleanInput>;
+  environmentVariables?: InputMaybe<TsWhereTsStaticSiteEnvironmentVariablesInput>;
+  triggers?: InputMaybe<TsWhereTsStaticSiteTriggersInput>;
+  templateHash?: InputMaybe<TsWhereStringInput>;
+  _shapeId?: InputMaybe<TsWhereIdInput>;
+  _id?: InputMaybe<TsWhereIdInput>;
+  _version?: InputMaybe<TsWhereIntegerInput>;
+  _shapeName?: InputMaybe<TsWhereStringInput>;
+  _createdAt?: InputMaybe<TsWhereDateInput>;
+  _updatedAt?: InputMaybe<TsWhereDateInput>;
+  _schemaVersion?: InputMaybe<TsWhereNumberInput>;
+  _status?: InputMaybe<TsWhereWorkflowInput>;
+  _contentTypeId?: InputMaybe<TsWhereIdInput>;
+  _contentTypeName?: InputMaybe<TsWhereStringInput>;
+  AND?: InputMaybe<Array<InputMaybe<TsWhereTsStaticSiteInput>>>;
+  OR?: InputMaybe<Array<InputMaybe<TsWhereTsStaticSiteInput>>>;
+  NOT?: InputMaybe<TsWhereTsStaticSiteInput>;
+};
+
+export type TsWhereBooleanInput = {
+  /** Exact match */
+  eq?: InputMaybe<Scalars['Boolean']>;
+};
+
+export type TsWhereTsStaticSiteEnvironmentVariablesInput = {
+  name?: InputMaybe<TsWhereStringInput>;
+  value?: InputMaybe<TsWhereStringInput>;
+};
+
+export type TsWhereTsStaticSiteTriggersInput = {
+  contentTypeId?: InputMaybe<TsWhereStringInput>;
+  status?: InputMaybe<TsWhereStringInput>;
+};
+
+export type Stripe_ProductPaginatedList = {
+  __typename?: 'Stripe_ProductPaginatedList';
+  items: Array<Stripe_Product>;
+  total: Scalars['Int'];
+};
+
+export type Stripe_Product = TsSearchable & {
+  __typename?: 'Stripe_Product';
+  /** Whether the product is currently available for purchase. */
+  active?: Maybe<Scalars['Boolean']>;
+  /** Time at which the object was created. Measured in seconds since the Unix epoch. */
+  created?: Maybe<Scalars['Int']>;
+  /** The product's description, meant to be displayable to the customer. Use this field to optionally store a long form explanation of the product being sold for your own rendering purposes. */
+  description?: Maybe<Scalars['String']>;
+  /** Unique identifier for the object. */
+  id?: Maybe<Scalars['String']>;
+  /** A list of up to 8 URLs of images for this product, meant to be displayable to the customer. */
+  images?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode. */
+  livemode?: Maybe<Scalars['Boolean']>;
+  /** Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. */
+  metadata?: Maybe<Scalars['JSONObject']>;
+  /** The product's name, meant to be displayable to the customer. Whenever this product is sold via a subscription, name will show up on associated invoice line item descriptions. */
+  name?: Maybe<Scalars['String']>;
+  /** String representing the object's type. Objects of the same type share the same value. */
+  object?: Maybe<Stripe_ProductObjectProperty>;
+  package_dimensions?: Maybe<Stripe_PackageDimensions>;
+  /** Whether this product is shipped (i.e., physical goods). */
+  shippable?: Maybe<Scalars['Boolean']>;
+  /** Extra information about a product which will appear on your customer's credit card statement. In the case that multiple products are billed at once, the first statement descriptor will be used. */
+  statement_descriptor?: Maybe<Scalars['String']>;
+  tax_code?: Maybe<Stripe_ProductTaxCodeProperty>;
+  /** A label that represents units of this product in Stripe and on customers’ receipts and invoices. When set, this will be included in associated invoice line item descriptions. */
+  unit_label?: Maybe<Scalars['String']>;
+  /** Time at which the object was last updated. Measured in seconds since the Unix epoch. */
+  updated?: Maybe<Scalars['Int']>;
+  /** A URL of a publicly-accessible webpage for this product. */
+  url?: Maybe<Scalars['String']>;
+  prices?: Maybe<Array<Maybe<Stripe_Price>>>;
+  _shapeId?: Maybe<Scalars['String']>;
+  _id?: Maybe<Scalars['ID']>;
+  searchSummary?: Maybe<Scalars['String']>;
+};
+
+export enum Stripe_ProductObjectProperty {
+  Product = 'product'
+}
+
+export type Stripe_PackageDimensions = {
+  __typename?: 'Stripe_PackageDimensions';
+  /** Height, in inches. */
+  height?: Maybe<Scalars['Float']>;
+  /** Length, in inches. */
+  length?: Maybe<Scalars['Float']>;
+  /** Weight, in ounces. */
+  weight?: Maybe<Scalars['Float']>;
+  /** Width, in inches. */
+  width?: Maybe<Scalars['Float']>;
+};
+
+export type Stripe_ProductTaxCodeProperty = WrappedString | Stripe_TaxCode;
+
+export type WrappedString = {
+  __typename?: 'WrappedString';
+  value: Scalars['String'];
+};
+
+export type Stripe_TaxCode = {
+  __typename?: 'Stripe_TaxCode';
+  /** A detailed description of which types of products the tax code represents. */
+  description?: Maybe<Scalars['String']>;
+  /** Unique identifier for the object. */
+  id?: Maybe<Scalars['String']>;
+  /** A short name for the tax code. */
+  name?: Maybe<Scalars['String']>;
+  /** String representing the object's type. Objects of the same type share the same value. */
+  object?: Maybe<Stripe_TaxCodeObjectProperty>;
+};
+
+export enum Stripe_TaxCodeObjectProperty {
+  TaxCode = 'tax_code'
+}
+
+export type Stripe_Price = {
+  __typename?: 'Stripe_Price';
+  /** Whether the price can be used for new purchases. */
+  active?: Maybe<Scalars['Boolean']>;
+  /** Describes how to compute the price per period. Either `per_unit` or `tiered`. `per_unit` indicates that the fixed amount (specified in `unit_amount` or `unit_amount_decimal`) will be charged per unit in `quantity` (for prices with `usage_type=licensed`), or per unit of total usage (for prices with `usage_type=metered`). `tiered` indicates that the unit pricing will be computed using a tiering strategy as defined using the `tiers` and `tiers_mode` attributes. */
+  billing_scheme?: Maybe<Stripe_PriceBillingSchemeProperty>;
+  /** Time at which the object was created. Measured in seconds since the Unix epoch. */
+  created?: Maybe<Scalars['Int']>;
+  /** Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies). */
+  currency?: Maybe<Scalars['String']>;
+  /** Unique identifier for the object. */
+  id?: Maybe<Scalars['String']>;
+  /** Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode. */
+  livemode?: Maybe<Scalars['Boolean']>;
+  /** A lookup key used to retrieve prices dynamically from a static string. */
+  lookup_key?: Maybe<Scalars['String']>;
+  /** Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. */
+  metadata?: Maybe<Scalars['JSONObject']>;
+  /** A brief description of the price, hidden from customers. */
+  nickname?: Maybe<Scalars['String']>;
+  /** String representing the object's type. Objects of the same type share the same value. */
+  object?: Maybe<Stripe_PriceObjectProperty>;
+  /** The Stripe product associated with this subscription. */
+  product?: Maybe<Stripe_Product>;
+  recurring?: Maybe<Stripe_Recurring>;
+  /** Specifies whether the price is considered inclusive of taxes or exclusive of taxes. One of `inclusive`, `exclusive`, or `unspecified`. Once specified as either `inclusive` or `exclusive`, it cannot be changed. */
+  tax_behavior?: Maybe<Stripe_PriceTaxBehaviorProperty>;
+  /** Each element represents a pricing tier. This parameter requires `billing_scheme` to be set to `tiered`. See also the documentation for `billing_scheme`. */
+  tiers?: Maybe<Array<Maybe<Stripe_PriceTier>>>;
+  /** Defines if the tiering price should be `graduated` or `volume` based. In `volume`-based tiering, the maximum quantity within a period determines the per unit price. In `graduated` tiering, pricing can change as the quantity grows. */
+  tiers_mode?: Maybe<Stripe_PriceTiersModeProperty>;
+  transform_quantity?: Maybe<Stripe_TransformQuantity>;
+  /** One of `one_time` or `recurring` depending on whether the price is for a one-time purchase or a recurring (subscription) purchase. */
+  type?: Maybe<Stripe_PriceTypeProperty>;
+  /** The unit amount in %s to be charged, represented as a whole integer if possible. Only set if `billing_scheme=per_unit`. */
+  unit_amount?: Maybe<Scalars['Int']>;
+  /** The unit amount in %s to be charged, represented as a decimal string with at most 12 decimal places. Only set if `billing_scheme=per_unit`. */
+  unit_amount_decimal?: Maybe<Scalars['String']>;
+};
+
+export enum Stripe_PriceBillingSchemeProperty {
+  PerUnit = 'per_unit',
+  Tiered = 'tiered'
+}
+
+export enum Stripe_PriceObjectProperty {
+  Price = 'price'
+}
+
+export type Stripe_Recurring = {
+  __typename?: 'Stripe_Recurring';
+  /** Specifies a usage aggregation strategy for prices of `usage_type=metered`. Allowed values are `sum` for summing up all usage during a period, `last_during_period` for using the last usage record reported within a period, `last_ever` for using the last usage record ever (across period bounds) or `max` which uses the usage record with the maximum reported usage during a period. Defaults to `sum`. */
+  aggregate_usage?: Maybe<Stripe_RecurringAggregateUsageProperty>;
+  /** The frequency at which a subscription is billed. One of `day`, `week`, `month` or `year`. */
+  interval?: Maybe<Stripe_RecurringIntervalProperty>;
+  /** The number of intervals (specified in the `interval` attribute) between subscription billings. For example, `interval=month` and `interval_count=3` bills every 3 months. */
+  interval_count?: Maybe<Scalars['Int']>;
+  /** Configures how the quantity per period should be determined. Can be either `metered` or `licensed`. `licensed` automatically bills the `quantity` set when adding it to a subscription. `metered` aggregates the total usage based on usage records. Defaults to `licensed`. */
+  usage_type?: Maybe<Stripe_RecurringUsageTypeProperty>;
+};
+
+export enum Stripe_RecurringAggregateUsageProperty {
+  LastDuringPeriod = 'last_during_period',
+  LastEver = 'last_ever',
+  Max = 'max',
+  Sum = 'sum'
+}
+
+export enum Stripe_RecurringIntervalProperty {
+  Day = 'day',
+  Month = 'month',
+  Week = 'week',
+  Year = 'year'
+}
+
+export enum Stripe_RecurringUsageTypeProperty {
+  Licensed = 'licensed',
+  Metered = 'metered'
+}
+
+export enum Stripe_PriceTaxBehaviorProperty {
+  Exclusive = 'exclusive',
+  Inclusive = 'inclusive',
+  Unspecified = 'unspecified'
+}
+
+export type Stripe_PriceTier = {
+  __typename?: 'Stripe_PriceTier';
+  /** Price for the entire tier. */
+  flat_amount?: Maybe<Scalars['Int']>;
+  /** Same as `flat_amount`, but contains a decimal value with at most 12 decimal places. */
+  flat_amount_decimal?: Maybe<Scalars['String']>;
+  /** Per unit price for units relevant to the tier. */
+  unit_amount?: Maybe<Scalars['Int']>;
+  /** Same as `unit_amount`, but contains a decimal value with at most 12 decimal places. */
+  unit_amount_decimal?: Maybe<Scalars['String']>;
+  /** Up to and including to this quantity will be contained in the tier. */
+  up_to?: Maybe<Scalars['Int']>;
+};
+
+export enum Stripe_PriceTiersModeProperty {
+  Graduated = 'graduated',
+  Volume = 'volume'
+}
+
+export type Stripe_TransformQuantity = {
+  __typename?: 'Stripe_TransformQuantity';
+  /** Divide usage by this number. */
+  divide_by?: Maybe<Scalars['Int']>;
+  /** After division, either round the result `up` or `down`. */
+  round?: Maybe<Stripe_TransformQuantityRoundProperty>;
+};
+
+export enum Stripe_TransformQuantityRoundProperty {
+  Down = 'down',
+  Up = 'up'
+}
+
+export enum Stripe_PriceTypeProperty {
+  OneTime = 'one_time',
+  Recurring = 'recurring'
+}
+
+export type TsWhereStripeProductInput = {
+  active?: InputMaybe<TsWhereBooleanInput>;
+  created?: InputMaybe<TsWhereIntegerInput>;
+  description?: InputMaybe<TsWhereStringInput>;
+  id?: InputMaybe<TsWhereStringInput>;
+  images?: InputMaybe<TsWhereStripe_ProductImagesInput>;
+  livemode?: InputMaybe<TsWhereBooleanInput>;
+  name?: InputMaybe<TsWhereStringInput>;
+  object?: InputMaybe<TsWhereInput>;
+  package_dimensions?: InputMaybe<TsWhereStripe_PackageDimensionsInput>;
+  shippable?: InputMaybe<TsWhereBooleanInput>;
+  statement_descriptor?: InputMaybe<TsWhereStringInput>;
+  unit_label?: InputMaybe<TsWhereStringInput>;
+  updated?: InputMaybe<TsWhereIntegerInput>;
+  url?: InputMaybe<TsWhereStringInput>;
+  _shapeId?: InputMaybe<TsWhereIdInput>;
+  _id?: InputMaybe<TsWhereIdInput>;
+  AND?: InputMaybe<Array<InputMaybe<TsWhereStripeProductInput>>>;
+  OR?: InputMaybe<Array<InputMaybe<TsWhereStripeProductInput>>>;
+  NOT?: InputMaybe<TsWhereStripeProductInput>;
+};
+
+export type TsWhereStripe_ProductImagesInput = {
+  /** Exact match */
+  eq?: InputMaybe<Scalars['String']>;
+  /** Array of possible exact match values. */
+  in?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  /** Full text searching with fuzzy matching. */
+  match?: InputMaybe<Scalars['String']>;
+  /** Regular expression string matching. Use of * wildcards could degrade performance. */
+  regexp?: InputMaybe<Scalars['String']>;
+};
+
+export type TsWhereInput = {
+  title?: InputMaybe<TsWhereStringInput>;
+  description?: InputMaybe<TsWhereStringInput>;
+  filename?: InputMaybe<TsWhereStringInput>;
+  caption?: InputMaybe<TsWhereDraftjsInput>;
+  credit?: InputMaybe<TsWhereDraftjsInput>;
+  path?: InputMaybe<TsWhereStringInput>;
+  mimeType?: InputMaybe<TsWhereStringInput>;
+  sourceUrl?: InputMaybe<TsWhereStringInput>;
+  uploadStatus?: InputMaybe<TsWhereStringInput>;
+  _shapeId?: InputMaybe<TsWhereIdInput>;
+  _id?: InputMaybe<TsWhereIdInput>;
+  _version?: InputMaybe<TsWhereIntegerInput>;
+  _shapeName?: InputMaybe<TsWhereStringInput>;
+  _createdAt?: InputMaybe<TsWhereDateInput>;
+  _updatedAt?: InputMaybe<TsWhereDateInput>;
+  _schemaVersion?: InputMaybe<TsWhereNumberInput>;
+  _status?: InputMaybe<TsWhereWorkflowInput>;
+  _contentTypeId?: InputMaybe<TsWhereIdInput>;
+  _contentTypeName?: InputMaybe<TsWhereStringInput>;
+  s3Key?: InputMaybe<TsWhereStringInput>;
+  baseUrl?: InputMaybe<TsWhereStringInput>;
+  provider?: InputMaybe<TsWhereStringInput>;
+  idKey?: InputMaybe<TsWhereStringInput>;
+  destination?: InputMaybe<TsWhereStringInput>;
+  privateAcl?: InputMaybe<TsWhereBooleanInput>;
+  environmentVariables?: InputMaybe<TsWhereTsStaticSiteEnvironmentVariablesInput>;
+  triggers?: InputMaybe<TsWhereTsStaticSiteTriggersInput>;
+  templateHash?: InputMaybe<TsWhereStringInput>;
+  active?: InputMaybe<TsWhereBooleanInput>;
+  created?: InputMaybe<TsWhereIntegerInput>;
+  id?: InputMaybe<TsWhereStringInput>;
+  images?: InputMaybe<TsWhereStripe_ProductImagesInput>;
+  livemode?: InputMaybe<TsWhereBooleanInput>;
+  name?: InputMaybe<TsWhereStringInput>;
+  object?: InputMaybe<TsWhereInput>;
+  package_dimensions?: InputMaybe<TsWhereStripe_PackageDimensionsInput>;
+  shippable?: InputMaybe<TsWhereBooleanInput>;
+  statement_descriptor?: InputMaybe<TsWhereStringInput>;
+  unit_label?: InputMaybe<TsWhereStringInput>;
+  updated?: InputMaybe<TsWhereIntegerInput>;
+  url?: InputMaybe<TsWhereStringInput>;
+  email?: InputMaybe<TsWhereStringInput>;
+  bio?: InputMaybe<TsWhereStringInput>;
+  avatar?: InputMaybe<TsWhereAssetRelationshipInput>;
+  stripeCustomerId?: InputMaybe<TsWhereStringInput>;
+  AND?: InputMaybe<Array<InputMaybe<TsWhereInput>>>;
+  OR?: InputMaybe<Array<InputMaybe<TsWhereInput>>>;
+  NOT?: InputMaybe<TsWhereInput>;
+};
+
+export type TsWhereStripe_PackageDimensionsInput = {
+  height?: InputMaybe<TsWhereNumberInput>;
+  length?: InputMaybe<TsWhereNumberInput>;
+  weight?: InputMaybe<TsWhereNumberInput>;
+  width?: InputMaybe<TsWhereNumberInput>;
+};
+
+export type TsWhereAssetRelationshipInput = {
+  title?: InputMaybe<TsWhereStringInput>;
+  description?: InputMaybe<TsWhereStringInput>;
+  filename?: InputMaybe<TsWhereStringInput>;
+  caption?: InputMaybe<TsWhereDraftjsInput>;
+  credit?: InputMaybe<TsWhereDraftjsInput>;
+  path?: InputMaybe<TsWhereStringInput>;
+  mimeType?: InputMaybe<TsWhereStringInput>;
+  sourceUrl?: InputMaybe<TsWhereStringInput>;
+  uploadStatus?: InputMaybe<TsWhereStringInput>;
+  _shapeId?: InputMaybe<TsWhereIdInput>;
+  _id?: InputMaybe<TsWhereIdInput>;
+  _version?: InputMaybe<TsWhereIntegerInput>;
+  _shapeName?: InputMaybe<TsWhereStringInput>;
+  _createdAt?: InputMaybe<TsWhereDateInput>;
+  _updatedAt?: InputMaybe<TsWhereDateInput>;
+  _schemaVersion?: InputMaybe<TsWhereNumberInput>;
+  _status?: InputMaybe<TsWhereWorkflowInput>;
+  _contentTypeId?: InputMaybe<TsWhereIdInput>;
+  _contentTypeName?: InputMaybe<TsWhereStringInput>;
+  s3Key?: InputMaybe<TsWhereStringInput>;
+};
+
+export type Profile = TsSearchable & {
+  __typename?: 'Profile';
+  id?: Maybe<Scalars['String']>;
+  name?: Maybe<Scalars['String']>;
+  email?: Maybe<Scalars['String']>;
+  bio?: Maybe<Scalars['String']>;
+  avatar?: Maybe<Asset>;
+  stripeCustomerId?: Maybe<Scalars['String']>;
+  stripeCustomer?: Maybe<Stripe_Customer>;
+  _shapeId?: Maybe<Scalars['String']>;
+  _id?: Maybe<Scalars['ID']>;
+  _version?: Maybe<Scalars['Int']>;
+  _shapeName?: Maybe<Scalars['String']>;
+  _createdAt?: Maybe<Scalars['String']>;
+  _createdBy?: Maybe<TsUser>;
+  _updatedAt?: Maybe<Scalars['String']>;
+  _updatedBy?: Maybe<TsUser>;
+  _schemaVersion?: Maybe<Scalars['Float']>;
+  /** @deprecated Use _status instead */
+  _enabled?: Maybe<Scalars['Boolean']>;
+  /** @deprecated Use a custom date field instead */
+  _enabledAt?: Maybe<Scalars['String']>;
+  _status?: Maybe<DefaultWorkflow>;
+  _contentTypeId?: Maybe<Scalars['String']>;
+  _contentTypeName?: Maybe<Scalars['String']>;
+  searchSummary?: Maybe<Scalars['String']>;
+};
+
+
+export type ProfileAvatarArgs = {
+  locale?: InputMaybe<Scalars['String']>;
+  enableLocaleFallback?: InputMaybe<Scalars['Boolean']>;
+};
+
+export type Stripe_Customer = {
+  __typename?: 'Stripe_Customer';
+  address?: Maybe<Stripe_Address>;
+  /** Current balance, if any, being stored on the customer. If negative, the customer has credit to apply to their next invoice. If positive, the customer has an amount owed that will be added to their next invoice. The balance does not refer to any unpaid invoices; it solely takes into account amounts that have yet to be successfully applied to any invoice. This balance is only taken into account as invoices are finalized. */
+  balance?: Maybe<Scalars['Int']>;
+  /** Time at which the object was created. Measured in seconds since the Unix epoch. */
+  created?: Maybe<Scalars['Int']>;
+  /** Three-letter [ISO code for the currency](https://stripe.com/docs/currencies) the customer can be charged in for recurring billing purposes. */
+  currency?: Maybe<Scalars['String']>;
+  default_source?: Maybe<Stripe_CustomerDefaultSourceProperty>;
+  /**
+   * When the customer's latest invoice is billed by charging automatically, `delinquent` is `true` if the invoice's latest charge failed. When the customer's latest invoice is billed by sending an invoice, `delinquent` is `true` if the invoice isn't paid by its due date.
+   *
+   * If an invoice is marked uncollectible by [dunning](https://stripe.com/docs/billing/automatic-collection), `delinquent` doesn't get reset to `false`.
+   */
+  delinquent?: Maybe<Scalars['Boolean']>;
+  /** An arbitrary string attached to the object. Often useful for displaying to users. */
+  description?: Maybe<Scalars['String']>;
+  discount?: Maybe<Stripe_Discount>;
+  /** The customer's email address. */
+  email?: Maybe<Scalars['String']>;
+  /** Unique identifier for the object. */
+  id?: Maybe<Scalars['String']>;
+  /** The prefix for the customer used to generate unique invoice numbers. */
+  invoice_prefix?: Maybe<Scalars['String']>;
+  invoice_settings?: Maybe<Stripe_InvoiceSettingCustomerSetting>;
+  /** Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode. */
+  livemode?: Maybe<Scalars['Boolean']>;
+  /** Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. */
+  metadata?: Maybe<Scalars['JSONObject']>;
+  /** The customer's full name or business name. */
+  name?: Maybe<Scalars['String']>;
+  /** The suffix of the customer's next invoice number, e.g., 0001. */
+  next_invoice_sequence?: Maybe<Scalars['Int']>;
+  /** String representing the object's type. Objects of the same type share the same value. */
+  object?: Maybe<Stripe_CustomerObjectProperty>;
+  /** The customer's phone number. */
+  phone?: Maybe<Scalars['String']>;
+  /** The customer's preferred locales (languages), ordered by preference. */
+  preferred_locales?: Maybe<Array<Maybe<Scalars['String']>>>;
+  shipping?: Maybe<Stripe_Shipping>;
+  /** The customer's payment sources, if any. */
+  sources?: Maybe<Stripe_CustomerSourcesProperty>;
+  /** The customer's current subscriptions, if any. */
+  subscriptions?: Maybe<Stripe_CustomerSubscriptionsProperty>;
+  tax?: Maybe<Stripe_CustomerTax>;
+  /** Describes the customer's tax exemption status. One of `none`, `exempt`, or `reverse`. When set to `reverse`, invoice and receipt PDFs include the text **"Reverse charge"**. */
+  tax_exempt?: Maybe<Stripe_CustomerTaxExemptProperty>;
+  /** The customer's tax IDs. */
+  tax_ids?: Maybe<Stripe_CustomerTaxIdsProperty>;
+};
+
+export type Stripe_Address = {
+  __typename?: 'Stripe_Address';
+  /** City, district, suburb, town, or village. */
+  city?: Maybe<Scalars['String']>;
+  /** Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)). */
+  country?: Maybe<Scalars['String']>;
+  /** Address line 1 (e.g., street, PO Box, or company name). */
+  line1?: Maybe<Scalars['String']>;
+  /** Address line 2 (e.g., apartment, suite, unit, or building). */
+  line2?: Maybe<Scalars['String']>;
+  /** ZIP or postal code. */
+  postal_code?: Maybe<Scalars['String']>;
+  /** State, county, province, or region. */
+  state?: Maybe<Scalars['String']>;
+};
+
+export type Stripe_CustomerDefaultSourceProperty = WrappedString | Stripe_AlipayAccount | Stripe_BankAccount | Stripe_BitcoinReceiver | Stripe_Card | Stripe_Source;
+
+export type Stripe_AlipayAccount = {
+  __typename?: 'Stripe_AlipayAccount';
+  /** Time at which the object was created. Measured in seconds since the Unix epoch. */
+  created?: Maybe<Scalars['Int']>;
+  customer?: Maybe<Stripe_AlipayAccountCustomerProperty>;
+  /** Uniquely identifies the account and will be the same across all Alipay account objects that are linked to the same Alipay account. */
+  fingerprint?: Maybe<Scalars['String']>;
+  /** Unique identifier for the object. */
+  id?: Maybe<Scalars['String']>;
+  /** Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode. */
+  livemode?: Maybe<Scalars['Boolean']>;
+  /** Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. */
+  metadata?: Maybe<Scalars['JSONObject']>;
+  /** String representing the object's type. Objects of the same type share the same value. */
+  object?: Maybe<Stripe_AlipayAccountObjectProperty>;
+  /** If the Alipay account object is not reusable, the exact amount that you can create a charge for. */
+  payment_amount?: Maybe<Scalars['Int']>;
+  /** If the Alipay account object is not reusable, the exact currency that you can create a charge for. */
+  payment_currency?: Maybe<Scalars['String']>;
+  /** True if you can create multiple payments using this account. If the account is reusable, then you can freely choose the amount of each payment. */
+  reusable?: Maybe<Scalars['Boolean']>;
+  /** Whether this Alipay account object has ever been used for a payment. */
+  used?: Maybe<Scalars['Boolean']>;
+  /** The username for the Alipay account. */
+  username?: Maybe<Scalars['String']>;
+};
+
+export type Stripe_AlipayAccountCustomerProperty = WrappedString | Stripe_Customer | Stripe_DeletedCustomer;
+
+export type Stripe_DeletedCustomer = {
+  __typename?: 'Stripe_DeletedCustomer';
+  /** Unique identifier for the object. */
+  id?: Maybe<Scalars['String']>;
+  /** String representing the object's type. Objects of the same type share the same value. */
+  object?: Maybe<Stripe_DeletedCustomerObjectProperty>;
+};
+
+export enum Stripe_DeletedCustomerObjectProperty {
+  Customer = 'customer'
+}
+
+export enum Stripe_AlipayAccountObjectProperty {
+  AlipayAccount = 'alipay_account'
+}
+
+export type Stripe_BankAccount = {
+  __typename?: 'Stripe_BankAccount';
+  account?: Maybe<Stripe_BankAccountAccountProperty>;
+  /** The name of the person or business that owns the bank account. */
+  account_holder_name?: Maybe<Scalars['String']>;
+  /** The type of entity that holds the account. This can be either `individual` or `company`. */
+  account_holder_type?: Maybe<Scalars['String']>;
+  /** A set of available payout methods for this bank account. Only values from this set should be passed as the `method` when creating a payout. */
+  available_payout_methods?: Maybe<Array<Maybe<Stripe_BankAccountAvailablePayoutMethodsProperty>>>;
+  /** Name of the bank associated with the routing number (e.g., `WELLS FARGO`). */
+  bank_name?: Maybe<Scalars['String']>;
+  /** Two-letter ISO code representing the country the bank account is located in. */
+  country?: Maybe<Scalars['String']>;
+  /** Three-letter [ISO code for the currency](https://stripe.com/docs/payouts) paid out to the bank account. */
+  currency?: Maybe<Scalars['String']>;
+  customer?: Maybe<Stripe_BankAccountCustomerProperty>;
+  /** Whether this bank account is the default external account for its currency. */
+  default_for_currency?: Maybe<Scalars['Boolean']>;
+  /** Uniquely identifies this particular bank account. You can use this attribute to check whether two bank accounts are the same. */
+  fingerprint?: Maybe<Scalars['String']>;
+  /** Unique identifier for the object. */
+  id?: Maybe<Scalars['String']>;
+  /** The last four digits of the bank account number. */
+  last4?: Maybe<Scalars['String']>;
+  /** Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. */
+  metadata?: Maybe<Scalars['JSONObject']>;
+  /** String representing the object's type. Objects of the same type share the same value. */
+  object?: Maybe<Stripe_BankAccountObjectProperty>;
+  /** The routing transit number for the bank account. */
+  routing_number?: Maybe<Scalars['String']>;
+  /**
+   * For bank accounts, possible values are `new`, `validated`, `verified`, `verification_failed`, or `errored`. A bank account that hasn't had any activity or validation performed is `new`. If Stripe can determine that the bank account exists, its status will be `validated`. Note that there often isn’t enough information to know (e.g., for smaller credit unions), and the validation is not always run. If customer bank account verification has succeeded, the bank account status will be `verified`. If the verification failed for any reason, such as microdeposit failure, the status will be `verification_failed`. If a transfer sent to this bank account fails, we'll set the status to `errored` and will not continue to send transfers until the bank details are updated.
+   *
+   * For external accounts, possible values are `new` and `errored`. Validations aren't run against external accounts because they're only used for payouts. This means the other statuses don't apply. If a transfer fails, the status is set to `errored` and transfers are stopped until account details are updated.
+   */
+  status?: Maybe<Scalars['String']>;
+};
+
+export type Stripe_BankAccountAccountProperty = WrappedString | Stripe_Account;
+
+export type Stripe_Account = {
+  __typename?: 'Stripe_Account';
+  business_profile?: Maybe<Stripe_AccountBusinessProfile>;
+  /** The business type. */
+  business_type?: Maybe<Stripe_AccountBusinessTypeProperty>;
+  capabilities?: Maybe<Stripe_AccountCapabilities>;
+  /** Whether the account can create live charges. */
+  charges_enabled?: Maybe<Scalars['Boolean']>;
+  company?: Maybe<Stripe_LegalEntityCompany>;
+  controller?: Maybe<Stripe_AccountController>;
+  /** The account's country. */
+  country?: Maybe<Scalars['String']>;
+  /** Time at which the object was created. Measured in seconds since the Unix epoch. */
+  created?: Maybe<Scalars['Int']>;
+  /** Three-letter ISO currency code representing the default currency for the account. This must be a currency that [Stripe supports in the account's country](https://stripe.com/docs/payouts). */
+  default_currency?: Maybe<Scalars['String']>;
+  /** Whether account details have been submitted. Standard accounts cannot receive payouts before this is true. */
+  details_submitted?: Maybe<Scalars['Boolean']>;
+  /** An email address associated with the account. You can treat this as metadata: it is not used for authentication or messaging account holders. */
+  email?: Maybe<Scalars['String']>;
+  /** External accounts (bank accounts and debit cards) currently attached to this account */
+  external_accounts?: Maybe<Stripe_AccountExternalAccountsProperty>;
+  /** Unique identifier for the object. */
+  id?: Maybe<Scalars['String']>;
+  individual?: Maybe<Stripe_Person>;
+  /** Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. */
+  metadata?: Maybe<Scalars['JSONObject']>;
+  /** String representing the object's type. Objects of the same type share the same value. */
+  object?: Maybe<Stripe_AccountObjectProperty>;
+  /** Whether Stripe can send payouts to this account. */
+  payouts_enabled?: Maybe<Scalars['Boolean']>;
+  requirements?: Maybe<Stripe_AccountRequirements>;
+  settings?: Maybe<Stripe_AccountSettings>;
+  tos_acceptance?: Maybe<Stripe_AccountTosAcceptance>;
+  /** The Stripe account type. Can be `standard`, `express`, or `custom`. */
+  type?: Maybe<Stripe_AccountTypeProperty>;
+};
+
+export type Stripe_AccountBusinessProfile = {
+  __typename?: 'Stripe_AccountBusinessProfile';
+  /** [The merchant category code for the account](https://stripe.com/docs/connect/setting-mcc). MCCs are used to classify businesses based on the goods or services they provide. */
+  mcc?: Maybe<Scalars['String']>;
+  /** The customer-facing business name. */
+  name?: Maybe<Scalars['String']>;
+  /** Internal-only description of the product sold or service provided by the business. It's used by Stripe for risk and underwriting purposes. */
+  product_description?: Maybe<Scalars['String']>;
+  support_address?: Maybe<Stripe_Address>;
+  /** A publicly available email address for sending support issues to. */
+  support_email?: Maybe<Scalars['String']>;
+  /** A publicly available phone number to call with support issues. */
+  support_phone?: Maybe<Scalars['String']>;
+  /** A publicly available website for handling support issues. */
+  support_url?: Maybe<Scalars['String']>;
+  /** The business's publicly available website. */
+  url?: Maybe<Scalars['String']>;
+};
+
+export enum Stripe_AccountBusinessTypeProperty {
+  Company = 'company',
+  GovernmentEntity = 'government_entity',
+  Individual = 'individual',
+  NonProfit = 'non_profit'
+}
+
+export type Stripe_AccountCapabilities = {
+  __typename?: 'Stripe_AccountCapabilities';
+  /** The status of the ACSS Direct Debits payments capability of the account, or whether the account can directly process ACSS Direct Debits charges. */
+  acss_debit_payments?: Maybe<Stripe_AccountCapabilitiesAcssDebitPaymentsProperty>;
+  /** The status of the Afterpay Clearpay capability of the account, or whether the account can directly process Afterpay Clearpay charges. */
+  afterpay_clearpay_payments?: Maybe<Stripe_AccountCapabilitiesAfterpayClearpayPaymentsProperty>;
+  /** The status of the BECS Direct Debit (AU) payments capability of the account, or whether the account can directly process BECS Direct Debit (AU) charges. */
+  au_becs_debit_payments?: Maybe<Stripe_AccountCapabilitiesAuBecsDebitPaymentsProperty>;
+  /** The status of the Bacs Direct Debits payments capability of the account, or whether the account can directly process Bacs Direct Debits charges. */
+  bacs_debit_payments?: Maybe<Stripe_AccountCapabilitiesBacsDebitPaymentsProperty>;
+  /** The status of the Bancontact payments capability of the account, or whether the account can directly process Bancontact charges. */
+  bancontact_payments?: Maybe<Stripe_AccountCapabilitiesBancontactPaymentsProperty>;
+  /** The status of the boleto payments capability of the account, or whether the account can directly process boleto charges. */
+  boleto_payments?: Maybe<Stripe_AccountCapabilitiesBoletoPaymentsProperty>;
+  /** The status of the card issuing capability of the account, or whether you can use Issuing to distribute funds on cards */
+  card_issuing?: Maybe<Stripe_AccountCapabilitiesCardIssuingProperty>;
+  /** The status of the card payments capability of the account, or whether the account can directly process credit and debit card charges. */
+  card_payments?: Maybe<Stripe_AccountCapabilitiesCardPaymentsProperty>;
+  /** The status of the Cartes Bancaires payments capability of the account, or whether the account can directly process Cartes Bancaires card charges in EUR currency. */
+  cartes_bancaires_payments?: Maybe<Stripe_AccountCapabilitiesCartesBancairesPaymentsProperty>;
+  /** The status of the EPS payments capability of the account, or whether the account can directly process EPS charges. */
+  eps_payments?: Maybe<Stripe_AccountCapabilitiesEpsPaymentsProperty>;
+  /** The status of the FPX payments capability of the account, or whether the account can directly process FPX charges. */
+  fpx_payments?: Maybe<Stripe_AccountCapabilitiesFpxPaymentsProperty>;
+  /** The status of the giropay payments capability of the account, or whether the account can directly process giropay charges. */
+  giropay_payments?: Maybe<Stripe_AccountCapabilitiesGiropayPaymentsProperty>;
+  /** The status of the GrabPay payments capability of the account, or whether the account can directly process GrabPay charges. */
+  grabpay_payments?: Maybe<Stripe_AccountCapabilitiesGrabpayPaymentsProperty>;
+  /** The status of the iDEAL payments capability of the account, or whether the account can directly process iDEAL charges. */
+  ideal_payments?: Maybe<Stripe_AccountCapabilitiesIdealPaymentsProperty>;
+  /** The status of the JCB payments capability of the account, or whether the account (Japan only) can directly process JCB credit card charges in JPY currency. */
+  jcb_payments?: Maybe<Stripe_AccountCapabilitiesJcbPaymentsProperty>;
+  /** The status of the legacy payments capability of the account. */
+  legacy_payments?: Maybe<Stripe_AccountCapabilitiesLegacyPaymentsProperty>;
+  /** The status of the OXXO payments capability of the account, or whether the account can directly process OXXO charges. */
+  oxxo_payments?: Maybe<Stripe_AccountCapabilitiesOxxoPaymentsProperty>;
+  /** The status of the P24 payments capability of the account, or whether the account can directly process P24 charges. */
+  p24_payments?: Maybe<Stripe_AccountCapabilitiesP24PaymentsProperty>;
+  /** The status of the SEPA Direct Debits payments capability of the account, or whether the account can directly process SEPA Direct Debits charges. */
+  sepa_debit_payments?: Maybe<Stripe_AccountCapabilitiesSepaDebitPaymentsProperty>;
+  /** The status of the Sofort payments capability of the account, or whether the account can directly process Sofort charges. */
+  sofort_payments?: Maybe<Stripe_AccountCapabilitiesSofortPaymentsProperty>;
+  /** The status of the tax reporting 1099-K (US) capability of the account. */
+  tax_reporting_us_1099_k?: Maybe<Stripe_AccountCapabilitiesTaxReportingUs1099KProperty>;
+  /** The status of the tax reporting 1099-MISC (US) capability of the account. */
+  tax_reporting_us_1099_misc?: Maybe<Stripe_AccountCapabilitiesTaxReportingUs1099MiscProperty>;
+  /** The status of the transfers capability of the account, or whether your platform can transfer funds to the account. */
+  transfers?: Maybe<Stripe_AccountCapabilitiesTransfersProperty>;
+};
+
+export enum Stripe_AccountCapabilitiesAcssDebitPaymentsProperty {
+  Active = 'active',
+  Inactive = 'inactive',
+  Pending = 'pending'
+}
+
+export enum Stripe_AccountCapabilitiesAfterpayClearpayPaymentsProperty {
+  Active = 'active',
+  Inactive = 'inactive',
+  Pending = 'pending'
+}
+
+export enum Stripe_AccountCapabilitiesAuBecsDebitPaymentsProperty {
+  Active = 'active',
+  Inactive = 'inactive',
+  Pending = 'pending'
+}
+
+export enum Stripe_AccountCapabilitiesBacsDebitPaymentsProperty {
+  Active = 'active',
+  Inactive = 'inactive',
+  Pending = 'pending'
+}
+
+export enum Stripe_AccountCapabilitiesBancontactPaymentsProperty {
+  Active = 'active',
+  Inactive = 'inactive',
+  Pending = 'pending'
+}
+
+export enum Stripe_AccountCapabilitiesBoletoPaymentsProperty {
+  Active = 'active',
+  Inactive = 'inactive',
+  Pending = 'pending'
+}
+
+export enum Stripe_AccountCapabilitiesCardIssuingProperty {
+  Active = 'active',
+  Inactive = 'inactive',
+  Pending = 'pending'
+}
+
+export enum Stripe_AccountCapabilitiesCardPaymentsProperty {
+  Active = 'active',
+  Inactive = 'inactive',
+  Pending = 'pending'
+}
+
+export enum Stripe_AccountCapabilitiesCartesBancairesPaymentsProperty {
+  Active = 'active',
+  Inactive = 'inactive',
+  Pending = 'pending'
+}
+
+export enum Stripe_AccountCapabilitiesEpsPaymentsProperty {
+  Active = 'active',
+  Inactive = 'inactive',
+  Pending = 'pending'
+}
+
+export enum Stripe_AccountCapabilitiesFpxPaymentsProperty {
+  Active = 'active',
+  Inactive = 'inactive',
+  Pending = 'pending'
+}
+
+export enum Stripe_AccountCapabilitiesGiropayPaymentsProperty {
+  Active = 'active',
+  Inactive = 'inactive',
+  Pending = 'pending'
+}
+
+export enum Stripe_AccountCapabilitiesGrabpayPaymentsProperty {
+  Active = 'active',
+  Inactive = 'inactive',
+  Pending = 'pending'
+}
+
+export enum Stripe_AccountCapabilitiesIdealPaymentsProperty {
+  Active = 'active',
+  Inactive = 'inactive',
+  Pending = 'pending'
+}
+
+export enum Stripe_AccountCapabilitiesJcbPaymentsProperty {
+  Active = 'active',
+  Inactive = 'inactive',
+  Pending = 'pending'
+}
+
+export enum Stripe_AccountCapabilitiesLegacyPaymentsProperty {
+  Active = 'active',
+  Inactive = 'inactive',
+  Pending = 'pending'
+}
+
+export enum Stripe_AccountCapabilitiesOxxoPaymentsProperty {
+  Active = 'active',
+  Inactive = 'inactive',
+  Pending = 'pending'
+}
+
+export enum Stripe_AccountCapabilitiesP24PaymentsProperty {
+  Active = 'active',
+  Inactive = 'inactive',
+  Pending = 'pending'
+}
+
+export enum Stripe_AccountCapabilitiesSepaDebitPaymentsProperty {
+  Active = 'active',
+  Inactive = 'inactive',
+  Pending = 'pending'
+}
+
+export enum Stripe_AccountCapabilitiesSofortPaymentsProperty {
+  Active = 'active',
+  Inactive = 'inactive',
+  Pending = 'pending'
+}
+
+export enum Stripe_AccountCapabilitiesTaxReportingUs1099KProperty {
+  Active = 'active',
+  Inactive = 'inactive',
+  Pending = 'pending'
+}
+
+export enum Stripe_AccountCapabilitiesTaxReportingUs1099MiscProperty {
+  Active = 'active',
+  Inactive = 'inactive',
+  Pending = 'pending'
+}
+
+export enum Stripe_AccountCapabilitiesTransfersProperty {
+  Active = 'active',
+  Inactive = 'inactive',
+  Pending = 'pending'
+}
+
+export type Stripe_LegalEntityCompany = {
+  __typename?: 'Stripe_LegalEntityCompany';
+  address?: Maybe<Stripe_Address>;
+  address_kana?: Maybe<Stripe_LegalEntityJapanAddress>;
+  address_kanji?: Maybe<Stripe_LegalEntityJapanAddress>;
+  /** Whether the company's directors have been provided. This Boolean will be `true` if you've manually indicated that all directors are provided via [the `directors_provided` parameter](https://stripe.com/docs/api/accounts/update#update_account-company-directors_provided). */
+  directors_provided?: Maybe<Scalars['Boolean']>;
+  /** Whether the company's executives have been provided. This Boolean will be `true` if you've manually indicated that all executives are provided via [the `executives_provided` parameter](https://stripe.com/docs/api/accounts/update#update_account-company-executives_provided), or if Stripe determined that sufficient executives were provided. */
+  executives_provided?: Maybe<Scalars['Boolean']>;
+  /** The company's legal name. */
+  name?: Maybe<Scalars['String']>;
+  /** The Kana variation of the company's legal name (Japan only). */
+  name_kana?: Maybe<Scalars['String']>;
+  /** The Kanji variation of the company's legal name (Japan only). */
+  name_kanji?: Maybe<Scalars['String']>;
+  /** Whether the company's owners have been provided. This Boolean will be `true` if you've manually indicated that all owners are provided via [the `owners_provided` parameter](https://stripe.com/docs/api/accounts/update#update_account-company-owners_provided), or if Stripe determined that sufficient owners were provided. Stripe determines ownership requirements using both the number of owners provided and their total percent ownership (calculated by adding the `percent_ownership` of each owner together). */
+  owners_provided?: Maybe<Scalars['Boolean']>;
+  /** The company's phone number (used for verification). */
+  phone?: Maybe<Scalars['String']>;
+  /** The category identifying the legal structure of the company or legal entity. See [Business structure](https://stripe.com/docs/connect/identity-verification#business-structure) for more details. */
+  structure?: Maybe<Stripe_LegalEntityCompanyStructureProperty>;
+  /** Whether the company's business ID number was provided. */
+  tax_id_provided?: Maybe<Scalars['Boolean']>;
+  /** The jurisdiction in which the `tax_id` is registered (Germany-based companies only). */
+  tax_id_registrar?: Maybe<Scalars['String']>;
+  /** Whether the company's business VAT number was provided. */
+  vat_id_provided?: Maybe<Scalars['Boolean']>;
+  verification?: Maybe<Stripe_LegalEntityCompanyVerification>;
+};
+
+export type Stripe_LegalEntityJapanAddress = {
+  __typename?: 'Stripe_LegalEntityJapanAddress';
+  /** City/Ward. */
+  city?: Maybe<Scalars['String']>;
+  /** Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)). */
+  country?: Maybe<Scalars['String']>;
+  /** Block/Building number. */
+  line1?: Maybe<Scalars['String']>;
+  /** Building details. */
+  line2?: Maybe<Scalars['String']>;
+  /** ZIP or postal code. */
+  postal_code?: Maybe<Scalars['String']>;
+  /** Prefecture. */
+  state?: Maybe<Scalars['String']>;
+  /** Town/cho-me. */
+  town?: Maybe<Scalars['String']>;
+};
+
+export enum Stripe_LegalEntityCompanyStructureProperty {
+  FreeZoneEstablishment = 'free_zone_establishment',
+  FreeZoneLlc = 'free_zone_llc',
+  GovernmentInstrumentality = 'government_instrumentality',
+  GovernmentalUnit = 'governmental_unit',
+  IncorporatedNonProfit = 'incorporated_non_profit',
+  LimitedLiabilityPartnership = 'limited_liability_partnership',
+  Llc = 'llc',
+  MultiMemberLlc = 'multi_member_llc',
+  PrivateCompany = 'private_company',
+  PrivateCorporation = 'private_corporation',
+  PrivatePartnership = 'private_partnership',
+  PublicCompany = 'public_company',
+  PublicCorporation = 'public_corporation',
+  PublicPartnership = 'public_partnership',
+  SingleMemberLlc = 'single_member_llc',
+  SoleEstablishment = 'sole_establishment',
+  SoleProprietorship = 'sole_proprietorship',
+  TaxExemptGovernmentInstrumentality = 'tax_exempt_government_instrumentality',
+  UnincorporatedAssociation = 'unincorporated_association',
+  UnincorporatedNonProfit = 'unincorporated_non_profit'
+}
+
+export type Stripe_LegalEntityCompanyVerification = {
+  __typename?: 'Stripe_LegalEntityCompanyVerification';
+  document?: Maybe<Stripe_LegalEntityCompanyVerificationDocument>;
+};
+
+export type Stripe_LegalEntityCompanyVerificationDocument = {
+  __typename?: 'Stripe_LegalEntityCompanyVerificationDocument';
+  back?: Maybe<Stripe_LegalEntityCompanyVerificationDocumentBackProperty>;
+  /** A user-displayable string describing the verification state of this document. */
+  details?: Maybe<Scalars['String']>;
+  /** One of `document_corrupt`, `document_expired`, `document_failed_copy`, `document_failed_greyscale`, `document_failed_other`, `document_failed_test_mode`, `document_fraudulent`, `document_incomplete`, `document_invalid`, `document_manipulated`, `document_not_readable`, `document_not_uploaded`, `document_type_not_supported`, or `document_too_large`. A machine-readable code specifying the verification state for this document. */
+  details_code?: Maybe<Scalars['String']>;
+  front?: Maybe<Stripe_LegalEntityCompanyVerificationDocumentFrontProperty>;
+};
+
+export type Stripe_LegalEntityCompanyVerificationDocumentBackProperty = WrappedString | Stripe_File;
+
+export type Stripe_File = {
+  __typename?: 'Stripe_File';
+  /** Time at which the object was created. Measured in seconds since the Unix epoch. */
+  created?: Maybe<Scalars['Int']>;
+  /** The time at which the file expires and is no longer available in epoch seconds. */
+  expires_at?: Maybe<Scalars['Int']>;
+  /** A filename for the file, suitable for saving to a filesystem. */
+  filename?: Maybe<Scalars['String']>;
+  /** Unique identifier for the object. */
+  id?: Maybe<Scalars['String']>;
+  /** A list of [file links](https://stripe.com/docs/api#file_links) that point at this file. */
+  links?: Maybe<Stripe_FileLinksProperty>;
+  /** String representing the object's type. Objects of the same type share the same value. */
+  object?: Maybe<Stripe_FileObjectProperty>;
+  /** The [purpose](https://stripe.com/docs/file-upload#uploading-a-file) of the uploaded file. */
+  purpose?: Maybe<Stripe_FilePurposeProperty>;
+  /** The size in bytes of the file object. */
+  size?: Maybe<Scalars['Int']>;
+  /** A user friendly title for the document. */
+  title?: Maybe<Scalars['String']>;
+  /** The type of the file returned (e.g., `csv`, `pdf`, `jpg`, or `png`). */
+  type?: Maybe<Scalars['String']>;
+  /** The URL from which the file can be downloaded using your live secret API key. */
+  url?: Maybe<Scalars['String']>;
+};
+
+/** A list of [file links](https://stripe.com/docs/api#file_links) that point at this file. */
+export type Stripe_FileLinksProperty = {
+  __typename?: 'Stripe_FileLinksProperty';
+  /** Details about each object. */
+  data: Array<Stripe_FileLink>;
+  /** True if this list has another page of items after this one that can be fetched. */
+  has_more: Scalars['Boolean'];
+  /** String representing the object's type. Objects of the same type share the same value. Always has the value `list`. */
+  object: Stripe_FileLinksObjectProperty;
+  /** The URL where this list can be accessed. */
+  url: Scalars['String'];
+};
+
+export type Stripe_FileLink = {
+  __typename?: 'Stripe_FileLink';
+  /** Time at which the object was created. Measured in seconds since the Unix epoch. */
+  created?: Maybe<Scalars['Int']>;
+  /** Whether this link is already expired. */
+  expired?: Maybe<Scalars['Boolean']>;
+  /** Time at which the link expires. */
+  expires_at?: Maybe<Scalars['Int']>;
+  file?: Maybe<Stripe_FileLinkFileProperty>;
+  /** Unique identifier for the object. */
+  id?: Maybe<Scalars['String']>;
+  /** Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode. */
+  livemode?: Maybe<Scalars['Boolean']>;
+  /** Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. */
+  metadata?: Maybe<Scalars['JSONObject']>;
+  /** String representing the object's type. Objects of the same type share the same value. */
+  object?: Maybe<Stripe_FileLinkObjectProperty>;
+  /** The publicly accessible URL to download the file. */
+  url?: Maybe<Scalars['String']>;
+};
+
+export type Stripe_FileLinkFileProperty = WrappedString | Stripe_File;
+
+export enum Stripe_FileLinkObjectProperty {
+  FileLink = 'file_link'
+}
+
+export enum Stripe_FileLinksObjectProperty {
+  List = 'list'
+}
+
+export enum Stripe_FileObjectProperty {
+  File = 'file'
+}
+
+export enum Stripe_FilePurposeProperty {
+  AccountRequirement = 'account_requirement',
+  AdditionalVerification = 'additional_verification',
+  BusinessIcon = 'business_icon',
+  BusinessLogo = 'business_logo',
+  CustomerSignature = 'customer_signature',
+  DisputeEvidence = 'dispute_evidence',
+  DocumentProviderIdentityDocument = 'document_provider_identity_document',
+  FinanceReportRun = 'finance_report_run',
+  IdentityDocument = 'identity_document',
+  IdentityDocumentDownloadable = 'identity_document_downloadable',
+  PciDocument = 'pci_document',
+  Selfie = 'selfie',
+  SigmaScheduledQuery = 'sigma_scheduled_query',
+  TaxDocumentUserUpload = 'tax_document_user_upload'
+}
+
+export type Stripe_LegalEntityCompanyVerificationDocumentFrontProperty = WrappedString | Stripe_File;
+
+export type Stripe_AccountController = {
+  __typename?: 'Stripe_AccountController';
+  /** `true` if the Connect application retrieving the resource controls the account and can therefore exercise [platform controls](https://stripe.com/docs/connect/platform-controls-for-standard-accounts). Otherwise, this field is null. */
+  is_controller?: Maybe<Scalars['Boolean']>;
+  /** The controller type. Can be `application`, if a Connect application controls the account, or `account`, if the account controls itself. */
+  type?: Maybe<Stripe_AccountControllerTypeProperty>;
+};
+
+export enum Stripe_AccountControllerTypeProperty {
+  Account = 'account',
+  Application = 'application'
+}
+
+/** External accounts (bank accounts and debit cards) currently attached to this account */
+export type Stripe_AccountExternalAccountsProperty = {
+  __typename?: 'Stripe_AccountExternalAccountsProperty';
+  /** The list contains all external accounts that have been attached to the Stripe account. These may be bank accounts or cards. */
+  data: Array<Stripe_AccountExternalAccountsDataProperty>;
+  /** True if this list has another page of items after this one that can be fetched. */
+  has_more: Scalars['Boolean'];
+  /** String representing the object's type. Objects of the same type share the same value. Always has the value `list`. */
+  object: Stripe_AccountExternalAccountsObjectProperty;
+  /** The URL where this list can be accessed. */
+  url: Scalars['String'];
+};
+
+export type Stripe_AccountExternalAccountsDataProperty = Stripe_BankAccount | Stripe_Card;
+
+export type Stripe_Card = {
+  __typename?: 'Stripe_Card';
+  account?: Maybe<Stripe_CardAccountProperty>;
+  /** City/District/Suburb/Town/Village. */
+  address_city?: Maybe<Scalars['String']>;
+  /** Billing address country, if provided when creating card. */
+  address_country?: Maybe<Scalars['String']>;
+  /** Address line 1 (Street address/PO Box/Company name). */
+  address_line1?: Maybe<Scalars['String']>;
+  /** If `address_line1` was provided, results of the check: `pass`, `fail`, `unavailable`, or `unchecked`. */
+  address_line1_check?: Maybe<Scalars['String']>;
+  /** Address line 2 (Apartment/Suite/Unit/Building). */
+  address_line2?: Maybe<Scalars['String']>;
+  /** State/County/Province/Region. */
+  address_state?: Maybe<Scalars['String']>;
+  /** ZIP or postal code. */
+  address_zip?: Maybe<Scalars['String']>;
+  /** If `address_zip` was provided, results of the check: `pass`, `fail`, `unavailable`, or `unchecked`. */
+  address_zip_check?: Maybe<Scalars['String']>;
+  /** A set of available payout methods for this card. Only values from this set should be passed as the `method` when creating a payout. */
+  available_payout_methods?: Maybe<Array<Maybe<Stripe_CardAvailablePayoutMethodsProperty>>>;
+  /** Card brand. Can be `American Express`, `Diners Club`, `Discover`, `JCB`, `MasterCard`, `UnionPay`, `Visa`, or `Unknown`. */
+  brand?: Maybe<Scalars['String']>;
+  /** Two-letter ISO code representing the country of the card. You could use this attribute to get a sense of the international breakdown of cards you've collected. */
+  country?: Maybe<Scalars['String']>;
+  /** Three-letter [ISO code for currency](https://stripe.com/docs/payouts). Only applicable on accounts (not customers or recipients). The card can be used as a transfer destination for funds in this currency. */
+  currency?: Maybe<Scalars['String']>;
+  customer?: Maybe<Stripe_CardCustomerProperty>;
+  /** If a CVC was provided, results of the check: `pass`, `fail`, `unavailable`, or `unchecked`. A result of unchecked indicates that CVC was provided but hasn't been checked yet. Checks are typically performed when attaching a card to a Customer object, or when creating a charge. For more details, see [Check if a card is valid without a charge](https://support.stripe.com/questions/check-if-a-card-is-valid-without-a-charge). */
+  cvc_check?: Maybe<Scalars['String']>;
+  /** Whether this card is the default external account for its currency. */
+  default_for_currency?: Maybe<Scalars['Boolean']>;
+  /** (For tokenized numbers only.) The last four digits of the device account number. */
+  dynamic_last4?: Maybe<Scalars['String']>;
+  /** Two-digit number representing the card's expiration month. */
+  exp_month?: Maybe<Scalars['Int']>;
+  /** Four-digit number representing the card's expiration year. */
+  exp_year?: Maybe<Scalars['Int']>;
+  /**
+   * Uniquely identifies this particular card number. You can use this attribute to check whether two customers who’ve signed up with you are using the same card number, for example. For payment methods that tokenize card information (Apple Pay, Google Pay), the tokenized number might be provided instead of the underlying card number.
+   *
+   * *Starting May 1, 2021, card fingerprint in India for Connect will change to allow two fingerprints for the same card --- one for India and one for the rest of the world.*
+   */
+  fingerprint?: Maybe<Scalars['String']>;
+  /** Card funding type. Can be `credit`, `debit`, `prepaid`, or `unknown`. */
+  funding?: Maybe<Scalars['String']>;
+  /** Unique identifier for the object. */
+  id?: Maybe<Scalars['String']>;
+  /** The last four digits of the card. */
+  last4?: Maybe<Scalars['String']>;
+  /** Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. */
+  metadata?: Maybe<Scalars['JSONObject']>;
+  /** Cardholder name. */
+  name?: Maybe<Scalars['String']>;
+  /** String representing the object's type. Objects of the same type share the same value. */
+  object?: Maybe<Stripe_CardObjectProperty>;
+  recipient?: Maybe<Stripe_CardRecipientProperty>;
+  /** If the card number is tokenized, this is the method that was used. Can be `android_pay` (includes Google Pay), `apple_pay`, `masterpass`, `visa_checkout`, or null. */
+  tokenization_method?: Maybe<Scalars['String']>;
+};
+
+export type Stripe_CardAccountProperty = WrappedString | Stripe_Account;
+
+export enum Stripe_CardAvailablePayoutMethodsProperty {
+  Instant = 'instant',
+  Standard = 'standard'
+}
+
+export type Stripe_CardCustomerProperty = WrappedString | Stripe_Customer | Stripe_DeletedCustomer;
+
+export enum Stripe_CardObjectProperty {
+  Card = 'card'
+}
+
+export type Stripe_CardRecipientProperty = WrappedString | Stripe_Recipient;
+
+export type Stripe_Recipient = {
+  __typename?: 'Stripe_Recipient';
+  active_account?: Maybe<Stripe_BankAccount>;
+  cards?: Maybe<Stripe_RecipientCardsProperty>;
+  /** Time at which the object was created. Measured in seconds since the Unix epoch. */
+  created?: Maybe<Scalars['Int']>;
+  default_card?: Maybe<Stripe_RecipientDefaultCardProperty>;
+  /** An arbitrary string attached to the object. Often useful for displaying to users. */
+  description?: Maybe<Scalars['String']>;
+  email?: Maybe<Scalars['String']>;
+  /** Unique identifier for the object. */
+  id?: Maybe<Scalars['String']>;
+  /** Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode. */
+  livemode?: Maybe<Scalars['Boolean']>;
+  /** Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. */
+  metadata?: Maybe<Scalars['JSONObject']>;
+  migrated_to?: Maybe<Stripe_RecipientMigratedToProperty>;
+  /** Full, legal name of the recipient. */
+  name?: Maybe<Scalars['String']>;
+  /** String representing the object's type. Objects of the same type share the same value. */
+  object?: Maybe<Stripe_RecipientObjectProperty>;
+  rolled_back_from?: Maybe<Stripe_RecipientRolledBackFromProperty>;
+  /** Type of the recipient, one of `individual` or `corporation`. */
+  type?: Maybe<Scalars['String']>;
+};
+
+export type Stripe_RecipientCardsProperty = {
+  __typename?: 'Stripe_RecipientCardsProperty';
+  data: Array<Stripe_Card>;
+  /** True if this list has another page of items after this one that can be fetched. */
+  has_more: Scalars['Boolean'];
+  /** String representing the object's type. Objects of the same type share the same value. Always has the value `list`. */
+  object: Stripe_RecipientCardsObjectProperty;
+  /** The URL where this list can be accessed. */
+  url: Scalars['String'];
+};
+
+export enum Stripe_RecipientCardsObjectProperty {
+  List = 'list'
+}
+
+export type Stripe_RecipientDefaultCardProperty = WrappedString | Stripe_Card;
+
+export type Stripe_RecipientMigratedToProperty = WrappedString | Stripe_Account;
+
+export enum Stripe_RecipientObjectProperty {
+  Recipient = 'recipient'
+}
+
+export type Stripe_RecipientRolledBackFromProperty = WrappedString | Stripe_Account;
+
+export enum Stripe_AccountExternalAccountsObjectProperty {
+  List = 'list'
+}
+
+export type Stripe_Person = {
+  __typename?: 'Stripe_Person';
+  /** The account the person is associated with. */
+  account?: Maybe<Scalars['String']>;
+  address?: Maybe<Stripe_Address>;
+  address_kana?: Maybe<Stripe_LegalEntityJapanAddress>;
+  address_kanji?: Maybe<Stripe_LegalEntityJapanAddress>;
+  /** Time at which the object was created. Measured in seconds since the Unix epoch. */
+  created?: Maybe<Scalars['Int']>;
+  dob?: Maybe<Stripe_LegalEntityDob>;
+  /** The person's email address. */
+  email?: Maybe<Scalars['String']>;
+  /** The person's first name. */
+  first_name?: Maybe<Scalars['String']>;
+  /** The Kana variation of the person's first name (Japan only). */
+  first_name_kana?: Maybe<Scalars['String']>;
+  /** The Kanji variation of the person's first name (Japan only). */
+  first_name_kanji?: Maybe<Scalars['String']>;
+  /** The person's gender (International regulations require either "male" or "female"). */
+  gender?: Maybe<Scalars['String']>;
+  /** Unique identifier for the object. */
+  id?: Maybe<Scalars['String']>;
+  /** Whether the person's `id_number` was provided. */
+  id_number_provided?: Maybe<Scalars['Boolean']>;
+  /** The person's last name. */
+  last_name?: Maybe<Scalars['String']>;
+  /** The Kana variation of the person's last name (Japan only). */
+  last_name_kana?: Maybe<Scalars['String']>;
+  /** The Kanji variation of the person's last name (Japan only). */
+  last_name_kanji?: Maybe<Scalars['String']>;
+  /** The person's maiden name. */
+  maiden_name?: Maybe<Scalars['String']>;
+  /** Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. */
+  metadata?: Maybe<Scalars['JSONObject']>;
+  /** The country where the person is a national. */
+  nationality?: Maybe<Scalars['String']>;
+  /** String representing the object's type. Objects of the same type share the same value. */
+  object?: Maybe<Stripe_PersonObjectProperty>;
+  /** The person's phone number. */
+  phone?: Maybe<Scalars['String']>;
+  /** Indicates if the person or any of their representatives, family members, or other closely related persons, declares that they hold or have held an important public job or function, in any jurisdiction. */
+  political_exposure?: Maybe<Stripe_PersonPoliticalExposureProperty>;
+  relationship?: Maybe<Stripe_PersonRelationship>;
+  requirements?: Maybe<Stripe_PersonRequirements>;
+  /** Whether the last four digits of the person's Social Security number have been provided (U.S. only). */
+  ssn_last_4_provided?: Maybe<Scalars['Boolean']>;
+  verification?: Maybe<Stripe_LegalEntityPersonVerification>;
+};
+
+export type Stripe_LegalEntityDob = {
+  __typename?: 'Stripe_LegalEntityDob';
+  /** The day of birth, between 1 and 31. */
+  day?: Maybe<Scalars['Int']>;
+  /** The month of birth, between 1 and 12. */
+  month?: Maybe<Scalars['Int']>;
+  /** The four-digit year of birth. */
+  year?: Maybe<Scalars['Int']>;
+};
+
+export enum Stripe_PersonObjectProperty {
+  Person = 'person'
+}
+
+export enum Stripe_PersonPoliticalExposureProperty {
+  Existing = 'existing',
+  None = 'none'
+}
+
+export type Stripe_PersonRelationship = {
+  __typename?: 'Stripe_PersonRelationship';
+  /** Whether the person is a director of the account's legal entity. Currently only required for accounts in the EU. Directors are typically members of the governing board of the company, or responsible for ensuring the company meets its regulatory obligations. */
+  director?: Maybe<Scalars['Boolean']>;
+  /** Whether the person has significant responsibility to control, manage, or direct the organization. */
+  executive?: Maybe<Scalars['Boolean']>;
+  /** Whether the person is an owner of the account’s legal entity. */
+  owner?: Maybe<Scalars['Boolean']>;
+  /** The percent owned by the person of the account's legal entity. */
+  percent_ownership?: Maybe<Scalars['Float']>;
+  /** Whether the person is authorized as the primary representative of the account. This is the person nominated by the business to provide information about themselves, and general information about the account. There can only be one representative at any given time. At the time the account is created, this person should be set to the person responsible for opening the account. */
+  representative?: Maybe<Scalars['Boolean']>;
+  /** The person's title (e.g., CEO, Support Engineer). */
+  title?: Maybe<Scalars['String']>;
+};
+
+export type Stripe_PersonRequirements = {
+  __typename?: 'Stripe_PersonRequirements';
+  /** Fields that need to be collected to keep the person's account enabled. If not collected by the account's `current_deadline`, these fields appear in `past_due` as well, and the account is disabled. */
+  currently_due?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Fields that are `currently_due` and need to be collected again because validation or verification failed. */
+  errors?: Maybe<Array<Maybe<Stripe_AccountRequirementsError>>>;
+  /** Fields that need to be collected assuming all volume thresholds are reached. As they become required, they appear in `currently_due` as well, and the account's `current_deadline` becomes set. */
+  eventually_due?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Fields that weren't collected by the account's `current_deadline`. These fields need to be collected to enable the person's account. */
+  past_due?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Fields that may become required depending on the results of verification or review. Will be an empty array unless an asynchronous verification is pending. If verification fails, these fields move to `eventually_due`, `currently_due`, or `past_due`. */
+  pending_verification?: Maybe<Array<Maybe<Scalars['String']>>>;
+};
+
+export type Stripe_AccountRequirementsError = {
+  __typename?: 'Stripe_AccountRequirementsError';
+  /** The code for the type of error. */
+  code?: Maybe<Stripe_AccountRequirementsErrorCodeProperty>;
+  /** An informative message that indicates the error type and provides additional details about the error. */
+  reason?: Maybe<Scalars['String']>;
+  /** The specific user onboarding requirement field (in the requirements hash) that needs to be resolved. */
+  requirement?: Maybe<Scalars['String']>;
+};
+
+export enum Stripe_AccountRequirementsErrorCodeProperty {
+  InvalidAddressCityStatePostalCode = 'invalid_address_city_state_postal_code',
+  InvalidStreetAddress = 'invalid_street_address',
+  InvalidValueOther = 'invalid_value_other',
+  VerificationDocumentAddressMismatch = 'verification_document_address_mismatch',
+  VerificationDocumentAddressMissing = 'verification_document_address_missing',
+  VerificationDocumentCorrupt = 'verification_document_corrupt',
+  VerificationDocumentCountryNotSupported = 'verification_document_country_not_supported',
+  VerificationDocumentDobMismatch = 'verification_document_dob_mismatch',
+  VerificationDocumentDuplicateType = 'verification_document_duplicate_type',
+  VerificationDocumentExpired = 'verification_document_expired',
+  VerificationDocumentFailedCopy = 'verification_document_failed_copy',
+  VerificationDocumentFailedGreyscale = 'verification_document_failed_greyscale',
+  VerificationDocumentFailedOther = 'verification_document_failed_other',
+  VerificationDocumentFailedTestMode = 'verification_document_failed_test_mode',
+  VerificationDocumentFraudulent = 'verification_document_fraudulent',
+  VerificationDocumentIdNumberMismatch = 'verification_document_id_number_mismatch',
+  VerificationDocumentIdNumberMissing = 'verification_document_id_number_missing',
+  VerificationDocumentIncomplete = 'verification_document_incomplete',
+  VerificationDocumentInvalid = 'verification_document_invalid',
+  VerificationDocumentIssueOrExpiryDateMissing = 'verification_document_issue_or_expiry_date_missing',
+  VerificationDocumentManipulated = 'verification_document_manipulated',
+  VerificationDocumentMissingBack = 'verification_document_missing_back',
+  VerificationDocumentMissingFront = 'verification_document_missing_front',
+  VerificationDocumentNameMismatch = 'verification_document_name_mismatch',
+  VerificationDocumentNameMissing = 'verification_document_name_missing',
+  VerificationDocumentNationalityMismatch = 'verification_document_nationality_mismatch',
+  VerificationDocumentNotReadable = 'verification_document_not_readable',
+  VerificationDocumentNotSigned = 'verification_document_not_signed',
+  VerificationDocumentNotUploaded = 'verification_document_not_uploaded',
+  VerificationDocumentPhotoMismatch = 'verification_document_photo_mismatch',
+  VerificationDocumentTooLarge = 'verification_document_too_large',
+  VerificationDocumentTypeNotSupported = 'verification_document_type_not_supported',
+  VerificationFailedAddressMatch = 'verification_failed_address_match',
+  VerificationFailedBusinessIecNumber = 'verification_failed_business_iec_number',
+  VerificationFailedDocumentMatch = 'verification_failed_document_match',
+  VerificationFailedIdNumberMatch = 'verification_failed_id_number_match',
+  VerificationFailedKeyedIdentity = 'verification_failed_keyed_identity',
+  VerificationFailedKeyedMatch = 'verification_failed_keyed_match',
+  VerificationFailedNameMatch = 'verification_failed_name_match',
+  VerificationFailedOther = 'verification_failed_other',
+  VerificationFailedTaxIdMatch = 'verification_failed_tax_id_match',
+  VerificationFailedTaxIdNotIssued = 'verification_failed_tax_id_not_issued',
+  VerificationMissingExecutives = 'verification_missing_executives',
+  VerificationMissingOwners = 'verification_missing_owners',
+  VerificationRequiresAdditionalMemorandumOfAssociations = 'verification_requires_additional_memorandum_of_associations'
+}
+
+export type Stripe_LegalEntityPersonVerification = {
+  __typename?: 'Stripe_LegalEntityPersonVerification';
+  additional_document?: Maybe<Stripe_LegalEntityPersonVerificationDocument>;
+  /** A user-displayable string describing the verification state for the person. For example, this may say "Provided identity information could not be verified". */
+  details?: Maybe<Scalars['String']>;
+  /** One of `document_address_mismatch`, `document_dob_mismatch`, `document_duplicate_type`, `document_id_number_mismatch`, `document_name_mismatch`, `document_nationality_mismatch`, `failed_keyed_identity`, or `failed_other`. A machine-readable code specifying the verification state for the person. */
+  details_code?: Maybe<Scalars['String']>;
+  document?: Maybe<Stripe_LegalEntityPersonVerificationDocument>;
+  /** The state of verification for the person. Possible values are `unverified`, `pending`, or `verified`. */
+  status?: Maybe<Scalars['String']>;
+};
+
+export type Stripe_LegalEntityPersonVerificationDocument = {
+  __typename?: 'Stripe_LegalEntityPersonVerificationDocument';
+  back?: Maybe<Stripe_LegalEntityPersonVerificationDocumentBackProperty>;
+  /** A user-displayable string describing the verification state of this document. For example, if a document is uploaded and the picture is too fuzzy, this may say "Identity document is too unclear to read". */
+  details?: Maybe<Scalars['String']>;
+  /** One of `document_corrupt`, `document_country_not_supported`, `document_expired`, `document_failed_copy`, `document_failed_other`, `document_failed_test_mode`, `document_fraudulent`, `document_failed_greyscale`, `document_incomplete`, `document_invalid`, `document_manipulated`, `document_missing_back`, `document_missing_front`, `document_not_readable`, `document_not_uploaded`, `document_photo_mismatch`, `document_too_large`, or `document_type_not_supported`. A machine-readable code specifying the verification state for this document. */
+  details_code?: Maybe<Scalars['String']>;
+  front?: Maybe<Stripe_LegalEntityPersonVerificationDocumentFrontProperty>;
+};
+
+export type Stripe_LegalEntityPersonVerificationDocumentBackProperty = WrappedString | Stripe_File;
+
+export type Stripe_LegalEntityPersonVerificationDocumentFrontProperty = WrappedString | Stripe_File;
+
+export enum Stripe_AccountObjectProperty {
+  Account = 'account'
+}
+
+export type Stripe_AccountRequirements = {
+  __typename?: 'Stripe_AccountRequirements';
+  /** Date by which the fields in `currently_due` must be collected to keep the account enabled. These fields may disable the account sooner if the next threshold is reached before they are collected. */
+  current_deadline?: Maybe<Scalars['Int']>;
+  /** Fields that need to be collected to keep the account enabled. If not collected by `current_deadline`, these fields appear in `past_due` as well, and the account is disabled. */
+  currently_due?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** If the account is disabled, this string describes why. Can be `requirements.past_due`, `requirements.pending_verification`, `listed`, `platform_paused`, `rejected.fraud`, `rejected.listed`, `rejected.terms_of_service`, `rejected.other`, `under_review`, or `other`. */
+  disabled_reason?: Maybe<Scalars['String']>;
+  /** Fields that are `currently_due` and need to be collected again because validation or verification failed. */
+  errors?: Maybe<Array<Maybe<Stripe_AccountRequirementsError>>>;
+  /** Fields that need to be collected assuming all volume thresholds are reached. As they become required, they appear in `currently_due` as well, and `current_deadline` becomes set. */
+  eventually_due?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Fields that weren't collected by `current_deadline`. These fields need to be collected to enable the account. */
+  past_due?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Fields that may become required depending on the results of verification or review. Will be an empty array unless an asynchronous verification is pending. If verification fails, these fields move to `eventually_due`, `currently_due`, or `past_due`. */
+  pending_verification?: Maybe<Array<Maybe<Scalars['String']>>>;
+};
+
+export type Stripe_AccountSettings = {
+  __typename?: 'Stripe_AccountSettings';
+  bacs_debit_payments?: Maybe<Stripe_AccountBacsDebitPaymentsSettings>;
+  branding?: Maybe<Stripe_AccountBrandingSettings>;
+  card_issuing?: Maybe<Stripe_AccountCardIssuingSettings>;
+  card_payments?: Maybe<Stripe_AccountCardPaymentsSettings>;
+  dashboard?: Maybe<Stripe_AccountDashboardSettings>;
+  payments?: Maybe<Stripe_AccountPaymentsSettings>;
+  payouts?: Maybe<Stripe_AccountPayoutSettings>;
+  sepa_debit_payments?: Maybe<Stripe_AccountSepaDebitPaymentsSettings>;
+};
+
+export type Stripe_AccountBacsDebitPaymentsSettings = {
+  __typename?: 'Stripe_AccountBacsDebitPaymentsSettings';
+  /** The Bacs Direct Debit Display Name for this account. For payments made with Bacs Direct Debit, this will appear on the mandate, and as the statement descriptor. */
+  display_name?: Maybe<Scalars['String']>;
+};
+
+export type Stripe_AccountBrandingSettings = {
+  __typename?: 'Stripe_AccountBrandingSettings';
+  icon?: Maybe<Stripe_AccountBrandingSettingsIconProperty>;
+  logo?: Maybe<Stripe_AccountBrandingSettingsLogoProperty>;
+  /** A CSS hex color value representing the primary branding color for this account */
+  primary_color?: Maybe<Scalars['String']>;
+  /** A CSS hex color value representing the secondary branding color for this account */
+  secondary_color?: Maybe<Scalars['String']>;
+};
+
+export type Stripe_AccountBrandingSettingsIconProperty = WrappedString | Stripe_File;
+
+export type Stripe_AccountBrandingSettingsLogoProperty = WrappedString | Stripe_File;
+
+export type Stripe_AccountCardIssuingSettings = {
+  __typename?: 'Stripe_AccountCardIssuingSettings';
+  tos_acceptance?: Maybe<Stripe_CardIssuingAccountTermsOfService>;
+};
+
+export type Stripe_CardIssuingAccountTermsOfService = {
+  __typename?: 'Stripe_CardIssuingAccountTermsOfService';
+  /** The Unix timestamp marking when the account representative accepted the service agreement. */
+  date?: Maybe<Scalars['Int']>;
+  /** The IP address from which the account representative accepted the service agreement. */
+  ip?: Maybe<Scalars['String']>;
+  /** The user agent of the browser from which the account representative accepted the service agreement. */
+  user_agent?: Maybe<Scalars['String']>;
+};
+
+export type Stripe_AccountCardPaymentsSettings = {
+  __typename?: 'Stripe_AccountCardPaymentsSettings';
+  decline_on?: Maybe<Stripe_AccountDeclineChargeOn>;
+  /** The default text that appears on credit card statements when a charge is made. This field prefixes any dynamic `statement_descriptor` specified on the charge. `statement_descriptor_prefix` is useful for maximizing descriptor space for the dynamic portion. */
+  statement_descriptor_prefix?: Maybe<Scalars['String']>;
+};
+
+export type Stripe_AccountDeclineChargeOn = {
+  __typename?: 'Stripe_AccountDeclineChargeOn';
+  /** Whether Stripe automatically declines charges with an incorrect ZIP or postal code. This setting only applies when a ZIP or postal code is provided and they fail bank verification. */
+  avs_failure?: Maybe<Scalars['Boolean']>;
+  /** Whether Stripe automatically declines charges with an incorrect CVC. This setting only applies when a CVC is provided and it fails bank verification. */
+  cvc_failure?: Maybe<Scalars['Boolean']>;
+};
+
+export type Stripe_AccountDashboardSettings = {
+  __typename?: 'Stripe_AccountDashboardSettings';
+  /** The display name for this account. This is used on the Stripe Dashboard to differentiate between accounts. */
+  display_name?: Maybe<Scalars['String']>;
+  /** The timezone used in the Stripe Dashboard for this account. A list of possible time zone values is maintained at the [IANA Time Zone Database](http://www.iana.org/time-zones). */
+  timezone?: Maybe<Scalars['String']>;
+};
+
+export type Stripe_AccountPaymentsSettings = {
+  __typename?: 'Stripe_AccountPaymentsSettings';
+  /** The default text that appears on credit card statements when a charge is made. This field prefixes any dynamic `statement_descriptor` specified on the charge. */
+  statement_descriptor?: Maybe<Scalars['String']>;
+  /** The Kana variation of the default text that appears on credit card statements when a charge is made (Japan only) */
+  statement_descriptor_kana?: Maybe<Scalars['String']>;
+  /** The Kanji variation of the default text that appears on credit card statements when a charge is made (Japan only) */
+  statement_descriptor_kanji?: Maybe<Scalars['String']>;
+};
+
+export type Stripe_AccountPayoutSettings = {
+  __typename?: 'Stripe_AccountPayoutSettings';
+  /** A Boolean indicating if Stripe should try to reclaim negative balances from an attached bank account. See our [Understanding Connect Account Balances](https://stripe.com/docs/connect/account-balances) documentation for details. Default value is `true` for Express accounts and `false` for Custom accounts. */
+  debit_negative_balances?: Maybe<Scalars['Boolean']>;
+  schedule?: Maybe<Stripe_TransferSchedule>;
+  /** The text that appears on the bank account statement for payouts. If not set, this defaults to the platform's bank descriptor as set in the Dashboard. */
+  statement_descriptor?: Maybe<Scalars['String']>;
+};
+
+export type Stripe_TransferSchedule = {
+  __typename?: 'Stripe_TransferSchedule';
+  /** The number of days charges for the account will be held before being paid out. */
+  delay_days?: Maybe<Scalars['Int']>;
+  /** How frequently funds will be paid out. One of `manual` (payouts only created via API call), `daily`, `weekly`, or `monthly`. */
+  interval?: Maybe<Scalars['String']>;
+  /** The day of the month funds will be paid out. Only shown if `interval` is monthly. Payouts scheduled between the 29th and 31st of the month are sent on the last day of shorter months. */
+  monthly_anchor?: Maybe<Scalars['Int']>;
+  /** The day of the week funds will be paid out, of the style 'monday', 'tuesday', etc. Only shown if `interval` is weekly. */
+  weekly_anchor?: Maybe<Scalars['String']>;
+};
+
+export type Stripe_AccountSepaDebitPaymentsSettings = {
+  __typename?: 'Stripe_AccountSepaDebitPaymentsSettings';
+  /** SEPA creditor identifier that identifies the company making the payment. */
+  creditor_id?: Maybe<Scalars['String']>;
+};
+
+export type Stripe_AccountTosAcceptance = {
+  __typename?: 'Stripe_AccountTosAcceptance';
+  /** The Unix timestamp marking when the account representative accepted their service agreement */
+  date?: Maybe<Scalars['Int']>;
+  /** The IP address from which the account representative accepted their service agreement */
+  ip?: Maybe<Scalars['String']>;
+  /** The user's service agreement type */
+  service_agreement?: Maybe<Scalars['String']>;
+  /** The user agent of the browser from which the account representative accepted their service agreement */
+  user_agent?: Maybe<Scalars['String']>;
+};
+
+export enum Stripe_AccountTypeProperty {
+  Custom = 'custom',
+  Express = 'express',
+  Standard = 'standard'
+}
+
+export enum Stripe_BankAccountAvailablePayoutMethodsProperty {
+  Instant = 'instant',
+  Standard = 'standard'
+}
+
+export type Stripe_BankAccountCustomerProperty = WrappedString | Stripe_Customer | Stripe_DeletedCustomer;
+
+export enum Stripe_BankAccountObjectProperty {
+  BankAccount = 'bank_account'
+}
+
+export type Stripe_BitcoinReceiver = {
+  __typename?: 'Stripe_BitcoinReceiver';
+  /** True when this bitcoin receiver has received a non-zero amount of bitcoin. */
+  active?: Maybe<Scalars['Boolean']>;
+  /** The amount of `currency` that you are collecting as payment. */
+  amount?: Maybe<Scalars['Int']>;
+  /** The amount of `currency` to which `bitcoin_amount_received` has been converted. */
+  amount_received?: Maybe<Scalars['Int']>;
+  /** The amount of bitcoin that the customer should send to fill the receiver. The `bitcoin_amount` is denominated in Satoshi: there are 10^8 Satoshi in one bitcoin. */
+  bitcoin_amount?: Maybe<Scalars['Int']>;
+  /** The amount of bitcoin that has been sent by the customer to this receiver. */
+  bitcoin_amount_received?: Maybe<Scalars['Int']>;
+  /** This URI can be displayed to the customer as a clickable link (to activate their bitcoin client) or as a QR code (for mobile wallets). */
+  bitcoin_uri?: Maybe<Scalars['String']>;
+  /** Time at which the object was created. Measured in seconds since the Unix epoch. */
+  created?: Maybe<Scalars['Int']>;
+  /** Three-letter [ISO code for the currency](https://stripe.com/docs/currencies) to which the bitcoin will be converted. */
+  currency?: Maybe<Scalars['String']>;
+  /** The customer ID of the bitcoin receiver. */
+  customer?: Maybe<Scalars['String']>;
+  /** An arbitrary string attached to the object. Often useful for displaying to users. */
+  description?: Maybe<Scalars['String']>;
+  /** The customer's email address, set by the API call that creates the receiver. */
+  email?: Maybe<Scalars['String']>;
+  /** This flag is initially false and updates to true when the customer sends the `bitcoin_amount` to this receiver. */
+  filled?: Maybe<Scalars['Boolean']>;
+  /** Unique identifier for the object. */
+  id?: Maybe<Scalars['String']>;
+  /** A bitcoin address that is specific to this receiver. The customer can send bitcoin to this address to fill the receiver. */
+  inbound_address?: Maybe<Scalars['String']>;
+  /** Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode. */
+  livemode?: Maybe<Scalars['Boolean']>;
+  /** Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. */
+  metadata?: Maybe<Scalars['JSONObject']>;
+  /** String representing the object's type. Objects of the same type share the same value. */
+  object?: Maybe<Stripe_BitcoinReceiverObjectProperty>;
+  /** The ID of the payment created from the receiver, if any. Hidden when viewing the receiver with a publishable key. */
+  payment?: Maybe<Scalars['String']>;
+  /** The refund address of this bitcoin receiver. */
+  refund_address?: Maybe<Scalars['String']>;
+  /** A list with one entry for each time that the customer sent bitcoin to the receiver. Hidden when viewing the receiver with a publishable key. */
+  transactions?: Maybe<Stripe_BitcoinReceiverTransactionsProperty>;
+  /** This receiver contains uncaptured funds that can be used for a payment or refunded. */
+  uncaptured_funds?: Maybe<Scalars['Boolean']>;
+  /** Indicate if this source is used for payment. */
+  used_for_payment?: Maybe<Scalars['Boolean']>;
+};
+
+export enum Stripe_BitcoinReceiverObjectProperty {
+  BitcoinReceiver = 'bitcoin_receiver'
+}
+
+/** A list with one entry for each time that the customer sent bitcoin to the receiver. Hidden when viewing the receiver with a publishable key. */
+export type Stripe_BitcoinReceiverTransactionsProperty = {
+  __typename?: 'Stripe_BitcoinReceiverTransactionsProperty';
+  /** Details about each object. */
+  data: Array<Stripe_BitcoinTransaction>;
+  /** True if this list has another page of items after this one that can be fetched. */
+  has_more: Scalars['Boolean'];
+  /** String representing the object's type. Objects of the same type share the same value. Always has the value `list`. */
+  object: Stripe_BitcoinReceiverTransactionsObjectProperty;
+  /** The URL where this list can be accessed. */
+  url: Scalars['String'];
+};
+
+export type Stripe_BitcoinTransaction = {
+  __typename?: 'Stripe_BitcoinTransaction';
+  /** The amount of `currency` that the transaction was converted to in real-time. */
+  amount?: Maybe<Scalars['Int']>;
+  /** The amount of bitcoin contained in the transaction. */
+  bitcoin_amount?: Maybe<Scalars['Int']>;
+  /** Time at which the object was created. Measured in seconds since the Unix epoch. */
+  created?: Maybe<Scalars['Int']>;
+  /** Three-letter [ISO code for the currency](https://stripe.com/docs/currencies) to which this transaction was converted. */
+  currency?: Maybe<Scalars['String']>;
+  /** Unique identifier for the object. */
+  id?: Maybe<Scalars['String']>;
+  /** String representing the object's type. Objects of the same type share the same value. */
+  object?: Maybe<Stripe_BitcoinTransactionObjectProperty>;
+  /** The receiver to which this transaction was sent. */
+  receiver?: Maybe<Scalars['String']>;
+};
+
+export enum Stripe_BitcoinTransactionObjectProperty {
+  BitcoinTransaction = 'bitcoin_transaction'
+}
+
+export enum Stripe_BitcoinReceiverTransactionsObjectProperty {
+  List = 'list'
+}
+
+export type Stripe_Source = {
+  __typename?: 'Stripe_Source';
+  ach_credit_transfer?: Maybe<Stripe_SourceTypeAchCreditTransfer>;
+  ach_debit?: Maybe<Stripe_SourceTypeAchDebit>;
+  acss_debit?: Maybe<Stripe_SourceTypeAcssDebit>;
+  alipay?: Maybe<Stripe_SourceTypeAlipay>;
+  /** A positive integer in the smallest currency unit (that is, 100 cents for $1.00, or 1 for ¥1, Japanese Yen being a zero-decimal currency) representing the total amount associated with the source. This is the amount for which the source will be chargeable once ready. Required for `single_use` sources. */
+  amount?: Maybe<Scalars['Int']>;
+  au_becs_debit?: Maybe<Stripe_SourceTypeAuBecsDebit>;
+  bancontact?: Maybe<Stripe_SourceTypeBancontact>;
+  card?: Maybe<Stripe_SourceTypeCard>;
+  card_present?: Maybe<Stripe_SourceTypeCardPresent>;
+  /** The client secret of the source. Used for client-side retrieval using a publishable key. */
+  client_secret?: Maybe<Scalars['String']>;
+  code_verification?: Maybe<Stripe_SourceCodeVerificationFlow>;
+  /** Time at which the object was created. Measured in seconds since the Unix epoch. */
+  created?: Maybe<Scalars['Int']>;
+  /** Three-letter [ISO code for the currency](https://stripe.com/docs/currencies) associated with the source. This is the currency for which the source will be chargeable once ready. Required for `single_use` sources. */
+  currency?: Maybe<Scalars['String']>;
+  /** The ID of the customer to which this source is attached. This will not be present when the source has not been attached to a customer. */
+  customer?: Maybe<Scalars['String']>;
+  eps?: Maybe<Stripe_SourceTypeEps>;
+  /** The authentication `flow` of the source. `flow` is one of `redirect`, `receiver`, `code_verification`, `none`. */
+  flow?: Maybe<Scalars['String']>;
+  giropay?: Maybe<Stripe_SourceTypeGiropay>;
+  /** Unique identifier for the object. */
+  id?: Maybe<Scalars['String']>;
+  ideal?: Maybe<Stripe_SourceTypeIdeal>;
+  klarna?: Maybe<Stripe_SourceTypeKlarna>;
+  /** Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode. */
+  livemode?: Maybe<Scalars['Boolean']>;
+  /** Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. */
+  metadata?: Maybe<Scalars['JSONObject']>;
+  multibanco?: Maybe<Stripe_SourceTypeMultibanco>;
+  /** String representing the object's type. Objects of the same type share the same value. */
+  object?: Maybe<Stripe_SourceObjectProperty>;
+  owner?: Maybe<Stripe_SourceOwner>;
+  p24?: Maybe<Stripe_SourceTypeP24>;
+  receiver?: Maybe<Stripe_SourceReceiverFlow>;
+  redirect?: Maybe<Stripe_SourceRedirectFlow>;
+  sepa_debit?: Maybe<Stripe_SourceTypeSepaDebit>;
+  sofort?: Maybe<Stripe_SourceTypeSofort>;
+  source_order?: Maybe<Stripe_SourceOrder>;
+  /** Extra information about a source. This will appear on your customer's statement every time you charge the source. */
+  statement_descriptor?: Maybe<Scalars['String']>;
+  /** The status of the source, one of `canceled`, `chargeable`, `consumed`, `failed`, or `pending`. Only `chargeable` sources can be used to create a charge. */
+  status?: Maybe<Scalars['String']>;
+  three_d_secure?: Maybe<Stripe_SourceTypeThreeDSecure>;
+  /** The `type` of the source. The `type` is a payment method, one of `ach_credit_transfer`, `ach_debit`, `alipay`, `bancontact`, `card`, `card_present`, `eps`, `giropay`, `ideal`, `multibanco`, `klarna`, `p24`, `sepa_debit`, `sofort`, `three_d_secure`, or `wechat`. An additional hash is included on the source with a name matching this value. It contains additional information specific to the [payment method](https://stripe.com/docs/sources) used. */
+  type?: Maybe<Stripe_SourceTypeProperty>;
+  /** Either `reusable` or `single_use`. Whether this source should be reusable or not. Some source types may or may not be reusable by construction, while others may leave the option at creation. If an incompatible value is passed, an error will be returned. */
+  usage?: Maybe<Scalars['String']>;
+  wechat?: Maybe<Stripe_SourceTypeWechat>;
+};
+
+export type Stripe_SourceTypeAchCreditTransfer = {
+  __typename?: 'Stripe_SourceTypeAchCreditTransfer';
+  account_number?: Maybe<Scalars['String']>;
+  bank_name?: Maybe<Scalars['String']>;
+  fingerprint?: Maybe<Scalars['String']>;
+  refund_account_holder_name?: Maybe<Scalars['String']>;
+  refund_account_holder_type?: Maybe<Scalars['String']>;
+  refund_routing_number?: Maybe<Scalars['String']>;
+  routing_number?: Maybe<Scalars['String']>;
+  swift_code?: Maybe<Scalars['String']>;
+};
+
+export type Stripe_SourceTypeAchDebit = {
+  __typename?: 'Stripe_SourceTypeAchDebit';
+  bank_name?: Maybe<Scalars['String']>;
+  country?: Maybe<Scalars['String']>;
+  fingerprint?: Maybe<Scalars['String']>;
+  last4?: Maybe<Scalars['String']>;
+  routing_number?: Maybe<Scalars['String']>;
+  type?: Maybe<Scalars['String']>;
+};
+
+export type Stripe_SourceTypeAcssDebit = {
+  __typename?: 'Stripe_SourceTypeAcssDebit';
+  bank_address_city?: Maybe<Scalars['String']>;
+  bank_address_line_1?: Maybe<Scalars['String']>;
+  bank_address_line_2?: Maybe<Scalars['String']>;
+  bank_address_postal_code?: Maybe<Scalars['String']>;
+  bank_name?: Maybe<Scalars['String']>;
+  category?: Maybe<Scalars['String']>;
+  country?: Maybe<Scalars['String']>;
+  fingerprint?: Maybe<Scalars['String']>;
+  last4?: Maybe<Scalars['String']>;
+  routing_number?: Maybe<Scalars['String']>;
+};
+
+export type Stripe_SourceTypeAlipay = {
+  __typename?: 'Stripe_SourceTypeAlipay';
+  data_string?: Maybe<Scalars['String']>;
+  native_url?: Maybe<Scalars['String']>;
+  statement_descriptor?: Maybe<Scalars['String']>;
+};
+
+export type Stripe_SourceTypeAuBecsDebit = {
+  __typename?: 'Stripe_SourceTypeAuBecsDebit';
+  bsb_number?: Maybe<Scalars['String']>;
+  fingerprint?: Maybe<Scalars['String']>;
+  last4?: Maybe<Scalars['String']>;
+};
+
+export type Stripe_SourceTypeBancontact = {
+  __typename?: 'Stripe_SourceTypeBancontact';
+  bank_code?: Maybe<Scalars['String']>;
+  bank_name?: Maybe<Scalars['String']>;
+  bic?: Maybe<Scalars['String']>;
+  iban_last4?: Maybe<Scalars['String']>;
+  preferred_language?: Maybe<Scalars['String']>;
+  statement_descriptor?: Maybe<Scalars['String']>;
+};
+
+export type Stripe_SourceTypeCard = {
+  __typename?: 'Stripe_SourceTypeCard';
+  address_line1_check?: Maybe<Scalars['String']>;
+  address_zip_check?: Maybe<Scalars['String']>;
+  brand?: Maybe<Scalars['String']>;
+  country?: Maybe<Scalars['String']>;
+  cvc_check?: Maybe<Scalars['String']>;
+  dynamic_last4?: Maybe<Scalars['String']>;
+  exp_month?: Maybe<Scalars['Int']>;
+  exp_year?: Maybe<Scalars['Int']>;
+  fingerprint?: Maybe<Scalars['String']>;
+  funding?: Maybe<Scalars['String']>;
+  last4?: Maybe<Scalars['String']>;
+  name?: Maybe<Scalars['String']>;
+  three_d_secure?: Maybe<Scalars['String']>;
+  tokenization_method?: Maybe<Scalars['String']>;
+};
+
+export type Stripe_SourceTypeCardPresent = {
+  __typename?: 'Stripe_SourceTypeCardPresent';
+  application_cryptogram?: Maybe<Scalars['String']>;
+  application_preferred_name?: Maybe<Scalars['String']>;
+  authorization_code?: Maybe<Scalars['String']>;
+  authorization_response_code?: Maybe<Scalars['String']>;
+  brand?: Maybe<Scalars['String']>;
+  country?: Maybe<Scalars['String']>;
+  cvm_type?: Maybe<Scalars['String']>;
+  data_type?: Maybe<Scalars['String']>;
+  dedicated_file_name?: Maybe<Scalars['String']>;
+  emv_auth_data?: Maybe<Scalars['String']>;
+  evidence_customer_signature?: Maybe<Scalars['String']>;
+  evidence_transaction_certificate?: Maybe<Scalars['String']>;
+  exp_month?: Maybe<Scalars['Int']>;
+  exp_year?: Maybe<Scalars['Int']>;
+  fingerprint?: Maybe<Scalars['String']>;
+  funding?: Maybe<Scalars['String']>;
+  last4?: Maybe<Scalars['String']>;
+  pos_device_id?: Maybe<Scalars['String']>;
+  pos_entry_mode?: Maybe<Scalars['String']>;
+  read_method?: Maybe<Scalars['String']>;
+  reader?: Maybe<Scalars['String']>;
+  terminal_verification_results?: Maybe<Scalars['String']>;
+  transaction_status_information?: Maybe<Scalars['String']>;
+};
+
+export type Stripe_SourceCodeVerificationFlow = {
+  __typename?: 'Stripe_SourceCodeVerificationFlow';
+  /** The number of attempts remaining to authenticate the source object with a verification code. */
+  attempts_remaining?: Maybe<Scalars['Int']>;
+  /** The status of the code verification, either `pending` (awaiting verification, `attempts_remaining` should be greater than 0), `succeeded` (successful verification) or `failed` (failed verification, cannot be verified anymore as `attempts_remaining` should be 0). */
+  status?: Maybe<Scalars['String']>;
+};
+
+export type Stripe_SourceTypeEps = {
+  __typename?: 'Stripe_SourceTypeEps';
+  reference?: Maybe<Scalars['String']>;
+  statement_descriptor?: Maybe<Scalars['String']>;
+};
+
+export type Stripe_SourceTypeGiropay = {
+  __typename?: 'Stripe_SourceTypeGiropay';
+  bank_code?: Maybe<Scalars['String']>;
+  bank_name?: Maybe<Scalars['String']>;
+  bic?: Maybe<Scalars['String']>;
+  statement_descriptor?: Maybe<Scalars['String']>;
+};
+
+export type Stripe_SourceTypeIdeal = {
+  __typename?: 'Stripe_SourceTypeIdeal';
+  bank?: Maybe<Scalars['String']>;
+  bic?: Maybe<Scalars['String']>;
+  iban_last4?: Maybe<Scalars['String']>;
+  statement_descriptor?: Maybe<Scalars['String']>;
+};
+
+export type Stripe_SourceTypeKlarna = {
+  __typename?: 'Stripe_SourceTypeKlarna';
+  background_image_url?: Maybe<Scalars['String']>;
+  client_token?: Maybe<Scalars['String']>;
+  first_name?: Maybe<Scalars['String']>;
+  last_name?: Maybe<Scalars['String']>;
+  locale?: Maybe<Scalars['String']>;
+  logo_url?: Maybe<Scalars['String']>;
+  page_title?: Maybe<Scalars['String']>;
+  pay_later_asset_urls_descriptive?: Maybe<Scalars['String']>;
+  pay_later_asset_urls_standard?: Maybe<Scalars['String']>;
+  pay_later_name?: Maybe<Scalars['String']>;
+  pay_later_redirect_url?: Maybe<Scalars['String']>;
+  pay_now_asset_urls_descriptive?: Maybe<Scalars['String']>;
+  pay_now_asset_urls_standard?: Maybe<Scalars['String']>;
+  pay_now_name?: Maybe<Scalars['String']>;
+  pay_now_redirect_url?: Maybe<Scalars['String']>;
+  pay_over_time_asset_urls_descriptive?: Maybe<Scalars['String']>;
+  pay_over_time_asset_urls_standard?: Maybe<Scalars['String']>;
+  pay_over_time_name?: Maybe<Scalars['String']>;
+  pay_over_time_redirect_url?: Maybe<Scalars['String']>;
+  payment_method_categories?: Maybe<Scalars['String']>;
+  purchase_country?: Maybe<Scalars['String']>;
+  purchase_type?: Maybe<Scalars['String']>;
+  redirect_url?: Maybe<Scalars['String']>;
+  shipping_delay?: Maybe<Scalars['Int']>;
+  shipping_first_name?: Maybe<Scalars['String']>;
+  shipping_last_name?: Maybe<Scalars['String']>;
+};
+
+export type Stripe_SourceTypeMultibanco = {
+  __typename?: 'Stripe_SourceTypeMultibanco';
+  entity?: Maybe<Scalars['String']>;
+  reference?: Maybe<Scalars['String']>;
+  refund_account_holder_address_city?: Maybe<Scalars['String']>;
+  refund_account_holder_address_country?: Maybe<Scalars['String']>;
+  refund_account_holder_address_line1?: Maybe<Scalars['String']>;
+  refund_account_holder_address_line2?: Maybe<Scalars['String']>;
+  refund_account_holder_address_postal_code?: Maybe<Scalars['String']>;
+  refund_account_holder_address_state?: Maybe<Scalars['String']>;
+  refund_account_holder_name?: Maybe<Scalars['String']>;
+  refund_iban?: Maybe<Scalars['String']>;
+};
+
+export enum Stripe_SourceObjectProperty {
+  Source = 'source'
+}
+
+export type Stripe_SourceOwner = {
+  __typename?: 'Stripe_SourceOwner';
+  address?: Maybe<Stripe_Address>;
+  /** Owner's email address. */
+  email?: Maybe<Scalars['String']>;
+  /** Owner's full name. */
+  name?: Maybe<Scalars['String']>;
+  /** Owner's phone number (including extension). */
+  phone?: Maybe<Scalars['String']>;
+  verified_address?: Maybe<Stripe_Address>;
+  /** Verified owner's email address. Verified values are verified or provided by the payment method directly (and if supported) at the time of authorization or settlement. They cannot be set or mutated. */
+  verified_email?: Maybe<Scalars['String']>;
+  /** Verified owner's full name. Verified values are verified or provided by the payment method directly (and if supported) at the time of authorization or settlement. They cannot be set or mutated. */
+  verified_name?: Maybe<Scalars['String']>;
+  /** Verified owner's phone number (including extension). Verified values are verified or provided by the payment method directly (and if supported) at the time of authorization or settlement. They cannot be set or mutated. */
+  verified_phone?: Maybe<Scalars['String']>;
+};
+
+export type Stripe_SourceTypeP24 = {
+  __typename?: 'Stripe_SourceTypeP24';
+  reference?: Maybe<Scalars['String']>;
+};
+
+export type Stripe_SourceReceiverFlow = {
+  __typename?: 'Stripe_SourceReceiverFlow';
+  /** The address of the receiver source. This is the value that should be communicated to the customer to send their funds to. */
+  address?: Maybe<Scalars['String']>;
+  /** The total amount that was moved to your balance. This is almost always equal to the amount charged. In rare cases when customers deposit excess funds and we are unable to refund those, those funds get moved to your balance and show up in amount_charged as well. The amount charged is expressed in the source's currency. */
+  amount_charged?: Maybe<Scalars['Int']>;
+  /** The total amount received by the receiver source. `amount_received = amount_returned + amount_charged` should be true for consumed sources unless customers deposit excess funds. The amount received is expressed in the source's currency. */
+  amount_received?: Maybe<Scalars['Int']>;
+  /** The total amount that was returned to the customer. The amount returned is expressed in the source's currency. */
+  amount_returned?: Maybe<Scalars['Int']>;
+  /** Type of refund attribute method, one of `email`, `manual`, or `none`. */
+  refund_attributes_method?: Maybe<Scalars['String']>;
+  /** Type of refund attribute status, one of `missing`, `requested`, or `available`. */
+  refund_attributes_status?: Maybe<Scalars['String']>;
+};
+
+export type Stripe_SourceRedirectFlow = {
+  __typename?: 'Stripe_SourceRedirectFlow';
+  /** The failure reason for the redirect, either `user_abort` (the customer aborted or dropped out of the redirect flow), `declined` (the authentication failed or the transaction was declined), or `processing_error` (the redirect failed due to a technical error). Present only if the redirect status is `failed`. */
+  failure_reason?: Maybe<Scalars['String']>;
+  /** The URL you provide to redirect the customer to after they authenticated their payment. */
+  return_url?: Maybe<Scalars['String']>;
+  /** The status of the redirect, either `pending` (ready to be used by your customer to authenticate the transaction), `succeeded` (succesful authentication, cannot be reused) or `not_required` (redirect should not be used) or `failed` (failed authentication, cannot be reused). */
+  status?: Maybe<Scalars['String']>;
+  /** The URL provided to you to redirect a customer to as part of a `redirect` authentication flow. */
+  url?: Maybe<Scalars['String']>;
+};
+
+export type Stripe_SourceTypeSepaDebit = {
+  __typename?: 'Stripe_SourceTypeSepaDebit';
+  bank_code?: Maybe<Scalars['String']>;
+  branch_code?: Maybe<Scalars['String']>;
+  country?: Maybe<Scalars['String']>;
+  fingerprint?: Maybe<Scalars['String']>;
+  last4?: Maybe<Scalars['String']>;
+  mandate_reference?: Maybe<Scalars['String']>;
+  mandate_url?: Maybe<Scalars['String']>;
+};
+
+export type Stripe_SourceTypeSofort = {
+  __typename?: 'Stripe_SourceTypeSofort';
+  bank_code?: Maybe<Scalars['String']>;
+  bank_name?: Maybe<Scalars['String']>;
+  bic?: Maybe<Scalars['String']>;
+  country?: Maybe<Scalars['String']>;
+  iban_last4?: Maybe<Scalars['String']>;
+  preferred_language?: Maybe<Scalars['String']>;
+  statement_descriptor?: Maybe<Scalars['String']>;
+};
+
+export type Stripe_SourceOrder = {
+  __typename?: 'Stripe_SourceOrder';
+  /** A positive integer in the smallest currency unit (that is, 100 cents for $1.00, or 1 for ¥1, Japanese Yen being a zero-decimal currency) representing the total amount for the order. */
+  amount?: Maybe<Scalars['Int']>;
+  /** Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies). */
+  currency?: Maybe<Scalars['String']>;
+  /** The email address of the customer placing the order. */
+  email?: Maybe<Scalars['String']>;
+  /** List of items constituting the order. */
+  items?: Maybe<Array<Maybe<Stripe_SourceOrderItem>>>;
+  shipping?: Maybe<Stripe_Shipping>;
+};
+
+export type Stripe_SourceOrderItem = {
+  __typename?: 'Stripe_SourceOrderItem';
+  /** The amount (price) for this order item. */
+  amount?: Maybe<Scalars['Int']>;
+  /** This currency of this order item. Required when `amount` is present. */
+  currency?: Maybe<Scalars['String']>;
+  /** Human-readable description for this order item. */
+  description?: Maybe<Scalars['String']>;
+  /** The ID of the associated object for this line item. Expandable if not null (e.g., expandable to a SKU). */
+  parent?: Maybe<Scalars['String']>;
+  /** The quantity of this order item. When type is `sku`, this is the number of instances of the SKU to be ordered. */
+  quantity?: Maybe<Scalars['Int']>;
+  /** The type of this order item. Must be `sku`, `tax`, or `shipping`. */
+  type?: Maybe<Scalars['String']>;
+};
+
+export type Stripe_Shipping = {
+  __typename?: 'Stripe_Shipping';
+  address?: Maybe<Stripe_Address>;
+  /** The delivery service that shipped a physical product, such as Fedex, UPS, USPS, etc. */
+  carrier?: Maybe<Scalars['String']>;
+  /** Recipient name. */
+  name?: Maybe<Scalars['String']>;
+  /** Recipient phone (including extension). */
+  phone?: Maybe<Scalars['String']>;
+  /** The tracking number for a physical product, obtained from the delivery service. If multiple tracking numbers were generated for this purchase, please separate them with commas. */
+  tracking_number?: Maybe<Scalars['String']>;
+};
+
+export type Stripe_SourceTypeThreeDSecure = {
+  __typename?: 'Stripe_SourceTypeThreeDSecure';
+  address_line1_check?: Maybe<Scalars['String']>;
+  address_zip_check?: Maybe<Scalars['String']>;
+  authenticated?: Maybe<Scalars['Boolean']>;
+  brand?: Maybe<Scalars['String']>;
+  card?: Maybe<Scalars['String']>;
+  country?: Maybe<Scalars['String']>;
+  customer?: Maybe<Scalars['String']>;
+  cvc_check?: Maybe<Scalars['String']>;
+  dynamic_last4?: Maybe<Scalars['String']>;
+  exp_month?: Maybe<Scalars['Int']>;
+  exp_year?: Maybe<Scalars['Int']>;
+  fingerprint?: Maybe<Scalars['String']>;
+  funding?: Maybe<Scalars['String']>;
+  last4?: Maybe<Scalars['String']>;
+  name?: Maybe<Scalars['String']>;
+  three_d_secure?: Maybe<Scalars['String']>;
+  tokenization_method?: Maybe<Scalars['String']>;
+};
+
+export enum Stripe_SourceTypeProperty {
+  AchCreditTransfer = 'ach_credit_transfer',
+  AchDebit = 'ach_debit',
+  AcssDebit = 'acss_debit',
+  Alipay = 'alipay',
+  AuBecsDebit = 'au_becs_debit',
+  Bancontact = 'bancontact',
+  Card = 'card',
+  CardPresent = 'card_present',
+  Eps = 'eps',
+  Giropay = 'giropay',
+  Ideal = 'ideal',
+  Klarna = 'klarna',
+  Multibanco = 'multibanco',
+  P24 = 'p24',
+  SepaDebit = 'sepa_debit',
+  Sofort = 'sofort',
+  ThreeDSecure = 'three_d_secure',
+  Wechat = 'wechat'
+}
+
+export type Stripe_SourceTypeWechat = {
+  __typename?: 'Stripe_SourceTypeWechat';
+  prepay_id?: Maybe<Scalars['String']>;
+  qr_code_url?: Maybe<Scalars['String']>;
+  statement_descriptor?: Maybe<Scalars['String']>;
+};
+
+export type Stripe_Discount = {
+  __typename?: 'Stripe_Discount';
+  /** The Checkout session that this coupon is applied to, if it is applied to a particular session in payment mode. Will not be present for subscription mode. */
+  checkout_session?: Maybe<Scalars['String']>;
+  coupon?: Maybe<Stripe_Coupon>;
+  customer?: Maybe<Stripe_DiscountCustomerProperty>;
+  /** If the coupon has a duration of `repeating`, the date that this discount will end. If the coupon has a duration of `once` or `forever`, this attribute will be null. */
+  end?: Maybe<Scalars['Int']>;
+  /** The ID of the discount object. Discounts cannot be fetched by ID. Use `expand[]=discounts` in API calls to expand discount IDs in an array. */
+  id?: Maybe<Scalars['String']>;
+  /** The invoice that the discount's coupon was applied to, if it was applied directly to a particular invoice. */
+  invoice?: Maybe<Scalars['String']>;
+  /** The invoice item `id` (or invoice line item `id` for invoice line items of type='subscription') that the discount's coupon was applied to, if it was applied directly to a particular invoice item or invoice line item. */
+  invoice_item?: Maybe<Scalars['String']>;
+  /** String representing the object's type. Objects of the same type share the same value. */
+  object?: Maybe<Stripe_DiscountObjectProperty>;
+  promotion_code?: Maybe<Stripe_DiscountPromotionCodeProperty>;
+  /** Date that the coupon was applied. */
+  start?: Maybe<Scalars['Int']>;
+  /** The subscription that this coupon is applied to, if it is applied to a particular subscription. */
+  subscription?: Maybe<Scalars['String']>;
+};
+
+export type Stripe_Coupon = {
+  __typename?: 'Stripe_Coupon';
+  /** Amount (in the `currency` specified) that will be taken off the subtotal of any invoices for this customer. */
+  amount_off?: Maybe<Scalars['Int']>;
+  applies_to?: Maybe<Stripe_CouponAppliesTo>;
+  /** Time at which the object was created. Measured in seconds since the Unix epoch. */
+  created?: Maybe<Scalars['Int']>;
+  /** If `amount_off` has been set, the three-letter [ISO code for the currency](https://stripe.com/docs/currencies) of the amount to take off. */
+  currency?: Maybe<Scalars['String']>;
+  /** One of `forever`, `once`, and `repeating`. Describes how long a customer who applies this coupon will get the discount. */
+  duration?: Maybe<Stripe_CouponDurationProperty>;
+  /** If `duration` is `repeating`, the number of months the coupon applies. Null if coupon `duration` is `forever` or `once`. */
+  duration_in_months?: Maybe<Scalars['Int']>;
+  /** Unique identifier for the object. */
+  id?: Maybe<Scalars['String']>;
+  /** Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode. */
+  livemode?: Maybe<Scalars['Boolean']>;
+  /** Maximum number of times this coupon can be redeemed, in total, across all customers, before it is no longer valid. */
+  max_redemptions?: Maybe<Scalars['Int']>;
+  /** Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. */
+  metadata?: Maybe<Scalars['JSONObject']>;
+  /** Name of the coupon displayed to customers on for instance invoices or receipts. */
+  name?: Maybe<Scalars['String']>;
+  /** String representing the object's type. Objects of the same type share the same value. */
+  object?: Maybe<Stripe_CouponObjectProperty>;
+  /** Percent that will be taken off the subtotal of any invoices for this customer for the duration of the coupon. For example, a coupon with percent_off of 50 will make a %s100 invoice %s50 instead. */
+  percent_off?: Maybe<Scalars['Float']>;
+  /** Date after which the coupon can no longer be redeemed. */
+  redeem_by?: Maybe<Scalars['Int']>;
+  /** Number of times this coupon has been applied to a customer. */
+  times_redeemed?: Maybe<Scalars['Int']>;
+  /** Taking account of the above properties, whether this coupon can still be applied to a customer. */
+  valid?: Maybe<Scalars['Boolean']>;
+};
+
+export type Stripe_CouponAppliesTo = {
+  __typename?: 'Stripe_CouponAppliesTo';
+  /** A list of product IDs this coupon applies to */
+  products?: Maybe<Array<Maybe<Scalars['String']>>>;
+};
+
+export enum Stripe_CouponDurationProperty {
+  Forever = 'forever',
+  Once = 'once',
+  Repeating = 'repeating'
+}
+
+export enum Stripe_CouponObjectProperty {
+  Coupon = 'coupon'
+}
+
+export type Stripe_DiscountCustomerProperty = WrappedString | Stripe_Customer | Stripe_DeletedCustomer;
+
+export enum Stripe_DiscountObjectProperty {
+  Discount = 'discount'
+}
+
+export type Stripe_DiscountPromotionCodeProperty = WrappedString | Stripe_PromotionCode;
+
+export type Stripe_PromotionCode = {
+  __typename?: 'Stripe_PromotionCode';
+  /** Whether the promotion code is currently active. A promotion code is only active if the coupon is also valid. */
+  active?: Maybe<Scalars['Boolean']>;
+  /** The customer-facing code. Regardless of case, this code must be unique across all active promotion codes for each customer. */
+  code?: Maybe<Scalars['String']>;
+  coupon?: Maybe<Stripe_Coupon>;
+  /** Time at which the object was created. Measured in seconds since the Unix epoch. */
+  created?: Maybe<Scalars['Int']>;
+  customer?: Maybe<Stripe_PromotionCodeCustomerProperty>;
+  /** Date at which the promotion code can no longer be redeemed. */
+  expires_at?: Maybe<Scalars['Int']>;
+  /** Unique identifier for the object. */
+  id?: Maybe<Scalars['String']>;
+  /** Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode. */
+  livemode?: Maybe<Scalars['Boolean']>;
+  /** Maximum number of times this promotion code can be redeemed. */
+  max_redemptions?: Maybe<Scalars['Int']>;
+  /** Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. */
+  metadata?: Maybe<Scalars['JSONObject']>;
+  /** String representing the object's type. Objects of the same type share the same value. */
+  object?: Maybe<Stripe_PromotionCodeObjectProperty>;
+  restrictions?: Maybe<Stripe_PromotionCodesResourceRestrictions>;
+  /** Number of times this promotion code has been used. */
+  times_redeemed?: Maybe<Scalars['Int']>;
+};
+
+export type Stripe_PromotionCodeCustomerProperty = WrappedString | Stripe_Customer | Stripe_DeletedCustomer;
+
+export enum Stripe_PromotionCodeObjectProperty {
+  PromotionCode = 'promotion_code'
+}
+
+export type Stripe_PromotionCodesResourceRestrictions = {
+  __typename?: 'Stripe_PromotionCodesResourceRestrictions';
+  /** A Boolean indicating if the Promotion Code should only be redeemed for Customers without any successful payments or invoices */
+  first_time_transaction?: Maybe<Scalars['Boolean']>;
+  /** Minimum amount required to redeem this Promotion Code into a Coupon (e.g., a purchase must be $100 or more to work). */
+  minimum_amount?: Maybe<Scalars['Int']>;
+  /** Three-letter [ISO code](https://stripe.com/docs/currencies) for minimum_amount */
+  minimum_amount_currency?: Maybe<Scalars['String']>;
+};
+
+export type Stripe_InvoiceSettingCustomerSetting = {
+  __typename?: 'Stripe_InvoiceSettingCustomerSetting';
+  /** Default custom fields to be displayed on invoices for this customer. */
+  custom_fields?: Maybe<Array<Maybe<Stripe_InvoiceSettingCustomField>>>;
+  default_payment_method?: Maybe<Stripe_InvoiceSettingCustomerSettingDefaultPaymentMethodProperty>;
+  /** Default footer to be displayed on invoices for this customer. */
+  footer?: Maybe<Scalars['String']>;
+};
+
+export type Stripe_InvoiceSettingCustomField = {
+  __typename?: 'Stripe_InvoiceSettingCustomField';
+  /** The name of the custom field. */
+  name?: Maybe<Scalars['String']>;
+  /** The value of the custom field. */
+  value?: Maybe<Scalars['String']>;
+};
+
+export type Stripe_InvoiceSettingCustomerSettingDefaultPaymentMethodProperty = WrappedString | Stripe_PaymentMethod;
+
+export type Stripe_PaymentMethod = {
+  __typename?: 'Stripe_PaymentMethod';
+  acss_debit?: Maybe<Stripe_PaymentMethodAcssDebit>;
+  afterpay_clearpay?: Maybe<Stripe_PaymentMethodAfterpayClearpay>;
+  alipay?: Maybe<Stripe_PaymentFlowsPrivatePaymentMethodsAlipay>;
+  au_becs_debit?: Maybe<Stripe_PaymentMethodAuBecsDebit>;
+  bacs_debit?: Maybe<Stripe_PaymentMethodBacsDebit>;
+  bancontact?: Maybe<Stripe_PaymentMethodBancontact>;
+  billing_details?: Maybe<Stripe_BillingDetails>;
+  boleto?: Maybe<Stripe_PaymentMethodBoleto>;
+  card?: Maybe<Stripe_PaymentMethodCard>;
+  card_present?: Maybe<Stripe_PaymentMethodCardPresent>;
+  /** Time at which the object was created. Measured in seconds since the Unix epoch. */
+  created?: Maybe<Scalars['Int']>;
+  customer?: Maybe<Stripe_PaymentMethodCustomerProperty>;
+  eps?: Maybe<Stripe_PaymentMethodEps>;
+  fpx?: Maybe<Stripe_PaymentMethodFpx>;
+  giropay?: Maybe<Stripe_PaymentMethodGiropay>;
+  grabpay?: Maybe<Stripe_PaymentMethodGrabpay>;
+  /** Unique identifier for the object. */
+  id?: Maybe<Scalars['String']>;
+  ideal?: Maybe<Stripe_PaymentMethodIdeal>;
+  interac_present?: Maybe<Stripe_PaymentMethodInteracPresent>;
+  /** Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode. */
+  livemode?: Maybe<Scalars['Boolean']>;
+  /** Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. */
+  metadata?: Maybe<Scalars['JSONObject']>;
+  /** String representing the object's type. Objects of the same type share the same value. */
+  object?: Maybe<Stripe_PaymentMethodObjectProperty>;
+  oxxo?: Maybe<Stripe_PaymentMethodOxxo>;
+  p24?: Maybe<Stripe_PaymentMethodP24>;
+  sepa_debit?: Maybe<Stripe_PaymentMethodSepaDebit>;
+  sofort?: Maybe<Stripe_PaymentMethodSofort>;
+  /** The type of the PaymentMethod. An additional hash is included on the PaymentMethod with a name matching this value. It contains additional information specific to the PaymentMethod type. */
+  type?: Maybe<Stripe_PaymentMethodTypeProperty>;
+  wechat_pay?: Maybe<Stripe_PaymentMethodWechatPay>;
+};
+
+export type Stripe_PaymentMethodAcssDebit = {
+  __typename?: 'Stripe_PaymentMethodAcssDebit';
+  /** Name of the bank associated with the bank account. */
+  bank_name?: Maybe<Scalars['String']>;
+  /** Uniquely identifies this particular bank account. You can use this attribute to check whether two bank accounts are the same. */
+  fingerprint?: Maybe<Scalars['String']>;
+  /** Institution number of the bank account. */
+  institution_number?: Maybe<Scalars['String']>;
+  /** Last four digits of the bank account number. */
+  last4?: Maybe<Scalars['String']>;
+  /** Transit number of the bank account. */
+  transit_number?: Maybe<Scalars['String']>;
+};
+
+export type Stripe_PaymentMethodAfterpayClearpay = {
+  __typename?: 'Stripe_PaymentMethodAfterpayClearpay';
+  result?: Maybe<Scalars['JSONObject']>;
+};
+
+export type Stripe_PaymentFlowsPrivatePaymentMethodsAlipay = {
+  __typename?: 'Stripe_PaymentFlowsPrivatePaymentMethodsAlipay';
+  result?: Maybe<Scalars['JSONObject']>;
+};
+
+export type Stripe_PaymentMethodAuBecsDebit = {
+  __typename?: 'Stripe_PaymentMethodAuBecsDebit';
+  /** Six-digit number identifying bank and branch associated with this bank account. */
+  bsb_number?: Maybe<Scalars['String']>;
+  /** Uniquely identifies this particular bank account. You can use this attribute to check whether two bank accounts are the same. */
+  fingerprint?: Maybe<Scalars['String']>;
+  /** Last four digits of the bank account number. */
+  last4?: Maybe<Scalars['String']>;
+};
+
+export type Stripe_PaymentMethodBacsDebit = {
+  __typename?: 'Stripe_PaymentMethodBacsDebit';
+  /** Uniquely identifies this particular bank account. You can use this attribute to check whether two bank accounts are the same. */
+  fingerprint?: Maybe<Scalars['String']>;
+  /** Last four digits of the bank account number. */
+  last4?: Maybe<Scalars['String']>;
+  /** Sort code of the bank account. (e.g., `10-20-30`) */
+  sort_code?: Maybe<Scalars['String']>;
+};
+
+export type Stripe_PaymentMethodBancontact = {
+  __typename?: 'Stripe_PaymentMethodBancontact';
+  result?: Maybe<Scalars['JSONObject']>;
+};
+
+export type Stripe_BillingDetails = {
+  __typename?: 'Stripe_BillingDetails';
+  address?: Maybe<Stripe_Address>;
+  /** Email address. */
+  email?: Maybe<Scalars['String']>;
+  /** Full name. */
+  name?: Maybe<Scalars['String']>;
+  /** Billing phone number (including extension). */
+  phone?: Maybe<Scalars['String']>;
+};
+
+export type Stripe_PaymentMethodBoleto = {
+  __typename?: 'Stripe_PaymentMethodBoleto';
+  /** Uniquely identifies the customer tax id (CNPJ or CPF) */
+  tax_id?: Maybe<Scalars['String']>;
+};
+
+export type Stripe_PaymentMethodCard = {
+  __typename?: 'Stripe_PaymentMethodCard';
+  /** Card brand. Can be `amex`, `diners`, `discover`, `jcb`, `mastercard`, `unionpay`, `visa`, or `unknown`. */
+  brand?: Maybe<Scalars['String']>;
+  checks?: Maybe<Stripe_PaymentMethodCardChecks>;
+  /** Two-letter ISO code representing the country of the card. You could use this attribute to get a sense of the international breakdown of cards you've collected. */
+  country?: Maybe<Scalars['String']>;
+  /** Two-digit number representing the card's expiration month. */
+  exp_month?: Maybe<Scalars['Int']>;
+  /** Four-digit number representing the card's expiration year. */
+  exp_year?: Maybe<Scalars['Int']>;
+  /**
+   * Uniquely identifies this particular card number. You can use this attribute to check whether two customers who’ve signed up with you are using the same card number, for example. For payment methods that tokenize card information (Apple Pay, Google Pay), the tokenized number might be provided instead of the underlying card number.
+   *
+   * *Starting May 1, 2021, card fingerprint in India for Connect will change to allow two fingerprints for the same card --- one for India and one for the rest of the world.*
+   */
+  fingerprint?: Maybe<Scalars['String']>;
+  /** Card funding type. Can be `credit`, `debit`, `prepaid`, or `unknown`. */
+  funding?: Maybe<Scalars['String']>;
+  generated_from?: Maybe<Stripe_PaymentMethodCardGeneratedCard>;
+  /** The last four digits of the card. */
+  last4?: Maybe<Scalars['String']>;
+  networks?: Maybe<Stripe_Networks>;
+  three_d_secure_usage?: Maybe<Stripe_ThreeDSecureUsage>;
+  wallet?: Maybe<Stripe_PaymentMethodCardWallet>;
+};
+
+export type Stripe_PaymentMethodCardChecks = {
+  __typename?: 'Stripe_PaymentMethodCardChecks';
+  /** If a address line1 was provided, results of the check, one of `pass`, `fail`, `unavailable`, or `unchecked`. */
+  address_line1_check?: Maybe<Scalars['String']>;
+  /** If a address postal code was provided, results of the check, one of `pass`, `fail`, `unavailable`, or `unchecked`. */
+  address_postal_code_check?: Maybe<Scalars['String']>;
+  /** If a CVC was provided, results of the check, one of `pass`, `fail`, `unavailable`, or `unchecked`. */
+  cvc_check?: Maybe<Scalars['String']>;
+};
+
+export type Stripe_PaymentMethodCardGeneratedCard = {
+  __typename?: 'Stripe_PaymentMethodCardGeneratedCard';
+  /** The charge that created this object. */
+  charge?: Maybe<Scalars['String']>;
+  payment_method_details?: Maybe<Stripe_CardGeneratedFromPaymentMethodDetails>;
+  setup_attempt?: Maybe<Stripe_PaymentMethodCardGeneratedCardSetupAttemptProperty>;
+};
+
+export type Stripe_CardGeneratedFromPaymentMethodDetails = {
+  __typename?: 'Stripe_CardGeneratedFromPaymentMethodDetails';
+  card_present?: Maybe<Stripe_PaymentMethodDetailsCardPresent>;
+  /** The type of payment method transaction-specific details from the transaction that generated this `card` payment method. Always `card_present`. */
+  type?: Maybe<Scalars['String']>;
+};
+
+export type Stripe_PaymentMethodDetailsCardPresent = {
+  __typename?: 'Stripe_PaymentMethodDetailsCardPresent';
+  /** Card brand. Can be `amex`, `diners`, `discover`, `jcb`, `mastercard`, `unionpay`, `visa`, or `unknown`. */
+  brand?: Maybe<Scalars['String']>;
+  /** The cardholder name as read from the card, in [ISO 7813](https://en.wikipedia.org/wiki/ISO/IEC_7813) format. May include alphanumeric characters, special characters and first/last name separator (`/`). */
+  cardholder_name?: Maybe<Scalars['String']>;
+  /** Two-letter ISO code representing the country of the card. You could use this attribute to get a sense of the international breakdown of cards you've collected. */
+  country?: Maybe<Scalars['String']>;
+  /** Authorization response cryptogram. */
+  emv_auth_data?: Maybe<Scalars['String']>;
+  /** Two-digit number representing the card's expiration month. */
+  exp_month?: Maybe<Scalars['Int']>;
+  /** Four-digit number representing the card's expiration year. */
+  exp_year?: Maybe<Scalars['Int']>;
+  /**
+   * Uniquely identifies this particular card number. You can use this attribute to check whether two customers who’ve signed up with you are using the same card number, for example. For payment methods that tokenize card information (Apple Pay, Google Pay), the tokenized number might be provided instead of the underlying card number.
+   *
+   * *Starting May 1, 2021, card fingerprint in India for Connect will change to allow two fingerprints for the same card --- one for India and one for the rest of the world.*
+   */
+  fingerprint?: Maybe<Scalars['String']>;
+  /** Card funding type. Can be `credit`, `debit`, `prepaid`, or `unknown`. */
+  funding?: Maybe<Scalars['String']>;
+  /** ID of a card PaymentMethod generated from the card_present PaymentMethod that may be attached to a Customer for future transactions. Only present if it was possible to generate a card PaymentMethod. */
+  generated_card?: Maybe<Scalars['String']>;
+  /** The last four digits of the card. */
+  last4?: Maybe<Scalars['String']>;
+  /** Identifies which network this charge was processed on. Can be `amex`, `cartes_bancaires`, `diners`, `discover`, `interac`, `jcb`, `mastercard`, `unionpay`, `visa`, or `unknown`. */
+  network?: Maybe<Scalars['String']>;
+  /** How card details were read in this transaction. */
+  read_method?: Maybe<Stripe_PaymentMethodDetailsCardPresentReadMethodProperty>;
+  receipt?: Maybe<Stripe_PaymentMethodDetailsCardPresentReceipt>;
+};
+
+export enum Stripe_PaymentMethodDetailsCardPresentReadMethodProperty {
+  ContactEmv = 'contact_emv',
+  ContactlessEmv = 'contactless_emv',
+  ContactlessMagstripeMode = 'contactless_magstripe_mode',
+  MagneticStripeFallback = 'magnetic_stripe_fallback',
+  MagneticStripeTrack2 = 'magnetic_stripe_track2'
+}
+
+export type Stripe_PaymentMethodDetailsCardPresentReceipt = {
+  __typename?: 'Stripe_PaymentMethodDetailsCardPresentReceipt';
+  /** The type of account being debited or credited */
+  account_type?: Maybe<Stripe_PaymentMethodDetailsCardPresentReceiptAccountTypeProperty>;
+  /** EMV tag 9F26, cryptogram generated by the integrated circuit chip. */
+  application_cryptogram?: Maybe<Scalars['String']>;
+  /** Mnenomic of the Application Identifier. */
+  application_preferred_name?: Maybe<Scalars['String']>;
+  /** Identifier for this transaction. */
+  authorization_code?: Maybe<Scalars['String']>;
+  /** EMV tag 8A. A code returned by the card issuer. */
+  authorization_response_code?: Maybe<Scalars['String']>;
+  /** How the cardholder verified ownership of the card. */
+  cardholder_verification_method?: Maybe<Scalars['String']>;
+  /** EMV tag 84. Similar to the application identifier stored on the integrated circuit chip. */
+  dedicated_file_name?: Maybe<Scalars['String']>;
+  /** The outcome of a series of EMV functions performed by the card reader. */
+  terminal_verification_results?: Maybe<Scalars['String']>;
+  /** An indication of various EMV functions performed during the transaction. */
+  transaction_status_information?: Maybe<Scalars['String']>;
+};
+
+export enum Stripe_PaymentMethodDetailsCardPresentReceiptAccountTypeProperty {
+  Checking = 'checking',
+  Credit = 'credit',
+  Prepaid = 'prepaid',
+  Unknown = 'unknown'
+}
+
+export type Stripe_PaymentMethodCardGeneratedCardSetupAttemptProperty = WrappedString | Stripe_SetupAttempt;
+
+export type Stripe_SetupAttempt = {
+  __typename?: 'Stripe_SetupAttempt';
+  application?: Maybe<Stripe_SetupAttemptApplicationProperty>;
+  /** Time at which the object was created. Measured in seconds since the Unix epoch. */
+  created?: Maybe<Scalars['Int']>;
+  customer?: Maybe<Stripe_SetupAttemptCustomerProperty>;
+  /** Unique identifier for the object. */
+  id?: Maybe<Scalars['String']>;
+  /** Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode. */
+  livemode?: Maybe<Scalars['Boolean']>;
+  /** String representing the object's type. Objects of the same type share the same value. */
+  object?: Maybe<Stripe_SetupAttemptObjectProperty>;
+  on_behalf_of?: Maybe<Stripe_SetupAttemptOnBehalfOfProperty>;
+  payment_method?: Maybe<Stripe_SetupAttemptPaymentMethodProperty>;
+  payment_method_details?: Maybe<Stripe_SetupAttemptPaymentMethodDetails>;
+  setup_error?: Maybe<Stripe_ApiErrors>;
+  setup_intent?: Maybe<Stripe_SetupAttemptSetupIntentProperty>;
+  /** Status of this SetupAttempt, one of `requires_confirmation`, `requires_action`, `processing`, `succeeded`, `failed`, or `abandoned`. */
+  status?: Maybe<Scalars['String']>;
+  /** The value of [usage](https://stripe.com/docs/api/setup_intents/object#setup_intent_object-usage) on the SetupIntent at the time of this confirmation, one of `off_session` or `on_session`. */
+  usage?: Maybe<Scalars['String']>;
+};
+
+export type Stripe_SetupAttemptApplicationProperty = WrappedString | Stripe_Application;
+
+export type Stripe_Application = {
+  __typename?: 'Stripe_Application';
+  /** Unique identifier for the object. */
+  id?: Maybe<Scalars['String']>;
+  /** The name of the application. */
+  name?: Maybe<Scalars['String']>;
+  /** String representing the object's type. Objects of the same type share the same value. */
+  object?: Maybe<Stripe_ApplicationObjectProperty>;
+};
+
+export enum Stripe_ApplicationObjectProperty {
+  Application = 'application'
+}
+
+export type Stripe_SetupAttemptCustomerProperty = WrappedString | Stripe_Customer | Stripe_DeletedCustomer;
+
+export enum Stripe_SetupAttemptObjectProperty {
+  SetupAttempt = 'setup_attempt'
+}
+
+export type Stripe_SetupAttemptOnBehalfOfProperty = WrappedString | Stripe_Account;
+
+export type Stripe_SetupAttemptPaymentMethodProperty = WrappedString | Stripe_PaymentMethod;
+
+export type Stripe_SetupAttemptPaymentMethodDetails = {
+  __typename?: 'Stripe_SetupAttemptPaymentMethodDetails';
+  acss_debit?: Maybe<Stripe_SetupAttemptPaymentMethodDetailsAcssDebit>;
+  au_becs_debit?: Maybe<Stripe_SetupAttemptPaymentMethodDetailsAuBecsDebit>;
+  bacs_debit?: Maybe<Stripe_SetupAttemptPaymentMethodDetailsBacsDebit>;
+  bancontact?: Maybe<Stripe_SetupAttemptPaymentMethodDetailsBancontact>;
+  card?: Maybe<Stripe_SetupAttemptPaymentMethodDetailsCard>;
+  card_present?: Maybe<Stripe_SetupAttemptPaymentMethodDetailsCardPresent>;
+  ideal?: Maybe<Stripe_SetupAttemptPaymentMethodDetailsIdeal>;
+  sepa_debit?: Maybe<Stripe_SetupAttemptPaymentMethodDetailsSepaDebit>;
+  sofort?: Maybe<Stripe_SetupAttemptPaymentMethodDetailsSofort>;
+  /** The type of the payment method used in the SetupIntent (e.g., `card`). An additional hash is included on `payment_method_details` with a name matching this value. It contains confirmation-specific information for the payment method. */
+  type?: Maybe<Scalars['String']>;
+};
+
+export type Stripe_SetupAttemptPaymentMethodDetailsAcssDebit = {
+  __typename?: 'Stripe_SetupAttemptPaymentMethodDetailsAcssDebit';
+  result?: Maybe<Scalars['JSONObject']>;
+};
+
+export type Stripe_SetupAttemptPaymentMethodDetailsAuBecsDebit = {
+  __typename?: 'Stripe_SetupAttemptPaymentMethodDetailsAuBecsDebit';
+  result?: Maybe<Scalars['JSONObject']>;
+};
+
+export type Stripe_SetupAttemptPaymentMethodDetailsBacsDebit = {
+  __typename?: 'Stripe_SetupAttemptPaymentMethodDetailsBacsDebit';
+  result?: Maybe<Scalars['JSONObject']>;
+};
+
+export type Stripe_SetupAttemptPaymentMethodDetailsBancontact = {
+  __typename?: 'Stripe_SetupAttemptPaymentMethodDetailsBancontact';
+  /** Bank code of bank associated with the bank account. */
+  bank_code?: Maybe<Scalars['String']>;
+  /** Name of the bank associated with the bank account. */
+  bank_name?: Maybe<Scalars['String']>;
+  /** Bank Identifier Code of the bank associated with the bank account. */
+  bic?: Maybe<Scalars['String']>;
+  generated_sepa_debit?: Maybe<Stripe_SetupAttemptPaymentMethodDetailsBancontactGeneratedSepaDebitProperty>;
+  generated_sepa_debit_mandate?: Maybe<Stripe_SetupAttemptPaymentMethodDetailsBancontactGeneratedSepaDebitMandateProperty>;
+  /** Last four characters of the IBAN. */
+  iban_last4?: Maybe<Scalars['String']>;
+  /**
+   * Preferred language of the Bancontact authorization page that the customer is redirected to.
+   * Can be one of `en`, `de`, `fr`, or `nl`
+   */
+  preferred_language?: Maybe<Stripe_SetupAttemptPaymentMethodDetailsBancontactPreferredLanguageProperty>;
+  /**
+   * Owner's verified full name. Values are verified or provided by Bancontact directly
+   * (if supported) at the time of authorization or settlement. They cannot be set or mutated.
+   */
+  verified_name?: Maybe<Scalars['String']>;
+};
+
+export type Stripe_SetupAttemptPaymentMethodDetailsBancontactGeneratedSepaDebitProperty = WrappedString | Stripe_PaymentMethod;
+
+export type Stripe_SetupAttemptPaymentMethodDetailsBancontactGeneratedSepaDebitMandateProperty = WrappedString | Stripe_Mandate;
+
+export type Stripe_Mandate = {
+  __typename?: 'Stripe_Mandate';
+  customer_acceptance?: Maybe<Stripe_CustomerAcceptance>;
+  /** Unique identifier for the object. */
+  id?: Maybe<Scalars['String']>;
+  /** Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode. */
+  livemode?: Maybe<Scalars['Boolean']>;
+  multi_use?: Maybe<Stripe_MandateMultiUse>;
+  /** String representing the object's type. Objects of the same type share the same value. */
+  object?: Maybe<Stripe_MandateObjectProperty>;
+  payment_method?: Maybe<Stripe_MandatePaymentMethodProperty>;
+  payment_method_details?: Maybe<Stripe_MandatePaymentMethodDetails>;
+  single_use?: Maybe<Stripe_MandateSingleUse>;
+  /** The status of the mandate, which indicates whether it can be used to initiate a payment. */
+  status?: Maybe<Stripe_MandateStatusProperty>;
+  /** The type of the mandate. */
+  type?: Maybe<Stripe_MandateTypeProperty>;
+};
+
+export type Stripe_CustomerAcceptance = {
+  __typename?: 'Stripe_CustomerAcceptance';
+  /** The time at which the customer accepted the Mandate. */
+  accepted_at?: Maybe<Scalars['Int']>;
+  offline?: Maybe<Stripe_OfflineAcceptance>;
+  online?: Maybe<Stripe_OnlineAcceptance>;
+  /** The type of customer acceptance information included with the Mandate. One of `online` or `offline`. */
+  type?: Maybe<Stripe_CustomerAcceptanceTypeProperty>;
+};
+
+export type Stripe_OfflineAcceptance = {
+  __typename?: 'Stripe_OfflineAcceptance';
+  result?: Maybe<Scalars['JSONObject']>;
+};
+
+export type Stripe_OnlineAcceptance = {
+  __typename?: 'Stripe_OnlineAcceptance';
+  /** The IP address from which the Mandate was accepted by the customer. */
+  ip_address?: Maybe<Scalars['String']>;
+  /** The user agent of the browser from which the Mandate was accepted by the customer. */
+  user_agent?: Maybe<Scalars['String']>;
+};
+
+export enum Stripe_CustomerAcceptanceTypeProperty {
+  Offline = 'offline',
+  Online = 'online'
+}
+
+export type Stripe_MandateMultiUse = {
+  __typename?: 'Stripe_MandateMultiUse';
+  result?: Maybe<Scalars['JSONObject']>;
+};
+
+export enum Stripe_MandateObjectProperty {
+  Mandate = 'mandate'
+}
+
+export type Stripe_MandatePaymentMethodProperty = WrappedString | Stripe_PaymentMethod;
+
+export type Stripe_MandatePaymentMethodDetails = {
+  __typename?: 'Stripe_MandatePaymentMethodDetails';
+  acss_debit?: Maybe<Stripe_MandateAcssDebit>;
+  au_becs_debit?: Maybe<Stripe_MandateAuBecsDebit>;
+  bacs_debit?: Maybe<Stripe_MandateBacsDebit>;
+  card?: Maybe<Stripe_CardMandatePaymentMethodDetails>;
+  sepa_debit?: Maybe<Stripe_MandateSepaDebit>;
+  /** The type of the payment method associated with this mandate. An additional hash is included on `payment_method_details` with a name matching this value. It contains mandate information specific to the payment method. */
+  type?: Maybe<Scalars['String']>;
+};
+
+export type Stripe_MandateAcssDebit = {
+  __typename?: 'Stripe_MandateAcssDebit';
+  /** Description of the interval. Only required if 'payment_schedule' parmeter is 'interval' or 'combined'. */
+  interval_description?: Maybe<Scalars['String']>;
+  /** Payment schedule for the mandate. */
+  payment_schedule?: Maybe<Stripe_MandateAcssDebitPaymentScheduleProperty>;
+  /** Transaction type of the mandate. */
+  transaction_type?: Maybe<Stripe_MandateAcssDebitTransactionTypeProperty>;
+};
+
+export enum Stripe_MandateAcssDebitPaymentScheduleProperty {
+  Combined = 'combined',
+  Interval = 'interval',
+  Sporadic = 'sporadic'
+}
+
+export enum Stripe_MandateAcssDebitTransactionTypeProperty {
+  Business = 'business',
+  Personal = 'personal'
+}
+
+export type Stripe_MandateAuBecsDebit = {
+  __typename?: 'Stripe_MandateAuBecsDebit';
+  /** The URL of the mandate. This URL generally contains sensitive information about the customer and should be shared with them exclusively. */
+  url?: Maybe<Scalars['String']>;
+};
+
+export type Stripe_MandateBacsDebit = {
+  __typename?: 'Stripe_MandateBacsDebit';
+  /** The status of the mandate on the Bacs network. Can be one of `pending`, `revoked`, `refused`, or `accepted`. */
+  network_status?: Maybe<Stripe_MandateBacsDebitNetworkStatusProperty>;
+  /** The unique reference identifying the mandate on the Bacs network. */
+  reference?: Maybe<Scalars['String']>;
+  /** The URL that will contain the mandate that the customer has signed. */
+  url?: Maybe<Scalars['String']>;
+};
+
+export enum Stripe_MandateBacsDebitNetworkStatusProperty {
+  Accepted = 'accepted',
+  Pending = 'pending',
+  Refused = 'refused',
+  Revoked = 'revoked'
+}
+
+export type Stripe_CardMandatePaymentMethodDetails = {
+  __typename?: 'Stripe_CardMandatePaymentMethodDetails';
+  result?: Maybe<Scalars['JSONObject']>;
+};
+
+export type Stripe_MandateSepaDebit = {
+  __typename?: 'Stripe_MandateSepaDebit';
+  /** The unique reference of the mandate. */
+  reference?: Maybe<Scalars['String']>;
+  /** The URL of the mandate. This URL generally contains sensitive information about the customer and should be shared with them exclusively. */
+  url?: Maybe<Scalars['String']>;
+};
+
+export type Stripe_MandateSingleUse = {
+  __typename?: 'Stripe_MandateSingleUse';
+  /** On a single use mandate, the amount of the payment. */
+  amount?: Maybe<Scalars['Int']>;
+  /** On a single use mandate, the currency of the payment. */
+  currency?: Maybe<Scalars['String']>;
+};
+
+export enum Stripe_MandateStatusProperty {
+  Active = 'active',
+  Inactive = 'inactive',
+  Pending = 'pending'
+}
+
+export enum Stripe_MandateTypeProperty {
+  MultiUse = 'multi_use',
+  SingleUse = 'single_use'
+}
+
+export enum Stripe_SetupAttemptPaymentMethodDetailsBancontactPreferredLanguageProperty {
+  De = 'de',
+  En = 'en',
+  Fr = 'fr',
+  Nl = 'nl'
+}
+
+export type Stripe_SetupAttemptPaymentMethodDetailsCard = {
+  __typename?: 'Stripe_SetupAttemptPaymentMethodDetailsCard';
+  three_d_secure?: Maybe<Stripe_ThreeDSecureDetails>;
+};
+
+export type Stripe_ThreeDSecureDetails = {
+  __typename?: 'Stripe_ThreeDSecureDetails';
+  /**
+   * For authenticated transactions: how the customer was authenticated by
+   * the issuing bank.
+   */
+  authentication_flow?: Maybe<Stripe_ThreeDSecureDetailsAuthenticationFlowProperty>;
+  /** Indicates the outcome of 3D Secure authentication. */
+  result?: Maybe<Stripe_ThreeDSecureDetailsResultProperty>;
+  /**
+   * Additional information about why 3D Secure succeeded or failed based
+   * on the `result`.
+   */
+  result_reason?: Maybe<Stripe_ThreeDSecureDetailsResultReasonProperty>;
+  /** The version of 3D Secure that was used. */
+  version?: Maybe<Stripe_ThreeDSecureDetailsVersionProperty>;
+};
+
+export enum Stripe_ThreeDSecureDetailsAuthenticationFlowProperty {
+  Challenge = 'challenge',
+  Frictionless = 'frictionless'
+}
+
+export enum Stripe_ThreeDSecureDetailsResultProperty {
+  AttemptAcknowledged = 'attempt_acknowledged',
+  Authenticated = 'authenticated',
+  Failed = 'failed',
+  NotSupported = 'not_supported',
+  ProcessingError = 'processing_error'
+}
+
+export enum Stripe_ThreeDSecureDetailsResultReasonProperty {
+  Abandoned = 'abandoned',
+  Bypassed = 'bypassed',
+  Canceled = 'canceled',
+  CardNotEnrolled = 'card_not_enrolled',
+  NetworkNotSupported = 'network_not_supported',
+  ProtocolError = 'protocol_error',
+  Rejected = 'rejected'
+}
+
+export enum Stripe_ThreeDSecureDetailsVersionProperty {
+  Onedot0Dot2 = 'ONEDOT0DOT2',
+  Twodot1Dot0 = 'TWODOT1DOT0',
+  Twodot2Dot0 = 'TWODOT2DOT0'
+}
+
+export type Stripe_SetupAttemptPaymentMethodDetailsCardPresent = {
+  __typename?: 'Stripe_SetupAttemptPaymentMethodDetailsCardPresent';
+  generated_card?: Maybe<Stripe_SetupAttemptPaymentMethodDetailsCardPresentGeneratedCardProperty>;
+};
+
+export type Stripe_SetupAttemptPaymentMethodDetailsCardPresentGeneratedCardProperty = WrappedString | Stripe_PaymentMethod;
+
+export type Stripe_SetupAttemptPaymentMethodDetailsIdeal = {
+  __typename?: 'Stripe_SetupAttemptPaymentMethodDetailsIdeal';
+  /** The customer's bank. Can be one of `abn_amro`, `asn_bank`, `bunq`, `handelsbanken`, `ing`, `knab`, `moneyou`, `rabobank`, `regiobank`, `revolut`, `sns_bank`, `triodos_bank`, or `van_lanschot`. */
+  bank?: Maybe<Stripe_SetupAttemptPaymentMethodDetailsIdealBankProperty>;
+  /** The Bank Identifier Code of the customer's bank. */
+  bic?: Maybe<Stripe_SetupAttemptPaymentMethodDetailsIdealBicProperty>;
+  generated_sepa_debit?: Maybe<Stripe_SetupAttemptPaymentMethodDetailsIdealGeneratedSepaDebitProperty>;
+  generated_sepa_debit_mandate?: Maybe<Stripe_SetupAttemptPaymentMethodDetailsIdealGeneratedSepaDebitMandateProperty>;
+  /** Last four characters of the IBAN. */
+  iban_last4?: Maybe<Scalars['String']>;
+  /**
+   * Owner's verified full name. Values are verified or provided by iDEAL directly
+   * (if supported) at the time of authorization or settlement. They cannot be set or mutated.
+   */
+  verified_name?: Maybe<Scalars['String']>;
+};
+
+export enum Stripe_SetupAttemptPaymentMethodDetailsIdealBankProperty {
+  AbnAmro = 'abn_amro',
+  AsnBank = 'asn_bank',
+  Bunq = 'bunq',
+  Handelsbanken = 'handelsbanken',
+  Ing = 'ing',
+  Knab = 'knab',
+  Moneyou = 'moneyou',
+  Rabobank = 'rabobank',
+  Regiobank = 'regiobank',
+  Revolut = 'revolut',
+  SnsBank = 'sns_bank',
+  TriodosBank = 'triodos_bank',
+  VanLanschot = 'van_lanschot'
+}
+
+export enum Stripe_SetupAttemptPaymentMethodDetailsIdealBicProperty {
+  Abnanl2A = 'ABNANL2A',
+  Asnbnl21 = 'ASNBNL21',
+  Bunqnl2A = 'BUNQNL2A',
+  Fvlbnl22 = 'FVLBNL22',
+  Handnl2A = 'HANDNL2A',
+  Ingbnl2A = 'INGBNL2A',
+  Knabnl2H = 'KNABNL2H',
+  Moyonl21 = 'MOYONL21',
+  Rabonl2U = 'RABONL2U',
+  Rbrbnl21 = 'RBRBNL21',
+  Revolt21 = 'REVOLT21',
+  Snsbnl2A = 'SNSBNL2A',
+  Trionl2U = 'TRIONL2U'
+}
+
+export type Stripe_SetupAttemptPaymentMethodDetailsIdealGeneratedSepaDebitProperty = WrappedString | Stripe_PaymentMethod;
+
+export type Stripe_SetupAttemptPaymentMethodDetailsIdealGeneratedSepaDebitMandateProperty = WrappedString | Stripe_Mandate;
+
+export type Stripe_SetupAttemptPaymentMethodDetailsSepaDebit = {
+  __typename?: 'Stripe_SetupAttemptPaymentMethodDetailsSepaDebit';
+  result?: Maybe<Scalars['JSONObject']>;
+};
+
+export type Stripe_SetupAttemptPaymentMethodDetailsSofort = {
+  __typename?: 'Stripe_SetupAttemptPaymentMethodDetailsSofort';
+  /** Bank code of bank associated with the bank account. */
+  bank_code?: Maybe<Scalars['String']>;
+  /** Name of the bank associated with the bank account. */
+  bank_name?: Maybe<Scalars['String']>;
+  /** Bank Identifier Code of the bank associated with the bank account. */
+  bic?: Maybe<Scalars['String']>;
+  generated_sepa_debit?: Maybe<Stripe_SetupAttemptPaymentMethodDetailsSofortGeneratedSepaDebitProperty>;
+  generated_sepa_debit_mandate?: Maybe<Stripe_SetupAttemptPaymentMethodDetailsSofortGeneratedSepaDebitMandateProperty>;
+  /** Last four characters of the IBAN. */
+  iban_last4?: Maybe<Scalars['String']>;
+  /**
+   * Preferred language of the Sofort authorization page that the customer is redirected to.
+   * Can be one of `en`, `de`, `fr`, or `nl`
+   */
+  preferred_language?: Maybe<Stripe_SetupAttemptPaymentMethodDetailsSofortPreferredLanguageProperty>;
+  /**
+   * Owner's verified full name. Values are verified or provided by Sofort directly
+   * (if supported) at the time of authorization or settlement. They cannot be set or mutated.
+   */
+  verified_name?: Maybe<Scalars['String']>;
+};
+
+export type Stripe_SetupAttemptPaymentMethodDetailsSofortGeneratedSepaDebitProperty = WrappedString | Stripe_PaymentMethod;
+
+export type Stripe_SetupAttemptPaymentMethodDetailsSofortGeneratedSepaDebitMandateProperty = WrappedString | Stripe_Mandate;
+
+export enum Stripe_SetupAttemptPaymentMethodDetailsSofortPreferredLanguageProperty {
+  De = 'de',
+  En = 'en',
+  Fr = 'fr',
+  Nl = 'nl'
+}
+
+export type Stripe_ApiErrors = {
+  __typename?: 'Stripe_ApiErrors';
+  /** For card errors, the ID of the failed charge. */
+  charge?: Maybe<Scalars['String']>;
+  /** For some errors that could be handled programmatically, a short string indicating the [error code](https://stripe.com/docs/error-codes) reported. */
+  code?: Maybe<Scalars['String']>;
+  /** For card errors resulting from a card issuer decline, a short string indicating the [card issuer's reason for the decline](https://stripe.com/docs/declines#issuer-declines) if they provide one. */
+  decline_code?: Maybe<Scalars['String']>;
+  /** A URL to more information about the [error code](https://stripe.com/docs/error-codes) reported. */
+  doc_url?: Maybe<Scalars['String']>;
+  /** A human-readable message providing more details about the error. For card errors, these messages can be shown to your users. */
+  message?: Maybe<Scalars['String']>;
+  /** If the error is parameter-specific, the parameter related to the error. For example, you can use this to display a message near the correct form field. */
+  param?: Maybe<Scalars['String']>;
+  payment_intent?: Maybe<Stripe_PaymentIntent>;
+  payment_method?: Maybe<Stripe_PaymentMethod>;
+  /** If the error is specific to the type of payment method, the payment method type that had a problem. This field is only populated for invoice-related errors. */
+  payment_method_type?: Maybe<Scalars['String']>;
+  setup_intent?: Maybe<Stripe_SetupIntent>;
+  source?: Maybe<Stripe_ApiErrorsSourceProperty>;
+  /** The type of error returned. One of `api_error`, `card_error`, `idempotency_error`, or `invalid_request_error` */
+  type?: Maybe<Stripe_ApiErrorsTypeProperty>;
+};
+
+export type Stripe_PaymentIntent = {
+  __typename?: 'Stripe_PaymentIntent';
+  /** Amount intended to be collected by this PaymentIntent. A positive integer representing how much to charge in the [smallest currency unit](https://stripe.com/docs/currencies#zero-decimal) (e.g., 100 cents to charge $1.00 or 100 to charge ¥100, a zero-decimal currency). The minimum amount is $0.50 US or [equivalent in charge currency](https://stripe.com/docs/currencies#minimum-and-maximum-charge-amounts). The amount value supports up to eight digits (e.g., a value of 99999999 for a USD charge of $999,999.99). */
+  amount?: Maybe<Scalars['Int']>;
+  /** Amount that can be captured from this PaymentIntent. */
+  amount_capturable?: Maybe<Scalars['Int']>;
+  /** Amount that was collected by this PaymentIntent. */
+  amount_received?: Maybe<Scalars['Int']>;
+  application?: Maybe<Stripe_PaymentIntentApplicationProperty>;
+  /** The amount of the application fee (if any) that will be requested to be applied to the payment and transferred to the application owner's Stripe account. The amount of the application fee collected will be capped at the total payment amount. For more information, see the PaymentIntents [use case for connected accounts](https://stripe.com/docs/payments/connected-accounts). */
+  application_fee_amount?: Maybe<Scalars['Int']>;
+  /** Populated when `status` is `canceled`, this is the time at which the PaymentIntent was canceled. Measured in seconds since the Unix epoch. */
+  canceled_at?: Maybe<Scalars['Int']>;
+  /** Reason for cancellation of this PaymentIntent, either user-provided (`duplicate`, `fraudulent`, `requested_by_customer`, or `abandoned`) or generated by Stripe internally (`failed_invoice`, `void_invoice`, or `automatic`). */
+  cancellation_reason?: Maybe<Stripe_PaymentIntentCancellationReasonProperty>;
+  /** Controls when the funds will be captured from the customer's account. */
+  capture_method?: Maybe<Stripe_PaymentIntentCaptureMethodProperty>;
+  /** Charges that were created by this PaymentIntent, if any. */
+  charges?: Maybe<Stripe_PaymentIntentChargesProperty>;
+  /**
+   * The client secret of this PaymentIntent. Used for client-side retrieval using a publishable key.
+   *
+   * The client secret can be used to complete a payment from your frontend. It should not be stored, logged, embedded in URLs, or exposed to anyone other than the customer. Make sure that you have TLS enabled on any page that includes the client secret.
+   *
+   * Refer to our docs to [accept a payment](https://stripe.com/docs/payments/accept-a-payment?integration=elements) and learn about how `client_secret` should be handled.
+   */
+  client_secret?: Maybe<Scalars['String']>;
+  confirmation_method?: Maybe<Stripe_PaymentIntentConfirmationMethodProperty>;
+  /** Time at which the object was created. Measured in seconds since the Unix epoch. */
+  created?: Maybe<Scalars['Int']>;
+  /** Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies). */
+  currency?: Maybe<Scalars['String']>;
+  customer?: Maybe<Stripe_PaymentIntentCustomerProperty>;
+  /** An arbitrary string attached to the object. Often useful for displaying to users. */
+  description?: Maybe<Scalars['String']>;
+  /** Unique identifier for the object. */
+  id?: Maybe<Scalars['String']>;
+  invoice?: Maybe<Stripe_PaymentIntentInvoiceProperty>;
+  last_payment_error?: Maybe<Stripe_ApiErrors>;
+  /** Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode. */
+  livemode?: Maybe<Scalars['Boolean']>;
+  /** Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. For more information, see the [documentation](https://stripe.com/docs/payments/payment-intents/creating-payment-intents#storing-information-in-metadata). */
+  metadata?: Maybe<Scalars['JSONObject']>;
+  next_action?: Maybe<Stripe_PaymentIntentNextAction>;
+  /** String representing the object's type. Objects of the same type share the same value. */
+  object?: Maybe<Stripe_PaymentIntentObjectProperty>;
+  on_behalf_of?: Maybe<Stripe_PaymentIntentOnBehalfOfProperty>;
+  payment_method?: Maybe<Stripe_PaymentIntentPaymentMethodProperty>;
+  payment_method_options?: Maybe<Stripe_PaymentIntentPaymentMethodOptions>;
+  /** The list of payment method types (e.g. card) that this PaymentIntent is allowed to use. */
+  payment_method_types?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Email address that the receipt for the resulting payment will be sent to. If `receipt_email` is specified for a payment in live mode, a receipt will be sent regardless of your [email settings](https://dashboard.stripe.com/account/emails). */
+  receipt_email?: Maybe<Scalars['String']>;
+  review?: Maybe<Stripe_PaymentIntentReviewProperty>;
+  /**
+   * Indicates that you intend to make future payments with this PaymentIntent's payment method.
+   *
+   * Providing this parameter will [attach the payment method](https://stripe.com/docs/payments/save-during-payment) to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any required actions from the user are complete. If no Customer was provided, the payment method can still be [attached](https://stripe.com/docs/api/payment_methods/attach) to a Customer after the transaction completes.
+   *
+   * When processing card payments, Stripe also uses `setup_future_usage` to dynamically optimize your payment flow and comply with regional legislation and network rules, such as [SCA](https://stripe.com/docs/strong-customer-authentication).
+   */
+  setup_future_usage?: Maybe<Stripe_PaymentIntentSetupFutureUsageProperty>;
+  shipping?: Maybe<Stripe_Shipping>;
+  /** For non-card charges, you can use this value as the complete description that appears on your customers’ statements. Must contain at least one letter, maximum 22 characters. */
+  statement_descriptor?: Maybe<Scalars['String']>;
+  /** Provides information about a card payment that customers see on their statements. Concatenated with the prefix (shortened descriptor) or statement descriptor that’s set on the account to form the complete statement descriptor. Maximum 22 characters for the concatenated descriptor. */
+  statement_descriptor_suffix?: Maybe<Scalars['String']>;
+  /** Status of this PaymentIntent, one of `requires_payment_method`, `requires_confirmation`, `requires_action`, `processing`, `requires_capture`, `canceled`, or `succeeded`. Read more about each PaymentIntent [status](https://stripe.com/docs/payments/intents#intent-statuses). */
+  status?: Maybe<Stripe_PaymentIntentStatusProperty>;
+  transfer_data?: Maybe<Stripe_TransferData>;
+  /** A string that identifies the resulting payment as part of a group. See the PaymentIntents [use case for connected accounts](https://stripe.com/docs/payments/connected-accounts) for details. */
+  transfer_group?: Maybe<Scalars['String']>;
+};
+
+export type Stripe_PaymentIntentApplicationProperty = WrappedString | Stripe_Application;
+
+export enum Stripe_PaymentIntentCancellationReasonProperty {
+  Abandoned = 'abandoned',
+  Automatic = 'automatic',
+  Duplicate = 'duplicate',
+  FailedInvoice = 'failed_invoice',
+  Fraudulent = 'fraudulent',
+  RequestedByCustomer = 'requested_by_customer',
+  VoidInvoice = 'void_invoice'
+}
+
+export enum Stripe_PaymentIntentCaptureMethodProperty {
+  Automatic = 'automatic',
+  Manual = 'manual'
+}
+
+/** Charges that were created by this PaymentIntent, if any. */
+export type Stripe_PaymentIntentChargesProperty = {
+  __typename?: 'Stripe_PaymentIntentChargesProperty';
+  /** This list only contains the latest charge, even if there were previously multiple unsuccessful charges. To view all previous charges for a PaymentIntent, you can filter the charges list using the `payment_intent` [parameter](https://stripe.com/docs/api/charges/list#list_charges-payment_intent). */
+  data: Array<Stripe_Charge>;
+  /** True if this list has another page of items after this one that can be fetched. */
+  has_more: Scalars['Boolean'];
+  /** String representing the object's type. Objects of the same type share the same value. Always has the value `list`. */
+  object: Stripe_PaymentIntentChargesObjectProperty;
+  /** The URL where this list can be accessed. */
+  url: Scalars['String'];
+};
+
+export type Stripe_Charge = {
+  __typename?: 'Stripe_Charge';
+  /** Amount intended to be collected by this payment. A positive integer representing how much to charge in the [smallest currency unit](https://stripe.com/docs/currencies#zero-decimal) (e.g., 100 cents to charge $1.00 or 100 to charge ¥100, a zero-decimal currency). The minimum amount is $0.50 US or [equivalent in charge currency](https://stripe.com/docs/currencies#minimum-and-maximum-charge-amounts). The amount value supports up to eight digits (e.g., a value of 99999999 for a USD charge of $999,999.99). */
+  amount?: Maybe<Scalars['Int']>;
+  /** Amount in %s captured (can be less than the amount attribute on the charge if a partial capture was made). */
+  amount_captured?: Maybe<Scalars['Int']>;
+  /** Amount in %s refunded (can be less than the amount attribute on the charge if a partial refund was issued). */
+  amount_refunded?: Maybe<Scalars['Int']>;
+  application?: Maybe<Stripe_ChargeApplicationProperty>;
+  application_fee?: Maybe<Stripe_ChargeApplicationFeeProperty>;
+  /** The amount of the application fee (if any) requested for the charge. [See the Connect documentation](https://stripe.com/docs/connect/direct-charges#collecting-fees) for details. */
+  application_fee_amount?: Maybe<Scalars['Int']>;
+  balance_transaction?: Maybe<Stripe_ChargeBalanceTransactionProperty>;
+  billing_details?: Maybe<Stripe_BillingDetails>;
+  /** The full statement descriptor that is passed to card networks, and that is displayed on your customers' credit card and bank statements. Allows you to see what the statement descriptor looks like after the static and dynamic portions are combined. */
+  calculated_statement_descriptor?: Maybe<Scalars['String']>;
+  /** If the charge was created without capturing, this Boolean represents whether it is still uncaptured or has since been captured. */
+  captured?: Maybe<Scalars['Boolean']>;
+  /** Time at which the object was created. Measured in seconds since the Unix epoch. */
+  created?: Maybe<Scalars['Int']>;
+  /** Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies). */
+  currency?: Maybe<Scalars['String']>;
+  customer?: Maybe<Stripe_ChargeCustomerProperty>;
+  /** An arbitrary string attached to the object. Often useful for displaying to users. */
+  description?: Maybe<Scalars['String']>;
+  /** Whether the charge has been disputed. */
+  disputed?: Maybe<Scalars['Boolean']>;
+  /** Error code explaining reason for charge failure if available (see [the errors section](https://stripe.com/docs/api#errors) for a list of codes). */
+  failure_code?: Maybe<Scalars['String']>;
+  /** Message to user further explaining reason for charge failure if available. */
+  failure_message?: Maybe<Scalars['String']>;
+  fraud_details?: Maybe<Stripe_ChargeFraudDetails>;
+  /** Unique identifier for the object. */
+  id?: Maybe<Scalars['String']>;
+  invoice?: Maybe<Stripe_ChargeInvoiceProperty>;
+  /** Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode. */
+  livemode?: Maybe<Scalars['Boolean']>;
+  /** Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. */
+  metadata?: Maybe<Scalars['JSONObject']>;
+  /** String representing the object's type. Objects of the same type share the same value. */
+  object?: Maybe<Stripe_ChargeObjectProperty>;
+  on_behalf_of?: Maybe<Stripe_ChargeOnBehalfOfProperty>;
+  order?: Maybe<Stripe_ChargeOrderProperty>;
+  outcome?: Maybe<Stripe_ChargeOutcome>;
+  /** `true` if the charge succeeded, or was successfully authorized for later capture. */
+  paid?: Maybe<Scalars['Boolean']>;
+  payment_intent?: Maybe<Stripe_ChargePaymentIntentProperty>;
+  /** ID of the payment method used in this charge. */
+  payment_method?: Maybe<Scalars['String']>;
+  payment_method_details?: Maybe<Stripe_PaymentMethodDetails>;
+  /** This is the email address that the receipt for this charge was sent to. */
+  receipt_email?: Maybe<Scalars['String']>;
+  /** This is the transaction number that appears on email receipts sent for this charge. This attribute will be `null` until a receipt has been sent. */
+  receipt_number?: Maybe<Scalars['String']>;
+  /** This is the URL to view the receipt for this charge. The receipt is kept up-to-date to the latest state of the charge, including any refunds. If the charge is for an Invoice, the receipt will be stylized as an Invoice receipt. */
+  receipt_url?: Maybe<Scalars['String']>;
+  /** Whether the charge has been fully refunded. If the charge is only partially refunded, this attribute will still be false. */
+  refunded?: Maybe<Scalars['Boolean']>;
+  /** A list of refunds that have been applied to the charge. */
+  refunds?: Maybe<Stripe_ChargeRefundsProperty>;
+  review?: Maybe<Stripe_ChargeReviewProperty>;
+  shipping?: Maybe<Stripe_Shipping>;
+  source_transfer?: Maybe<Stripe_ChargeSourceTransferProperty>;
+  /** For card charges, use `statement_descriptor_suffix` instead. Otherwise, you can use this value as the complete description of a charge on your customers’ statements. Must contain at least one letter, maximum 22 characters. */
+  statement_descriptor?: Maybe<Scalars['String']>;
+  /** Provides information about the charge that customers see on their statements. Concatenated with the prefix (shortened descriptor) or statement descriptor that’s set on the account to form the complete statement descriptor. Maximum 22 characters for the concatenated descriptor. */
+  statement_descriptor_suffix?: Maybe<Scalars['String']>;
+  /** The status of the payment is either `succeeded`, `pending`, or `failed`. */
+  status?: Maybe<Scalars['String']>;
+  transfer?: Maybe<Stripe_ChargeTransferProperty>;
+  transfer_data?: Maybe<Stripe_ChargeTransferData>;
+  /** A string that identifies this transaction as part of a group. See the [Connect documentation](https://stripe.com/docs/connect/charges-transfers#transfer-options) for details. */
+  transfer_group?: Maybe<Scalars['String']>;
+};
+
+export type Stripe_ChargeApplicationProperty = WrappedString | Stripe_Application;
+
+export type Stripe_ChargeApplicationFeeProperty = WrappedString | Stripe_ApplicationFee;
+
+export type Stripe_ApplicationFee = {
+  __typename?: 'Stripe_ApplicationFee';
+  account?: Maybe<Stripe_ApplicationFeeAccountProperty>;
+  /** Amount earned, in %s. */
+  amount?: Maybe<Scalars['Int']>;
+  /** Amount in %s refunded (can be less than the amount attribute on the fee if a partial refund was issued) */
+  amount_refunded?: Maybe<Scalars['Int']>;
+  application?: Maybe<Stripe_ApplicationFeeApplicationProperty>;
+  balance_transaction?: Maybe<Stripe_ApplicationFeeBalanceTransactionProperty>;
+  charge?: Maybe<Stripe_ApplicationFeeChargeProperty>;
+  /** Time at which the object was created. Measured in seconds since the Unix epoch. */
+  created?: Maybe<Scalars['Int']>;
+  /** Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies). */
+  currency?: Maybe<Scalars['String']>;
+  /** Unique identifier for the object. */
+  id?: Maybe<Scalars['String']>;
+  /** Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode. */
+  livemode?: Maybe<Scalars['Boolean']>;
+  /** String representing the object's type. Objects of the same type share the same value. */
+  object?: Maybe<Stripe_ApplicationFeeObjectProperty>;
+  originating_transaction?: Maybe<Stripe_ApplicationFeeOriginatingTransactionProperty>;
+  /** Whether the fee has been fully refunded. If the fee is only partially refunded, this attribute will still be false. */
+  refunded?: Maybe<Scalars['Boolean']>;
+  /** A list of refunds that have been applied to the fee. */
+  refunds?: Maybe<Stripe_ApplicationFeeRefundsProperty>;
+};
+
+export type Stripe_ApplicationFeeAccountProperty = WrappedString | Stripe_Account;
+
+export type Stripe_ApplicationFeeApplicationProperty = WrappedString | Stripe_Application;
+
+export type Stripe_ApplicationFeeBalanceTransactionProperty = WrappedString | Stripe_BalanceTransaction;
+
+export type Stripe_BalanceTransaction = {
+  __typename?: 'Stripe_BalanceTransaction';
+  /** Gross amount of the transaction, in %s. */
+  amount?: Maybe<Scalars['Int']>;
+  /** The date the transaction's net funds will become available in the Stripe balance. */
+  available_on?: Maybe<Scalars['Int']>;
+  /** Time at which the object was created. Measured in seconds since the Unix epoch. */
+  created?: Maybe<Scalars['Int']>;
+  /** Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies). */
+  currency?: Maybe<Scalars['String']>;
+  /** An arbitrary string attached to the object. Often useful for displaying to users. */
+  description?: Maybe<Scalars['String']>;
+  /** The exchange rate used, if applicable, for this transaction. Specifically, if money was converted from currency A to currency B, then the `amount` in currency A, times `exchange_rate`, would be the `amount` in currency B. For example, suppose you charged a customer 10.00 EUR. Then the PaymentIntent's `amount` would be `1000` and `currency` would be `eur`. Suppose this was converted into 12.34 USD in your Stripe account. Then the BalanceTransaction's `amount` would be `1234`, `currency` would be `usd`, and `exchange_rate` would be `1.234`. */
+  exchange_rate?: Maybe<Scalars['Float']>;
+  /** Fees (in %s) paid for this transaction. */
+  fee?: Maybe<Scalars['Int']>;
+  /** Detailed breakdown of fees (in %s) paid for this transaction. */
+  fee_details?: Maybe<Array<Maybe<Stripe_Fee>>>;
+  /** Unique identifier for the object. */
+  id?: Maybe<Scalars['String']>;
+  /** Net amount of the transaction, in %s. */
+  net?: Maybe<Scalars['Int']>;
+  /** String representing the object's type. Objects of the same type share the same value. */
+  object?: Maybe<Stripe_BalanceTransactionObjectProperty>;
+  /** [Learn more](https://stripe.com/docs/reports/reporting-categories) about how reporting categories can help you understand balance transactions from an accounting perspective. */
+  reporting_category?: Maybe<Scalars['String']>;
+  source?: Maybe<Stripe_BalanceTransactionSourceProperty>;
+  /** If the transaction's net funds are available in the Stripe balance yet. Either `available` or `pending`. */
+  status?: Maybe<Scalars['String']>;
+  /** Transaction type: `adjustment`, `advance`, `advance_funding`, `anticipation_repayment`, `application_fee`, `application_fee_refund`, `charge`, `connect_collection_transfer`, `contribution`, `issuing_authorization_hold`, `issuing_authorization_release`, `issuing_dispute`, `issuing_transaction`, `payment`, `payment_failure_refund`, `payment_refund`, `payout`, `payout_cancel`, `payout_failure`, `refund`, `refund_failure`, `reserve_transaction`, `reserved_funds`, `stripe_fee`, `stripe_fx_fee`, `tax_fee`, `topup`, `topup_reversal`, `transfer`, `transfer_cancel`, `transfer_failure`, or `transfer_refund`. [Learn more](https://stripe.com/docs/reports/balance-transaction-types) about balance transaction types and what they represent. If you are looking to classify transactions for accounting purposes, you might want to consider `reporting_category` instead. */
+  type?: Maybe<Stripe_BalanceTransactionTypeProperty>;
+};
+
+export type Stripe_Fee = {
+  __typename?: 'Stripe_Fee';
+  /** Amount of the fee, in cents. */
+  amount?: Maybe<Scalars['Int']>;
+  /** ID of the Connect application that earned the fee. */
+  application?: Maybe<Scalars['String']>;
+  /** Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies). */
+  currency?: Maybe<Scalars['String']>;
+  /** An arbitrary string attached to the object. Often useful for displaying to users. */
+  description?: Maybe<Scalars['String']>;
+  /** Type of the fee, one of: `application_fee`, `stripe_fee` or `tax`. */
+  type?: Maybe<Scalars['String']>;
+};
+
+export enum Stripe_BalanceTransactionObjectProperty {
+  BalanceTransaction = 'balance_transaction'
+}
+
+export type Stripe_BalanceTransactionSourceProperty = WrappedString | Stripe_ApplicationFee | Stripe_Charge | Stripe_ConnectCollectionTransfer | Stripe_Dispute | Stripe_FeeRefund | Stripe_IssuingAuthorization | Stripe_IssuingDispute | Stripe_IssuingTransaction | Stripe_Payout | Stripe_PlatformTaxFee | Stripe_Refund | Stripe_ReserveTransaction | Stripe_TaxDeductedAtSource | Stripe_Topup | Stripe_Transfer | Stripe_TransferReversal;
+
+export type Stripe_ConnectCollectionTransfer = {
+  __typename?: 'Stripe_ConnectCollectionTransfer';
+  /** Amount transferred, in %s. */
+  amount?: Maybe<Scalars['Int']>;
+  /** Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies). */
+  currency?: Maybe<Scalars['String']>;
+  destination?: Maybe<Stripe_ConnectCollectionTransferDestinationProperty>;
+  /** Unique identifier for the object. */
+  id?: Maybe<Scalars['String']>;
+  /** Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode. */
+  livemode?: Maybe<Scalars['Boolean']>;
+  /** String representing the object's type. Objects of the same type share the same value. */
+  object?: Maybe<Stripe_ConnectCollectionTransferObjectProperty>;
+};
+
+export type Stripe_ConnectCollectionTransferDestinationProperty = WrappedString | Stripe_Account;
+
+export enum Stripe_ConnectCollectionTransferObjectProperty {
+  ConnectCollectionTransfer = 'connect_collection_transfer'
+}
+
+export type Stripe_Dispute = {
+  __typename?: 'Stripe_Dispute';
+  /** Disputed amount. Usually the amount of the charge, but can differ (usually because of currency fluctuation or because only part of the order is disputed). */
+  amount?: Maybe<Scalars['Int']>;
+  /** List of zero, one, or two balance transactions that show funds withdrawn and reinstated to your Stripe account as a result of this dispute. */
+  balance_transactions?: Maybe<Array<Maybe<Stripe_BalanceTransaction>>>;
+  charge?: Maybe<Stripe_DisputeChargeProperty>;
+  /** Time at which the object was created. Measured in seconds since the Unix epoch. */
+  created?: Maybe<Scalars['Int']>;
+  /** Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies). */
+  currency?: Maybe<Scalars['String']>;
+  evidence?: Maybe<Stripe_DisputeEvidence>;
+  evidence_details?: Maybe<Stripe_DisputeEvidenceDetails>;
+  /** Unique identifier for the object. */
+  id?: Maybe<Scalars['String']>;
+  /** If true, it is still possible to refund the disputed payment. Once the payment has been fully refunded, no further funds will be withdrawn from your Stripe account as a result of this dispute. */
+  is_charge_refundable?: Maybe<Scalars['Boolean']>;
+  /** Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode. */
+  livemode?: Maybe<Scalars['Boolean']>;
+  /** Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. */
+  metadata?: Maybe<Scalars['JSONObject']>;
+  /** String representing the object's type. Objects of the same type share the same value. */
+  object?: Maybe<Stripe_DisputeObjectProperty>;
+  payment_intent?: Maybe<Stripe_DisputePaymentIntentProperty>;
+  /** Reason given by cardholder for dispute. Possible values are `bank_cannot_process`, `check_returned`, `credit_not_processed`, `customer_initiated`, `debit_not_authorized`, `duplicate`, `fraudulent`, `general`, `incorrect_account_details`, `insufficient_funds`, `product_not_received`, `product_unacceptable`, `subscription_canceled`, or `unrecognized`. Read more about [dispute reasons](https://stripe.com/docs/disputes/categories). */
+  reason?: Maybe<Scalars['String']>;
+  /** Current status of dispute. Possible values are `warning_needs_response`, `warning_under_review`, `warning_closed`, `needs_response`, `under_review`, `charge_refunded`, `won`, or `lost`. */
+  status?: Maybe<Stripe_DisputeStatusProperty>;
+};
+
+export type Stripe_DisputeChargeProperty = WrappedString | Stripe_Charge;
+
+export type Stripe_DisputeEvidence = {
+  __typename?: 'Stripe_DisputeEvidence';
+  /** Any server or activity logs showing proof that the customer accessed or downloaded the purchased digital product. This information should include IP addresses, corresponding timestamps, and any detailed recorded activity. */
+  access_activity_log?: Maybe<Scalars['String']>;
+  /** The billing address provided by the customer. */
+  billing_address?: Maybe<Scalars['String']>;
+  cancellation_policy?: Maybe<Stripe_DisputeEvidenceCancellationPolicyProperty>;
+  /** An explanation of how and when the customer was shown your refund policy prior to purchase. */
+  cancellation_policy_disclosure?: Maybe<Scalars['String']>;
+  /** A justification for why the customer's subscription was not canceled. */
+  cancellation_rebuttal?: Maybe<Scalars['String']>;
+  customer_communication?: Maybe<Stripe_DisputeEvidenceCustomerCommunicationProperty>;
+  /** The email address of the customer. */
+  customer_email_address?: Maybe<Scalars['String']>;
+  /** The name of the customer. */
+  customer_name?: Maybe<Scalars['String']>;
+  /** The IP address that the customer used when making the purchase. */
+  customer_purchase_ip?: Maybe<Scalars['String']>;
+  customer_signature?: Maybe<Stripe_DisputeEvidenceCustomerSignatureProperty>;
+  duplicate_charge_documentation?: Maybe<Stripe_DisputeEvidenceDuplicateChargeDocumentationProperty>;
+  /** An explanation of the difference between the disputed charge versus the prior charge that appears to be a duplicate. */
+  duplicate_charge_explanation?: Maybe<Scalars['String']>;
+  /** The Stripe ID for the prior charge which appears to be a duplicate of the disputed charge. */
+  duplicate_charge_id?: Maybe<Scalars['String']>;
+  /** A description of the product or service that was sold. */
+  product_description?: Maybe<Scalars['String']>;
+  receipt?: Maybe<Stripe_DisputeEvidenceReceiptProperty>;
+  refund_policy?: Maybe<Stripe_DisputeEvidenceRefundPolicyProperty>;
+  /** Documentation demonstrating that the customer was shown your refund policy prior to purchase. */
+  refund_policy_disclosure?: Maybe<Scalars['String']>;
+  /** A justification for why the customer is not entitled to a refund. */
+  refund_refusal_explanation?: Maybe<Scalars['String']>;
+  /** The date on which the customer received or began receiving the purchased service, in a clear human-readable format. */
+  service_date?: Maybe<Scalars['String']>;
+  service_documentation?: Maybe<Stripe_DisputeEvidenceServiceDocumentationProperty>;
+  /** The address to which a physical product was shipped. You should try to include as complete address information as possible. */
+  shipping_address?: Maybe<Scalars['String']>;
+  /** The delivery service that shipped a physical product, such as Fedex, UPS, USPS, etc. If multiple carriers were used for this purchase, please separate them with commas. */
+  shipping_carrier?: Maybe<Scalars['String']>;
+  /** The date on which a physical product began its route to the shipping address, in a clear human-readable format. */
+  shipping_date?: Maybe<Scalars['String']>;
+  shipping_documentation?: Maybe<Stripe_DisputeEvidenceShippingDocumentationProperty>;
+  /** The tracking number for a physical product, obtained from the delivery service. If multiple tracking numbers were generated for this purchase, please separate them with commas. */
+  shipping_tracking_number?: Maybe<Scalars['String']>;
+  uncategorized_file?: Maybe<Stripe_DisputeEvidenceUncategorizedFileProperty>;
+  /** Any additional evidence or statements. */
+  uncategorized_text?: Maybe<Scalars['String']>;
+};
+
+export type Stripe_DisputeEvidenceCancellationPolicyProperty = WrappedString | Stripe_File;
+
+export type Stripe_DisputeEvidenceCustomerCommunicationProperty = WrappedString | Stripe_File;
+
+export type Stripe_DisputeEvidenceCustomerSignatureProperty = WrappedString | Stripe_File;
+
+export type Stripe_DisputeEvidenceDuplicateChargeDocumentationProperty = WrappedString | Stripe_File;
+
+export type Stripe_DisputeEvidenceReceiptProperty = WrappedString | Stripe_File;
+
+export type Stripe_DisputeEvidenceRefundPolicyProperty = WrappedString | Stripe_File;
+
+export type Stripe_DisputeEvidenceServiceDocumentationProperty = WrappedString | Stripe_File;
+
+export type Stripe_DisputeEvidenceShippingDocumentationProperty = WrappedString | Stripe_File;
+
+export type Stripe_DisputeEvidenceUncategorizedFileProperty = WrappedString | Stripe_File;
+
+export type Stripe_DisputeEvidenceDetails = {
+  __typename?: 'Stripe_DisputeEvidenceDetails';
+  /** Date by which evidence must be submitted in order to successfully challenge dispute. Will be null if the customer's bank or credit card company doesn't allow a response for this particular dispute. */
+  due_by?: Maybe<Scalars['Int']>;
+  /** Whether evidence has been staged for this dispute. */
+  has_evidence?: Maybe<Scalars['Boolean']>;
+  /** Whether the last evidence submission was submitted past the due date. Defaults to `false` if no evidence submissions have occurred. If `true`, then delivery of the latest evidence is *not* guaranteed. */
+  past_due?: Maybe<Scalars['Boolean']>;
+  /** The number of times evidence has been submitted. Typically, you may only submit evidence once. */
+  submission_count?: Maybe<Scalars['Int']>;
+};
+
+export enum Stripe_DisputeObjectProperty {
+  Dispute = 'dispute'
+}
+
+export type Stripe_DisputePaymentIntentProperty = WrappedString | Stripe_PaymentIntent;
+
+export enum Stripe_DisputeStatusProperty {
+  ChargeRefunded = 'charge_refunded',
+  Lost = 'lost',
+  NeedsResponse = 'needs_response',
+  UnderReview = 'under_review',
+  WarningClosed = 'warning_closed',
+  WarningNeedsResponse = 'warning_needs_response',
+  WarningUnderReview = 'warning_under_review',
+  Won = 'won'
+}
+
+export type Stripe_FeeRefund = {
+  __typename?: 'Stripe_FeeRefund';
+  /** Amount, in %s. */
+  amount?: Maybe<Scalars['Int']>;
+  balance_transaction?: Maybe<Stripe_FeeRefundBalanceTransactionProperty>;
+  /** Time at which the object was created. Measured in seconds since the Unix epoch. */
+  created?: Maybe<Scalars['Int']>;
+  /** Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies). */
+  currency?: Maybe<Scalars['String']>;
+  fee?: Maybe<Stripe_FeeRefundFeeProperty>;
+  /** Unique identifier for the object. */
+  id?: Maybe<Scalars['String']>;
+  /** Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. */
+  metadata?: Maybe<Scalars['JSONObject']>;
+  /** String representing the object's type. Objects of the same type share the same value. */
+  object?: Maybe<Stripe_FeeRefundObjectProperty>;
+};
+
+export type Stripe_FeeRefundBalanceTransactionProperty = WrappedString | Stripe_BalanceTransaction;
+
+export type Stripe_FeeRefundFeeProperty = WrappedString | Stripe_ApplicationFee;
+
+export enum Stripe_FeeRefundObjectProperty {
+  FeeRefund = 'fee_refund'
+}
+
+export type Stripe_IssuingAuthorization = {
+  __typename?: 'Stripe_IssuingAuthorization';
+  /** The total amount that was authorized or rejected. This amount is in the card's currency and in the [smallest currency unit](https://stripe.com/docs/currencies#zero-decimal). */
+  amount?: Maybe<Scalars['Int']>;
+  amount_details?: Maybe<Stripe_IssuingAuthorizationAmountDetails>;
+  /** Whether the authorization has been approved. */
+  approved?: Maybe<Scalars['Boolean']>;
+  /** How the card details were provided. */
+  authorization_method?: Maybe<Stripe_IssuingAuthorizationAuthorizationMethodProperty>;
+  /** List of balance transactions associated with this authorization. */
+  balance_transactions?: Maybe<Array<Maybe<Stripe_BalanceTransaction>>>;
+  card?: Maybe<Stripe_IssuingCard>;
+  cardholder?: Maybe<Stripe_IssuingAuthorizationCardholderProperty>;
+  /** Time at which the object was created. Measured in seconds since the Unix epoch. */
+  created?: Maybe<Scalars['Int']>;
+  /** Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies). */
+  currency?: Maybe<Scalars['String']>;
+  /** Unique identifier for the object. */
+  id?: Maybe<Scalars['String']>;
+  /** Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode. */
+  livemode?: Maybe<Scalars['Boolean']>;
+  /** The total amount that was authorized or rejected. This amount is in the `merchant_currency` and in the [smallest currency unit](https://stripe.com/docs/currencies#zero-decimal). */
+  merchant_amount?: Maybe<Scalars['Int']>;
+  /** The currency that was presented to the cardholder for the authorization. Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies). */
+  merchant_currency?: Maybe<Scalars['String']>;
+  merchant_data?: Maybe<Stripe_IssuingAuthorizationMerchantData>;
+  /** Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. */
+  metadata?: Maybe<Scalars['JSONObject']>;
+  /** String representing the object's type. Objects of the same type share the same value. */
+  object?: Maybe<Stripe_IssuingAuthorizationObjectProperty>;
+  pending_request?: Maybe<Stripe_IssuingAuthorizationPendingRequest>;
+  /** History of every time `pending_request` was approved/denied, either by you directly or by Stripe (e.g. based on your `spending_controls`). If the merchant changes the authorization by performing an [incremental authorization](https://stripe.com/docs/issuing/purchases/authorizations), you can look at this field to see the previous requests for the authorization. */
+  request_history?: Maybe<Array<Maybe<Stripe_IssuingAuthorizationRequest>>>;
+  /** The current status of the authorization in its lifecycle. */
+  status?: Maybe<Stripe_IssuingAuthorizationStatusProperty>;
+  /** List of [transactions](https://stripe.com/docs/api/issuing/transactions) associated with this authorization. */
+  transactions?: Maybe<Array<Maybe<Stripe_IssuingTransaction>>>;
+  verification_data?: Maybe<Stripe_IssuingAuthorizationVerificationData>;
+  /** The digital wallet used for this authorization. One of `apple_pay`, `google_pay`, or `samsung_pay`. */
+  wallet?: Maybe<Scalars['String']>;
+};
+
+export type Stripe_IssuingAuthorizationAmountDetails = {
+  __typename?: 'Stripe_IssuingAuthorizationAmountDetails';
+  /** The fee charged by the ATM for the cash withdrawal. */
+  atm_fee?: Maybe<Scalars['Int']>;
+};
+
+export enum Stripe_IssuingAuthorizationAuthorizationMethodProperty {
+  Chip = 'chip',
+  Contactless = 'contactless',
+  KeyedIn = 'keyed_in',
+  Online = 'online',
+  Swipe = 'swipe'
+}
+
+export type Stripe_IssuingCard = {
+  __typename?: 'Stripe_IssuingCard';
+  /** The brand of the card. */
+  brand?: Maybe<Scalars['String']>;
+  /** The reason why the card was canceled. */
+  cancellation_reason?: Maybe<Stripe_IssuingCardCancellationReasonProperty>;
+  cardholder?: Maybe<Stripe_IssuingCardholder>;
+  /** Time at which the object was created. Measured in seconds since the Unix epoch. */
+  created?: Maybe<Scalars['Int']>;
+  /** Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies). */
+  currency?: Maybe<Scalars['String']>;
+  /** The card's CVC. For security reasons, this is only available for virtual cards, and will be omitted unless you explicitly request it with [the `expand` parameter](https://stripe.com/docs/api/expanding_objects). Additionally, it's only available via the ["Retrieve a card" endpoint](https://stripe.com/docs/api/issuing/cards/retrieve), not via "List all cards" or any other endpoint. */
+  cvc?: Maybe<Scalars['String']>;
+  /** The expiration month of the card. */
+  exp_month?: Maybe<Scalars['Int']>;
+  /** The expiration year of the card. */
+  exp_year?: Maybe<Scalars['Int']>;
+  /** Unique identifier for the object. */
+  id?: Maybe<Scalars['String']>;
+  /** The last 4 digits of the card number. */
+  last4?: Maybe<Scalars['String']>;
+  /** Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode. */
+  livemode?: Maybe<Scalars['Boolean']>;
+  /** Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. */
+  metadata?: Maybe<Scalars['JSONObject']>;
+  /** The full unredacted card number. For security reasons, this is only available for virtual cards, and will be omitted unless you explicitly request it with [the `expand` parameter](https://stripe.com/docs/api/expanding_objects). Additionally, it's only available via the ["Retrieve a card" endpoint](https://stripe.com/docs/api/issuing/cards/retrieve), not via "List all cards" or any other endpoint. */
+  number?: Maybe<Scalars['String']>;
+  /** String representing the object's type. Objects of the same type share the same value. */
+  object?: Maybe<Stripe_IssuingCardObjectProperty>;
+  replaced_by?: Maybe<Stripe_IssuingCardReplacedByProperty>;
+  replacement_for?: Maybe<Stripe_IssuingCardReplacementForProperty>;
+  /** The reason why the previous card needed to be replaced. */
+  replacement_reason?: Maybe<Stripe_IssuingCardReplacementReasonProperty>;
+  shipping?: Maybe<Stripe_IssuingCardShipping>;
+  spending_controls?: Maybe<Stripe_IssuingCardAuthorizationControls>;
+  /** Whether authorizations can be approved on this card. */
+  status?: Maybe<Stripe_IssuingCardStatusProperty>;
+  /** The type of the card. */
+  type?: Maybe<Stripe_IssuingCardTypeProperty>;
+};
+
+export enum Stripe_IssuingCardCancellationReasonProperty {
+  Lost = 'lost',
+  Stolen = 'stolen'
+}
+
+export type Stripe_IssuingCardholder = {
+  __typename?: 'Stripe_IssuingCardholder';
+  billing?: Maybe<Stripe_IssuingCardholderAddress>;
+  company?: Maybe<Stripe_IssuingCardholderCompany>;
+  /** Time at which the object was created. Measured in seconds since the Unix epoch. */
+  created?: Maybe<Scalars['Int']>;
+  /** The cardholder's email address. */
+  email?: Maybe<Scalars['String']>;
+  /** Unique identifier for the object. */
+  id?: Maybe<Scalars['String']>;
+  individual?: Maybe<Stripe_IssuingCardholderIndividual>;
+  /** Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode. */
+  livemode?: Maybe<Scalars['Boolean']>;
+  /** Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. */
+  metadata?: Maybe<Scalars['JSONObject']>;
+  /** The cardholder's name. This will be printed on cards issued to them. */
+  name?: Maybe<Scalars['String']>;
+  /** String representing the object's type. Objects of the same type share the same value. */
+  object?: Maybe<Stripe_IssuingCardholderObjectProperty>;
+  /** The cardholder's phone number. */
+  phone_number?: Maybe<Scalars['String']>;
+  requirements?: Maybe<Stripe_IssuingCardholderRequirements>;
+  spending_controls?: Maybe<Stripe_IssuingCardholderAuthorizationControls>;
+  /** Specifies whether to permit authorizations on this cardholder's cards. */
+  status?: Maybe<Stripe_IssuingCardholderStatusProperty>;
+  /** One of `individual` or `company`. */
+  type?: Maybe<Stripe_IssuingCardholderTypeProperty>;
+};
+
+export type Stripe_IssuingCardholderAddress = {
+  __typename?: 'Stripe_IssuingCardholderAddress';
+  address?: Maybe<Stripe_Address>;
+};
+
+export type Stripe_IssuingCardholderCompany = {
+  __typename?: 'Stripe_IssuingCardholderCompany';
+  /** Whether the company's business ID number was provided. */
+  tax_id_provided?: Maybe<Scalars['Boolean']>;
+};
+
+export type Stripe_IssuingCardholderIndividual = {
+  __typename?: 'Stripe_IssuingCardholderIndividual';
+  dob?: Maybe<Stripe_IssuingCardholderIndividualDob>;
+  /** The first name of this cardholder. */
+  first_name?: Maybe<Scalars['String']>;
+  /** The last name of this cardholder. */
+  last_name?: Maybe<Scalars['String']>;
+  verification?: Maybe<Stripe_IssuingCardholderVerification>;
+};
+
+export type Stripe_IssuingCardholderIndividualDob = {
+  __typename?: 'Stripe_IssuingCardholderIndividualDob';
+  /** The day of birth, between 1 and 31. */
+  day?: Maybe<Scalars['Int']>;
+  /** The month of birth, between 1 and 12. */
+  month?: Maybe<Scalars['Int']>;
+  /** The four-digit year of birth. */
+  year?: Maybe<Scalars['Int']>;
+};
+
+export type Stripe_IssuingCardholderVerification = {
+  __typename?: 'Stripe_IssuingCardholderVerification';
+  document?: Maybe<Stripe_IssuingCardholderIdDocument>;
+};
+
+export type Stripe_IssuingCardholderIdDocument = {
+  __typename?: 'Stripe_IssuingCardholderIdDocument';
+  back?: Maybe<Stripe_IssuingCardholderIdDocumentBackProperty>;
+  front?: Maybe<Stripe_IssuingCardholderIdDocumentFrontProperty>;
+};
+
+export type Stripe_IssuingCardholderIdDocumentBackProperty = WrappedString | Stripe_File;
+
+export type Stripe_IssuingCardholderIdDocumentFrontProperty = WrappedString | Stripe_File;
+
+export enum Stripe_IssuingCardholderObjectProperty {
+  IssuingDoTcardholder = 'issuingDOTcardholder'
+}
+
+export type Stripe_IssuingCardholderRequirements = {
+  __typename?: 'Stripe_IssuingCardholderRequirements';
+  /** If `disabled_reason` is present, all cards will decline authorizations with `cardholder_verification_required` reason. */
+  disabled_reason?: Maybe<Stripe_IssuingCardholderRequirementsDisabledReasonProperty>;
+  /** Array of fields that need to be collected in order to verify and re-enable the cardholder. */
+  past_due?: Maybe<Array<Maybe<Stripe_IssuingCardholderRequirementsPastDueProperty>>>;
+};
+
+export enum Stripe_IssuingCardholderRequirementsDisabledReasonProperty {
+  Listed = 'listed',
+  RejectedDoTlisted = 'rejectedDOTlisted',
+  UnderReview = 'under_review'
+}
+
+export enum Stripe_IssuingCardholderRequirementsPastDueProperty {
+  CompanyDoTtaxId = 'companyDOTtax_id',
+  IndividualDoTdobDoTday = 'individualDOTdobDOTday',
+  IndividualDoTdobDoTmonth = 'individualDOTdobDOTmonth',
+  IndividualDoTdobDoTyear = 'individualDOTdobDOTyear',
+  IndividualDoTfirstName = 'individualDOTfirst_name',
+  IndividualDoTlastName = 'individualDOTlast_name',
+  IndividualDoTverificationDoTdocument = 'individualDOTverificationDOTdocument'
+}
+
+export type Stripe_IssuingCardholderAuthorizationControls = {
+  __typename?: 'Stripe_IssuingCardholderAuthorizationControls';
+  /** Array of strings containing [categories](https://stripe.com/docs/api#issuing_authorization_object-merchant_data-category) of authorizations to allow. All other categories will be blocked. Cannot be set with `blocked_categories`. */
+  allowed_categories?: Maybe<Array<Maybe<Stripe_IssuingCardholderAuthorizationControlsAllowedCategoriesProperty>>>;
+  /** Array of strings containing [categories](https://stripe.com/docs/api#issuing_authorization_object-merchant_data-category) of authorizations to decline. All other categories will be allowed. Cannot be set with `allowed_categories`. */
+  blocked_categories?: Maybe<Array<Maybe<Stripe_IssuingCardholderAuthorizationControlsBlockedCategoriesProperty>>>;
+  /** Limit spending with amount-based rules that apply across this cardholder's cards. */
+  spending_limits?: Maybe<Array<Maybe<Stripe_IssuingCardholderSpendingLimit>>>;
+  /** Currency of the amounts within `spending_limits`. */
+  spending_limits_currency?: Maybe<Scalars['String']>;
+};
+
+export enum Stripe_IssuingCardholderAuthorizationControlsAllowedCategoriesProperty {
+  AcRefrigerationRepair = 'ac_refrigeration_repair',
+  AccountingBookkeepingServices = 'accounting_bookkeeping_services',
+  AdvertisingServices = 'advertising_services',
+  AgriculturalCooperative = 'agricultural_cooperative',
+  AirlinesAirCarriers = 'airlines_air_carriers',
+  AirportsFlyingFields = 'airports_flying_fields',
+  AmbulanceServices = 'ambulance_services',
+  AmusementParksCarnivals = 'amusement_parks_carnivals',
+  AntiqueReproductions = 'antique_reproductions',
+  AntiqueShops = 'antique_shops',
+  Aquariums = 'aquariums',
+  ArchitecturalSurveyingServices = 'architectural_surveying_services',
+  ArtDealersAndGalleries = 'art_dealers_and_galleries',
+  ArtistsSupplyAndCraftShops = 'artists_supply_and_craft_shops',
+  AutoAndHomeSupplyStores = 'auto_and_home_supply_stores',
+  AutoBodyRepairShops = 'auto_body_repair_shops',
+  AutoPaintShops = 'auto_paint_shops',
+  AutoServiceShops = 'auto_service_shops',
+  AutomatedCashDisburse = 'automated_cash_disburse',
+  AutomatedFuelDispensers = 'automated_fuel_dispensers',
+  AutomobileAssociations = 'automobile_associations',
+  AutomotivePartsAndAccessoriesStores = 'automotive_parts_and_accessories_stores',
+  AutomotiveTireStores = 'automotive_tire_stores',
+  BailAndBondPayments = 'bail_and_bond_payments',
+  Bakeries = 'bakeries',
+  BandsOrchestras = 'bands_orchestras',
+  BarberAndBeautyShops = 'barber_and_beauty_shops',
+  BettingCasinoGambling = 'betting_casino_gambling',
+  BicycleShops = 'bicycle_shops',
+  BilliardPoolEstablishments = 'billiard_pool_establishments',
+  BoatDealers = 'boat_dealers',
+  BoatRentalsAndLeases = 'boat_rentals_and_leases',
+  BookStores = 'book_stores',
+  BooksPeriodicalsAndNewspapers = 'books_periodicals_and_newspapers',
+  BowlingAlleys = 'bowling_alleys',
+  BusLines = 'bus_lines',
+  BusinessSecretarialSchools = 'business_secretarial_schools',
+  BuyingShoppingServices = 'buying_shopping_services',
+  CableSatelliteAndOtherPayTelevisionAndRadio = 'cable_satellite_and_other_pay_television_and_radio',
+  CameraAndPhotographicSupplyStores = 'camera_and_photographic_supply_stores',
+  CandyNutAndConfectioneryStores = 'candy_nut_and_confectionery_stores',
+  CarAndTruckDealersNewUsed = 'car_and_truck_dealers_new_used',
+  CarAndTruckDealersUsedOnly = 'car_and_truck_dealers_used_only',
+  CarRentalAgencies = 'car_rental_agencies',
+  CarWashes = 'car_washes',
+  CarpentryServices = 'carpentry_services',
+  CarpetUpholsteryCleaning = 'carpet_upholstery_cleaning',
+  Caterers = 'caterers',
+  CharitableAndSocialServiceOrganizationsFundraising = 'charitable_and_social_service_organizations_fundraising',
+  ChemicalsAndAlliedProducts = 'chemicals_and_allied_products',
+  ChildCareServices = 'child_care_services',
+  ChildrensAndInfantsWearStores = 'childrens_and_infants_wear_stores',
+  ChiropodistsPodiatrists = 'chiropodists_podiatrists',
+  Chiropractors = 'chiropractors',
+  CigarStoresAndStands = 'cigar_stores_and_stands',
+  CivicSocialFraternalAssociations = 'civic_social_fraternal_associations',
+  CleaningAndMaintenance = 'cleaning_and_maintenance',
+  ClothingRental = 'clothing_rental',
+  CollegesUniversities = 'colleges_universities',
+  CommercialEquipment = 'commercial_equipment',
+  CommercialFootwear = 'commercial_footwear',
+  CommercialPhotographyArtAndGraphics = 'commercial_photography_art_and_graphics',
+  CommuterTransportAndFerries = 'commuter_transport_and_ferries',
+  ComputerNetworkServices = 'computer_network_services',
+  ComputerProgramming = 'computer_programming',
+  ComputerRepair = 'computer_repair',
+  ComputerSoftwareStores = 'computer_software_stores',
+  ComputersPeripheralsAndSoftware = 'computers_peripherals_and_software',
+  ConcreteWorkServices = 'concrete_work_services',
+  ConstructionMaterials = 'construction_materials',
+  ConsultingPublicRelations = 'consulting_public_relations',
+  CorrespondenceSchools = 'correspondence_schools',
+  CosmeticStores = 'cosmetic_stores',
+  CounselingServices = 'counseling_services',
+  CountryClubs = 'country_clubs',
+  CourierServices = 'courier_services',
+  CourtCosts = 'court_costs',
+  CreditReportingAgencies = 'credit_reporting_agencies',
+  CruiseLines = 'cruise_lines',
+  DairyProductsStores = 'dairy_products_stores',
+  DanceHallStudiosSchools = 'dance_hall_studios_schools',
+  DatingEscortServices = 'dating_escort_services',
+  DentistsOrthodontists = 'dentists_orthodontists',
+  DepartmentStores = 'department_stores',
+  DetectiveAgencies = 'detective_agencies',
+  DigitalGoodsApplications = 'digital_goods_applications',
+  DigitalGoodsGames = 'digital_goods_games',
+  DigitalGoodsLargeVolume = 'digital_goods_large_volume',
+  DigitalGoodsMedia = 'digital_goods_media',
+  DirectMarketingCatalogMerchant = 'direct_marketing_catalog_merchant',
+  DirectMarketingCombinationCatalogAndRetailMerchant = 'direct_marketing_combination_catalog_and_retail_merchant',
+  DirectMarketingInboundTelemarketing = 'direct_marketing_inbound_telemarketing',
+  DirectMarketingInsuranceServices = 'direct_marketing_insurance_services',
+  DirectMarketingOther = 'direct_marketing_other',
+  DirectMarketingOutboundTelemarketing = 'direct_marketing_outbound_telemarketing',
+  DirectMarketingSubscription = 'direct_marketing_subscription',
+  DirectMarketingTravel = 'direct_marketing_travel',
+  DiscountStores = 'discount_stores',
+  Doctors = 'doctors',
+  DoorToDoorSales = 'door_to_door_sales',
+  DraperyWindowCoveringAndUpholsteryStores = 'drapery_window_covering_and_upholstery_stores',
+  DrinkingPlaces = 'drinking_places',
+  DrugStoresAndPharmacies = 'drug_stores_and_pharmacies',
+  DrugsDrugProprietariesAndDruggistSundries = 'drugs_drug_proprietaries_and_druggist_sundries',
+  DryCleaners = 'dry_cleaners',
+  DurableGoods = 'durable_goods',
+  DutyFreeStores = 'duty_free_stores',
+  EatingPlacesRestaurants = 'eating_places_restaurants',
+  EducationalServices = 'educational_services',
+  ElectricRazorStores = 'electric_razor_stores',
+  ElectricalPartsAndEquipment = 'electrical_parts_and_equipment',
+  ElectricalServices = 'electrical_services',
+  ElectronicsRepairShops = 'electronics_repair_shops',
+  ElectronicsStores = 'electronics_stores',
+  ElementarySecondarySchools = 'elementary_secondary_schools',
+  EmploymentTempAgencies = 'employment_temp_agencies',
+  EquipmentRental = 'equipment_rental',
+  ExterminatingServices = 'exterminating_services',
+  FamilyClothingStores = 'family_clothing_stores',
+  FastFoodRestaurants = 'fast_food_restaurants',
+  FinancialInstitutions = 'financial_institutions',
+  FinesGovernmentAdministrativeEntities = 'fines_government_administrative_entities',
+  FireplaceFireplaceScreensAndAccessoriesStores = 'fireplace_fireplace_screens_and_accessories_stores',
+  FloorCoveringStores = 'floor_covering_stores',
+  Florists = 'florists',
+  FloristsSuppliesNurseryStockAndFlowers = 'florists_supplies_nursery_stock_and_flowers',
+  FreezerAndLockerMeatProvisioners = 'freezer_and_locker_meat_provisioners',
+  FuelDealersNonAutomotive = 'fuel_dealers_non_automotive',
+  FuneralServicesCrematories = 'funeral_services_crematories',
+  FurnitureHomeFurnishingsAndEquipmentStoresExceptAppliances = 'furniture_home_furnishings_and_equipment_stores_except_appliances',
+  FurnitureRepairRefinishing = 'furniture_repair_refinishing',
+  FurriersAndFurShops = 'furriers_and_fur_shops',
+  GeneralServices = 'general_services',
+  GiftCardNoveltyAndSouvenirShops = 'gift_card_novelty_and_souvenir_shops',
+  GlassPaintAndWallpaperStores = 'glass_paint_and_wallpaper_stores',
+  GlasswareCrystalStores = 'glassware_crystal_stores',
+  GolfCoursesPublic = 'golf_courses_public',
+  GovernmentServices = 'government_services',
+  GroceryStoresSupermarkets = 'grocery_stores_supermarkets',
+  HardwareEquipmentAndSupplies = 'hardware_equipment_and_supplies',
+  HardwareStores = 'hardware_stores',
+  HealthAndBeautySpas = 'health_and_beauty_spas',
+  HearingAidsSalesAndSupplies = 'hearing_aids_sales_and_supplies',
+  HeatingPlumbingAC = 'heating_plumbing_a_c',
+  HobbyToyAndGameShops = 'hobby_toy_and_game_shops',
+  HomeSupplyWarehouseStores = 'home_supply_warehouse_stores',
+  Hospitals = 'hospitals',
+  HotelsMotelsAndResorts = 'hotels_motels_and_resorts',
+  HouseholdApplianceStores = 'household_appliance_stores',
+  IndustrialSupplies = 'industrial_supplies',
+  InformationRetrievalServices = 'information_retrieval_services',
+  InsuranceDefault = 'insurance_default',
+  InsuranceUnderwritingPremiums = 'insurance_underwriting_premiums',
+  IntraCompanyPurchases = 'intra_company_purchases',
+  JewelryStoresWatchesClocksAndSilverwareStores = 'jewelry_stores_watches_clocks_and_silverware_stores',
+  LandscapingServices = 'landscaping_services',
+  Laundries = 'laundries',
+  LaundryCleaningServices = 'laundry_cleaning_services',
+  LegalServicesAttorneys = 'legal_services_attorneys',
+  LuggageAndLeatherGoodsStores = 'luggage_and_leather_goods_stores',
+  LumberBuildingMaterialsStores = 'lumber_building_materials_stores',
+  ManualCashDisburse = 'manual_cash_disburse',
+  MarinasServiceAndSupplies = 'marinas_service_and_supplies',
+  MasonryStoneworkAndPlaster = 'masonry_stonework_and_plaster',
+  MassageParlors = 'massage_parlors',
+  MedicalAndDentalLabs = 'medical_and_dental_labs',
+  MedicalDentalOphthalmicAndHospitalEquipmentAndSupplies = 'medical_dental_ophthalmic_and_hospital_equipment_and_supplies',
+  MedicalServices = 'medical_services',
+  MembershipOrganizations = 'membership_organizations',
+  MensAndBoysClothingAndAccessoriesStores = 'mens_and_boys_clothing_and_accessories_stores',
+  MensWomensClothingStores = 'mens_womens_clothing_stores',
+  MetalServiceCenters = 'metal_service_centers',
+  Miscellaneous = 'miscellaneous',
+  MiscellaneousApparelAndAccessoryShops = 'miscellaneous_apparel_and_accessory_shops',
+  MiscellaneousAutoDealers = 'miscellaneous_auto_dealers',
+  MiscellaneousBusinessServices = 'miscellaneous_business_services',
+  MiscellaneousFoodStores = 'miscellaneous_food_stores',
+  MiscellaneousGeneralMerchandise = 'miscellaneous_general_merchandise',
+  MiscellaneousGeneralServices = 'miscellaneous_general_services',
+  MiscellaneousHomeFurnishingSpecialtyStores = 'miscellaneous_home_furnishing_specialty_stores',
+  MiscellaneousPublishingAndPrinting = 'miscellaneous_publishing_and_printing',
+  MiscellaneousRecreationServices = 'miscellaneous_recreation_services',
+  MiscellaneousRepairShops = 'miscellaneous_repair_shops',
+  MiscellaneousSpecialtyRetail = 'miscellaneous_specialty_retail',
+  MobileHomeDealers = 'mobile_home_dealers',
+  MotionPictureTheaters = 'motion_picture_theaters',
+  MotorFreightCarriersAndTrucking = 'motor_freight_carriers_and_trucking',
+  MotorHomesDealers = 'motor_homes_dealers',
+  MotorVehicleSuppliesAndNewParts = 'motor_vehicle_supplies_and_new_parts',
+  MotorcycleShopsAndDealers = 'motorcycle_shops_and_dealers',
+  MotorcycleShopsDealers = 'motorcycle_shops_dealers',
+  MusicStoresMusicalInstrumentsPianosAndSheetMusic = 'music_stores_musical_instruments_pianos_and_sheet_music',
+  NewsDealersAndNewsstands = 'news_dealers_and_newsstands',
+  NonFiMoneyOrders = 'non_fi_money_orders',
+  NonFiStoredValueCardPurchaseLoad = 'non_fi_stored_value_card_purchase_load',
+  NondurableGoods = 'nondurable_goods',
+  NurseriesLawnAndGardenSupplyStores = 'nurseries_lawn_and_garden_supply_stores',
+  NursingPersonalCare = 'nursing_personal_care',
+  OfficeAndCommercialFurniture = 'office_and_commercial_furniture',
+  OpticiansEyeglasses = 'opticians_eyeglasses',
+  OptometristsOphthalmologist = 'optometrists_ophthalmologist',
+  OrthopedicGoodsProstheticDevices = 'orthopedic_goods_prosthetic_devices',
+  Osteopaths = 'osteopaths',
+  PackageStoresBeerWineAndLiquor = 'package_stores_beer_wine_and_liquor',
+  PaintsVarnishesAndSupplies = 'paints_varnishes_and_supplies',
+  ParkingLotsGarages = 'parking_lots_garages',
+  PassengerRailways = 'passenger_railways',
+  PawnShops = 'pawn_shops',
+  PetShopsPetFoodAndSupplies = 'pet_shops_pet_food_and_supplies',
+  PetroleumAndPetroleumProducts = 'petroleum_and_petroleum_products',
+  PhotoDeveloping = 'photo_developing',
+  PhotographicPhotocopyMicrofilmEquipmentAndSupplies = 'photographic_photocopy_microfilm_equipment_and_supplies',
+  PhotographicStudios = 'photographic_studios',
+  PictureVideoProduction = 'picture_video_production',
+  PieceGoodsNotionsAndOtherDryGoods = 'piece_goods_notions_and_other_dry_goods',
+  PlumbingHeatingEquipmentAndSupplies = 'plumbing_heating_equipment_and_supplies',
+  PoliticalOrganizations = 'political_organizations',
+  PostalServicesGovernmentOnly = 'postal_services_government_only',
+  PreciousStonesAndMetalsWatchesAndJewelry = 'precious_stones_and_metals_watches_and_jewelry',
+  ProfessionalServices = 'professional_services',
+  PublicWarehousingAndStorage = 'public_warehousing_and_storage',
+  QuickCopyReproAndBlueprint = 'quick_copy_repro_and_blueprint',
+  Railroads = 'railroads',
+  RealEstateAgentsAndManagersRentals = 'real_estate_agents_and_managers_rentals',
+  RecordStores = 'record_stores',
+  RecreationalVehicleRentals = 'recreational_vehicle_rentals',
+  ReligiousGoodsStores = 'religious_goods_stores',
+  ReligiousOrganizations = 'religious_organizations',
+  RoofingSidingSheetMetal = 'roofing_siding_sheet_metal',
+  SecretarialSupportServices = 'secretarial_support_services',
+  SecurityBrokersDealers = 'security_brokers_dealers',
+  ServiceStations = 'service_stations',
+  SewingNeedleworkFabricAndPieceGoodsStores = 'sewing_needlework_fabric_and_piece_goods_stores',
+  ShoeRepairHatCleaning = 'shoe_repair_hat_cleaning',
+  ShoeStores = 'shoe_stores',
+  SmallApplianceRepair = 'small_appliance_repair',
+  SnowmobileDealers = 'snowmobile_dealers',
+  SpecialTradeServices = 'special_trade_services',
+  SpecialtyCleaning = 'specialty_cleaning',
+  SportingGoodsStores = 'sporting_goods_stores',
+  SportingRecreationCamps = 'sporting_recreation_camps',
+  SportsAndRidingApparelStores = 'sports_and_riding_apparel_stores',
+  SportsClubsFields = 'sports_clubs_fields',
+  StampAndCoinStores = 'stamp_and_coin_stores',
+  StationaryOfficeSuppliesPrintingAndWritingPaper = 'stationary_office_supplies_printing_and_writing_paper',
+  StationeryStoresOfficeAndSchoolSupplyStores = 'stationery_stores_office_and_school_supply_stores',
+  SwimmingPoolsSales = 'swimming_pools_sales',
+  TUiTravelGermany = 't_ui_travel_germany',
+  TailorsAlterations = 'tailors_alterations',
+  TaxPaymentsGovernmentAgencies = 'tax_payments_government_agencies',
+  TaxPreparationServices = 'tax_preparation_services',
+  TaxicabsLimousines = 'taxicabs_limousines',
+  TelecommunicationEquipmentAndTelephoneSales = 'telecommunication_equipment_and_telephone_sales',
+  TelecommunicationServices = 'telecommunication_services',
+  TelegraphServices = 'telegraph_services',
+  TentAndAwningShops = 'tent_and_awning_shops',
+  TestingLaboratories = 'testing_laboratories',
+  TheatricalTicketAgencies = 'theatrical_ticket_agencies',
+  Timeshares = 'timeshares',
+  TireRetreadingAndRepair = 'tire_retreading_and_repair',
+  TollsBridgeFees = 'tolls_bridge_fees',
+  TouristAttractionsAndExhibits = 'tourist_attractions_and_exhibits',
+  TowingServices = 'towing_services',
+  TrailerParksCampgrounds = 'trailer_parks_campgrounds',
+  TransportationServices = 'transportation_services',
+  TravelAgenciesTourOperators = 'travel_agencies_tour_operators',
+  TruckStopIteration = 'truck_stop_iteration',
+  TruckUtilityTrailerRentals = 'truck_utility_trailer_rentals',
+  TypesettingPlateMakingAndRelatedServices = 'typesetting_plate_making_and_related_services',
+  TypewriterStores = 'typewriter_stores',
+  USFederalGovernmentAgenciesOrDepartments = 'u_s_federal_government_agencies_or_departments',
+  UniformsCommercialClothing = 'uniforms_commercial_clothing',
+  UsedMerchandiseAndSecondhandStores = 'used_merchandise_and_secondhand_stores',
+  Utilities = 'utilities',
+  VarietyStores = 'variety_stores',
+  VeterinaryServices = 'veterinary_services',
+  VideoAmusementGameSupplies = 'video_amusement_game_supplies',
+  VideoGameArcades = 'video_game_arcades',
+  VideoTapeRentalStores = 'video_tape_rental_stores',
+  VocationalTradeSchools = 'vocational_trade_schools',
+  WatchJewelryRepair = 'watch_jewelry_repair',
+  WeldingRepair = 'welding_repair',
+  WholesaleClubs = 'wholesale_clubs',
+  WigAndToupeeStores = 'wig_and_toupee_stores',
+  WiresMoneyOrders = 'wires_money_orders',
+  WomensAccessoryAndSpecialtyShops = 'womens_accessory_and_specialty_shops',
+  WomensReadyToWearStores = 'womens_ready_to_wear_stores',
+  WreckingAndSalvageYards = 'wrecking_and_salvage_yards'
+}
+
+export enum Stripe_IssuingCardholderAuthorizationControlsBlockedCategoriesProperty {
+  AcRefrigerationRepair = 'ac_refrigeration_repair',
+  AccountingBookkeepingServices = 'accounting_bookkeeping_services',
+  AdvertisingServices = 'advertising_services',
+  AgriculturalCooperative = 'agricultural_cooperative',
+  AirlinesAirCarriers = 'airlines_air_carriers',
+  AirportsFlyingFields = 'airports_flying_fields',
+  AmbulanceServices = 'ambulance_services',
+  AmusementParksCarnivals = 'amusement_parks_carnivals',
+  AntiqueReproductions = 'antique_reproductions',
+  AntiqueShops = 'antique_shops',
+  Aquariums = 'aquariums',
+  ArchitecturalSurveyingServices = 'architectural_surveying_services',
+  ArtDealersAndGalleries = 'art_dealers_and_galleries',
+  ArtistsSupplyAndCraftShops = 'artists_supply_and_craft_shops',
+  AutoAndHomeSupplyStores = 'auto_and_home_supply_stores',
+  AutoBodyRepairShops = 'auto_body_repair_shops',
+  AutoPaintShops = 'auto_paint_shops',
+  AutoServiceShops = 'auto_service_shops',
+  AutomatedCashDisburse = 'automated_cash_disburse',
+  AutomatedFuelDispensers = 'automated_fuel_dispensers',
+  AutomobileAssociations = 'automobile_associations',
+  AutomotivePartsAndAccessoriesStores = 'automotive_parts_and_accessories_stores',
+  AutomotiveTireStores = 'automotive_tire_stores',
+  BailAndBondPayments = 'bail_and_bond_payments',
+  Bakeries = 'bakeries',
+  BandsOrchestras = 'bands_orchestras',
+  BarberAndBeautyShops = 'barber_and_beauty_shops',
+  BettingCasinoGambling = 'betting_casino_gambling',
+  BicycleShops = 'bicycle_shops',
+  BilliardPoolEstablishments = 'billiard_pool_establishments',
+  BoatDealers = 'boat_dealers',
+  BoatRentalsAndLeases = 'boat_rentals_and_leases',
+  BookStores = 'book_stores',
+  BooksPeriodicalsAndNewspapers = 'books_periodicals_and_newspapers',
+  BowlingAlleys = 'bowling_alleys',
+  BusLines = 'bus_lines',
+  BusinessSecretarialSchools = 'business_secretarial_schools',
+  BuyingShoppingServices = 'buying_shopping_services',
+  CableSatelliteAndOtherPayTelevisionAndRadio = 'cable_satellite_and_other_pay_television_and_radio',
+  CameraAndPhotographicSupplyStores = 'camera_and_photographic_supply_stores',
+  CandyNutAndConfectioneryStores = 'candy_nut_and_confectionery_stores',
+  CarAndTruckDealersNewUsed = 'car_and_truck_dealers_new_used',
+  CarAndTruckDealersUsedOnly = 'car_and_truck_dealers_used_only',
+  CarRentalAgencies = 'car_rental_agencies',
+  CarWashes = 'car_washes',
+  CarpentryServices = 'carpentry_services',
+  CarpetUpholsteryCleaning = 'carpet_upholstery_cleaning',
+  Caterers = 'caterers',
+  CharitableAndSocialServiceOrganizationsFundraising = 'charitable_and_social_service_organizations_fundraising',
+  ChemicalsAndAlliedProducts = 'chemicals_and_allied_products',
+  ChildCareServices = 'child_care_services',
+  ChildrensAndInfantsWearStores = 'childrens_and_infants_wear_stores',
+  ChiropodistsPodiatrists = 'chiropodists_podiatrists',
+  Chiropractors = 'chiropractors',
+  CigarStoresAndStands = 'cigar_stores_and_stands',
+  CivicSocialFraternalAssociations = 'civic_social_fraternal_associations',
+  CleaningAndMaintenance = 'cleaning_and_maintenance',
+  ClothingRental = 'clothing_rental',
+  CollegesUniversities = 'colleges_universities',
+  CommercialEquipment = 'commercial_equipment',
+  CommercialFootwear = 'commercial_footwear',
+  CommercialPhotographyArtAndGraphics = 'commercial_photography_art_and_graphics',
+  CommuterTransportAndFerries = 'commuter_transport_and_ferries',
+  ComputerNetworkServices = 'computer_network_services',
+  ComputerProgramming = 'computer_programming',
+  ComputerRepair = 'computer_repair',
+  ComputerSoftwareStores = 'computer_software_stores',
+  ComputersPeripheralsAndSoftware = 'computers_peripherals_and_software',
+  ConcreteWorkServices = 'concrete_work_services',
+  ConstructionMaterials = 'construction_materials',
+  ConsultingPublicRelations = 'consulting_public_relations',
+  CorrespondenceSchools = 'correspondence_schools',
+  CosmeticStores = 'cosmetic_stores',
+  CounselingServices = 'counseling_services',
+  CountryClubs = 'country_clubs',
+  CourierServices = 'courier_services',
+  CourtCosts = 'court_costs',
+  CreditReportingAgencies = 'credit_reporting_agencies',
+  CruiseLines = 'cruise_lines',
+  DairyProductsStores = 'dairy_products_stores',
+  DanceHallStudiosSchools = 'dance_hall_studios_schools',
+  DatingEscortServices = 'dating_escort_services',
+  DentistsOrthodontists = 'dentists_orthodontists',
+  DepartmentStores = 'department_stores',
+  DetectiveAgencies = 'detective_agencies',
+  DigitalGoodsApplications = 'digital_goods_applications',
+  DigitalGoodsGames = 'digital_goods_games',
+  DigitalGoodsLargeVolume = 'digital_goods_large_volume',
+  DigitalGoodsMedia = 'digital_goods_media',
+  DirectMarketingCatalogMerchant = 'direct_marketing_catalog_merchant',
+  DirectMarketingCombinationCatalogAndRetailMerchant = 'direct_marketing_combination_catalog_and_retail_merchant',
+  DirectMarketingInboundTelemarketing = 'direct_marketing_inbound_telemarketing',
+  DirectMarketingInsuranceServices = 'direct_marketing_insurance_services',
+  DirectMarketingOther = 'direct_marketing_other',
+  DirectMarketingOutboundTelemarketing = 'direct_marketing_outbound_telemarketing',
+  DirectMarketingSubscription = 'direct_marketing_subscription',
+  DirectMarketingTravel = 'direct_marketing_travel',
+  DiscountStores = 'discount_stores',
+  Doctors = 'doctors',
+  DoorToDoorSales = 'door_to_door_sales',
+  DraperyWindowCoveringAndUpholsteryStores = 'drapery_window_covering_and_upholstery_stores',
+  DrinkingPlaces = 'drinking_places',
+  DrugStoresAndPharmacies = 'drug_stores_and_pharmacies',
+  DrugsDrugProprietariesAndDruggistSundries = 'drugs_drug_proprietaries_and_druggist_sundries',
+  DryCleaners = 'dry_cleaners',
+  DurableGoods = 'durable_goods',
+  DutyFreeStores = 'duty_free_stores',
+  EatingPlacesRestaurants = 'eating_places_restaurants',
+  EducationalServices = 'educational_services',
+  ElectricRazorStores = 'electric_razor_stores',
+  ElectricalPartsAndEquipment = 'electrical_parts_and_equipment',
+  ElectricalServices = 'electrical_services',
+  ElectronicsRepairShops = 'electronics_repair_shops',
+  ElectronicsStores = 'electronics_stores',
+  ElementarySecondarySchools = 'elementary_secondary_schools',
+  EmploymentTempAgencies = 'employment_temp_agencies',
+  EquipmentRental = 'equipment_rental',
+  ExterminatingServices = 'exterminating_services',
+  FamilyClothingStores = 'family_clothing_stores',
+  FastFoodRestaurants = 'fast_food_restaurants',
+  FinancialInstitutions = 'financial_institutions',
+  FinesGovernmentAdministrativeEntities = 'fines_government_administrative_entities',
+  FireplaceFireplaceScreensAndAccessoriesStores = 'fireplace_fireplace_screens_and_accessories_stores',
+  FloorCoveringStores = 'floor_covering_stores',
+  Florists = 'florists',
+  FloristsSuppliesNurseryStockAndFlowers = 'florists_supplies_nursery_stock_and_flowers',
+  FreezerAndLockerMeatProvisioners = 'freezer_and_locker_meat_provisioners',
+  FuelDealersNonAutomotive = 'fuel_dealers_non_automotive',
+  FuneralServicesCrematories = 'funeral_services_crematories',
+  FurnitureHomeFurnishingsAndEquipmentStoresExceptAppliances = 'furniture_home_furnishings_and_equipment_stores_except_appliances',
+  FurnitureRepairRefinishing = 'furniture_repair_refinishing',
+  FurriersAndFurShops = 'furriers_and_fur_shops',
+  GeneralServices = 'general_services',
+  GiftCardNoveltyAndSouvenirShops = 'gift_card_novelty_and_souvenir_shops',
+  GlassPaintAndWallpaperStores = 'glass_paint_and_wallpaper_stores',
+  GlasswareCrystalStores = 'glassware_crystal_stores',
+  GolfCoursesPublic = 'golf_courses_public',
+  GovernmentServices = 'government_services',
+  GroceryStoresSupermarkets = 'grocery_stores_supermarkets',
+  HardwareEquipmentAndSupplies = 'hardware_equipment_and_supplies',
+  HardwareStores = 'hardware_stores',
+  HealthAndBeautySpas = 'health_and_beauty_spas',
+  HearingAidsSalesAndSupplies = 'hearing_aids_sales_and_supplies',
+  HeatingPlumbingAC = 'heating_plumbing_a_c',
+  HobbyToyAndGameShops = 'hobby_toy_and_game_shops',
+  HomeSupplyWarehouseStores = 'home_supply_warehouse_stores',
+  Hospitals = 'hospitals',
+  HotelsMotelsAndResorts = 'hotels_motels_and_resorts',
+  HouseholdApplianceStores = 'household_appliance_stores',
+  IndustrialSupplies = 'industrial_supplies',
+  InformationRetrievalServices = 'information_retrieval_services',
+  InsuranceDefault = 'insurance_default',
+  InsuranceUnderwritingPremiums = 'insurance_underwriting_premiums',
+  IntraCompanyPurchases = 'intra_company_purchases',
+  JewelryStoresWatchesClocksAndSilverwareStores = 'jewelry_stores_watches_clocks_and_silverware_stores',
+  LandscapingServices = 'landscaping_services',
+  Laundries = 'laundries',
+  LaundryCleaningServices = 'laundry_cleaning_services',
+  LegalServicesAttorneys = 'legal_services_attorneys',
+  LuggageAndLeatherGoodsStores = 'luggage_and_leather_goods_stores',
+  LumberBuildingMaterialsStores = 'lumber_building_materials_stores',
+  ManualCashDisburse = 'manual_cash_disburse',
+  MarinasServiceAndSupplies = 'marinas_service_and_supplies',
+  MasonryStoneworkAndPlaster = 'masonry_stonework_and_plaster',
+  MassageParlors = 'massage_parlors',
+  MedicalAndDentalLabs = 'medical_and_dental_labs',
+  MedicalDentalOphthalmicAndHospitalEquipmentAndSupplies = 'medical_dental_ophthalmic_and_hospital_equipment_and_supplies',
+  MedicalServices = 'medical_services',
+  MembershipOrganizations = 'membership_organizations',
+  MensAndBoysClothingAndAccessoriesStores = 'mens_and_boys_clothing_and_accessories_stores',
+  MensWomensClothingStores = 'mens_womens_clothing_stores',
+  MetalServiceCenters = 'metal_service_centers',
+  Miscellaneous = 'miscellaneous',
+  MiscellaneousApparelAndAccessoryShops = 'miscellaneous_apparel_and_accessory_shops',
+  MiscellaneousAutoDealers = 'miscellaneous_auto_dealers',
+  MiscellaneousBusinessServices = 'miscellaneous_business_services',
+  MiscellaneousFoodStores = 'miscellaneous_food_stores',
+  MiscellaneousGeneralMerchandise = 'miscellaneous_general_merchandise',
+  MiscellaneousGeneralServices = 'miscellaneous_general_services',
+  MiscellaneousHomeFurnishingSpecialtyStores = 'miscellaneous_home_furnishing_specialty_stores',
+  MiscellaneousPublishingAndPrinting = 'miscellaneous_publishing_and_printing',
+  MiscellaneousRecreationServices = 'miscellaneous_recreation_services',
+  MiscellaneousRepairShops = 'miscellaneous_repair_shops',
+  MiscellaneousSpecialtyRetail = 'miscellaneous_specialty_retail',
+  MobileHomeDealers = 'mobile_home_dealers',
+  MotionPictureTheaters = 'motion_picture_theaters',
+  MotorFreightCarriersAndTrucking = 'motor_freight_carriers_and_trucking',
+  MotorHomesDealers = 'motor_homes_dealers',
+  MotorVehicleSuppliesAndNewParts = 'motor_vehicle_supplies_and_new_parts',
+  MotorcycleShopsAndDealers = 'motorcycle_shops_and_dealers',
+  MotorcycleShopsDealers = 'motorcycle_shops_dealers',
+  MusicStoresMusicalInstrumentsPianosAndSheetMusic = 'music_stores_musical_instruments_pianos_and_sheet_music',
+  NewsDealersAndNewsstands = 'news_dealers_and_newsstands',
+  NonFiMoneyOrders = 'non_fi_money_orders',
+  NonFiStoredValueCardPurchaseLoad = 'non_fi_stored_value_card_purchase_load',
+  NondurableGoods = 'nondurable_goods',
+  NurseriesLawnAndGardenSupplyStores = 'nurseries_lawn_and_garden_supply_stores',
+  NursingPersonalCare = 'nursing_personal_care',
+  OfficeAndCommercialFurniture = 'office_and_commercial_furniture',
+  OpticiansEyeglasses = 'opticians_eyeglasses',
+  OptometristsOphthalmologist = 'optometrists_ophthalmologist',
+  OrthopedicGoodsProstheticDevices = 'orthopedic_goods_prosthetic_devices',
+  Osteopaths = 'osteopaths',
+  PackageStoresBeerWineAndLiquor = 'package_stores_beer_wine_and_liquor',
+  PaintsVarnishesAndSupplies = 'paints_varnishes_and_supplies',
+  ParkingLotsGarages = 'parking_lots_garages',
+  PassengerRailways = 'passenger_railways',
+  PawnShops = 'pawn_shops',
+  PetShopsPetFoodAndSupplies = 'pet_shops_pet_food_and_supplies',
+  PetroleumAndPetroleumProducts = 'petroleum_and_petroleum_products',
+  PhotoDeveloping = 'photo_developing',
+  PhotographicPhotocopyMicrofilmEquipmentAndSupplies = 'photographic_photocopy_microfilm_equipment_and_supplies',
+  PhotographicStudios = 'photographic_studios',
+  PictureVideoProduction = 'picture_video_production',
+  PieceGoodsNotionsAndOtherDryGoods = 'piece_goods_notions_and_other_dry_goods',
+  PlumbingHeatingEquipmentAndSupplies = 'plumbing_heating_equipment_and_supplies',
+  PoliticalOrganizations = 'political_organizations',
+  PostalServicesGovernmentOnly = 'postal_services_government_only',
+  PreciousStonesAndMetalsWatchesAndJewelry = 'precious_stones_and_metals_watches_and_jewelry',
+  ProfessionalServices = 'professional_services',
+  PublicWarehousingAndStorage = 'public_warehousing_and_storage',
+  QuickCopyReproAndBlueprint = 'quick_copy_repro_and_blueprint',
+  Railroads = 'railroads',
+  RealEstateAgentsAndManagersRentals = 'real_estate_agents_and_managers_rentals',
+  RecordStores = 'record_stores',
+  RecreationalVehicleRentals = 'recreational_vehicle_rentals',
+  ReligiousGoodsStores = 'religious_goods_stores',
+  ReligiousOrganizations = 'religious_organizations',
+  RoofingSidingSheetMetal = 'roofing_siding_sheet_metal',
+  SecretarialSupportServices = 'secretarial_support_services',
+  SecurityBrokersDealers = 'security_brokers_dealers',
+  ServiceStations = 'service_stations',
+  SewingNeedleworkFabricAndPieceGoodsStores = 'sewing_needlework_fabric_and_piece_goods_stores',
+  ShoeRepairHatCleaning = 'shoe_repair_hat_cleaning',
+  ShoeStores = 'shoe_stores',
+  SmallApplianceRepair = 'small_appliance_repair',
+  SnowmobileDealers = 'snowmobile_dealers',
+  SpecialTradeServices = 'special_trade_services',
+  SpecialtyCleaning = 'specialty_cleaning',
+  SportingGoodsStores = 'sporting_goods_stores',
+  SportingRecreationCamps = 'sporting_recreation_camps',
+  SportsAndRidingApparelStores = 'sports_and_riding_apparel_stores',
+  SportsClubsFields = 'sports_clubs_fields',
+  StampAndCoinStores = 'stamp_and_coin_stores',
+  StationaryOfficeSuppliesPrintingAndWritingPaper = 'stationary_office_supplies_printing_and_writing_paper',
+  StationeryStoresOfficeAndSchoolSupplyStores = 'stationery_stores_office_and_school_supply_stores',
+  SwimmingPoolsSales = 'swimming_pools_sales',
+  TUiTravelGermany = 't_ui_travel_germany',
+  TailorsAlterations = 'tailors_alterations',
+  TaxPaymentsGovernmentAgencies = 'tax_payments_government_agencies',
+  TaxPreparationServices = 'tax_preparation_services',
+  TaxicabsLimousines = 'taxicabs_limousines',
+  TelecommunicationEquipmentAndTelephoneSales = 'telecommunication_equipment_and_telephone_sales',
+  TelecommunicationServices = 'telecommunication_services',
+  TelegraphServices = 'telegraph_services',
+  TentAndAwningShops = 'tent_and_awning_shops',
+  TestingLaboratories = 'testing_laboratories',
+  TheatricalTicketAgencies = 'theatrical_ticket_agencies',
+  Timeshares = 'timeshares',
+  TireRetreadingAndRepair = 'tire_retreading_and_repair',
+  TollsBridgeFees = 'tolls_bridge_fees',
+  TouristAttractionsAndExhibits = 'tourist_attractions_and_exhibits',
+  TowingServices = 'towing_services',
+  TrailerParksCampgrounds = 'trailer_parks_campgrounds',
+  TransportationServices = 'transportation_services',
+  TravelAgenciesTourOperators = 'travel_agencies_tour_operators',
+  TruckStopIteration = 'truck_stop_iteration',
+  TruckUtilityTrailerRentals = 'truck_utility_trailer_rentals',
+  TypesettingPlateMakingAndRelatedServices = 'typesetting_plate_making_and_related_services',
+  TypewriterStores = 'typewriter_stores',
+  USFederalGovernmentAgenciesOrDepartments = 'u_s_federal_government_agencies_or_departments',
+  UniformsCommercialClothing = 'uniforms_commercial_clothing',
+  UsedMerchandiseAndSecondhandStores = 'used_merchandise_and_secondhand_stores',
+  Utilities = 'utilities',
+  VarietyStores = 'variety_stores',
+  VeterinaryServices = 'veterinary_services',
+  VideoAmusementGameSupplies = 'video_amusement_game_supplies',
+  VideoGameArcades = 'video_game_arcades',
+  VideoTapeRentalStores = 'video_tape_rental_stores',
+  VocationalTradeSchools = 'vocational_trade_schools',
+  WatchJewelryRepair = 'watch_jewelry_repair',
+  WeldingRepair = 'welding_repair',
+  WholesaleClubs = 'wholesale_clubs',
+  WigAndToupeeStores = 'wig_and_toupee_stores',
+  WiresMoneyOrders = 'wires_money_orders',
+  WomensAccessoryAndSpecialtyShops = 'womens_accessory_and_specialty_shops',
+  WomensReadyToWearStores = 'womens_ready_to_wear_stores',
+  WreckingAndSalvageYards = 'wrecking_and_salvage_yards'
+}
+
+export type Stripe_IssuingCardholderSpendingLimit = {
+  __typename?: 'Stripe_IssuingCardholderSpendingLimit';
+  /** Maximum amount allowed to spend per interval. */
+  amount?: Maybe<Scalars['Int']>;
+  /** Array of strings containing [categories](https://stripe.com/docs/api#issuing_authorization_object-merchant_data-category) this limit applies to. Omitting this field will apply the limit to all categories. */
+  categories?: Maybe<Array<Maybe<Stripe_IssuingCardholderSpendingLimitCategoriesProperty>>>;
+  /** Interval (or event) to which the amount applies. */
+  interval?: Maybe<Stripe_IssuingCardholderSpendingLimitIntervalProperty>;
+};
+
+export enum Stripe_IssuingCardholderSpendingLimitCategoriesProperty {
+  AcRefrigerationRepair = 'ac_refrigeration_repair',
+  AccountingBookkeepingServices = 'accounting_bookkeeping_services',
+  AdvertisingServices = 'advertising_services',
+  AgriculturalCooperative = 'agricultural_cooperative',
+  AirlinesAirCarriers = 'airlines_air_carriers',
+  AirportsFlyingFields = 'airports_flying_fields',
+  AmbulanceServices = 'ambulance_services',
+  AmusementParksCarnivals = 'amusement_parks_carnivals',
+  AntiqueReproductions = 'antique_reproductions',
+  AntiqueShops = 'antique_shops',
+  Aquariums = 'aquariums',
+  ArchitecturalSurveyingServices = 'architectural_surveying_services',
+  ArtDealersAndGalleries = 'art_dealers_and_galleries',
+  ArtistsSupplyAndCraftShops = 'artists_supply_and_craft_shops',
+  AutoAndHomeSupplyStores = 'auto_and_home_supply_stores',
+  AutoBodyRepairShops = 'auto_body_repair_shops',
+  AutoPaintShops = 'auto_paint_shops',
+  AutoServiceShops = 'auto_service_shops',
+  AutomatedCashDisburse = 'automated_cash_disburse',
+  AutomatedFuelDispensers = 'automated_fuel_dispensers',
+  AutomobileAssociations = 'automobile_associations',
+  AutomotivePartsAndAccessoriesStores = 'automotive_parts_and_accessories_stores',
+  AutomotiveTireStores = 'automotive_tire_stores',
+  BailAndBondPayments = 'bail_and_bond_payments',
+  Bakeries = 'bakeries',
+  BandsOrchestras = 'bands_orchestras',
+  BarberAndBeautyShops = 'barber_and_beauty_shops',
+  BettingCasinoGambling = 'betting_casino_gambling',
+  BicycleShops = 'bicycle_shops',
+  BilliardPoolEstablishments = 'billiard_pool_establishments',
+  BoatDealers = 'boat_dealers',
+  BoatRentalsAndLeases = 'boat_rentals_and_leases',
+  BookStores = 'book_stores',
+  BooksPeriodicalsAndNewspapers = 'books_periodicals_and_newspapers',
+  BowlingAlleys = 'bowling_alleys',
+  BusLines = 'bus_lines',
+  BusinessSecretarialSchools = 'business_secretarial_schools',
+  BuyingShoppingServices = 'buying_shopping_services',
+  CableSatelliteAndOtherPayTelevisionAndRadio = 'cable_satellite_and_other_pay_television_and_radio',
+  CameraAndPhotographicSupplyStores = 'camera_and_photographic_supply_stores',
+  CandyNutAndConfectioneryStores = 'candy_nut_and_confectionery_stores',
+  CarAndTruckDealersNewUsed = 'car_and_truck_dealers_new_used',
+  CarAndTruckDealersUsedOnly = 'car_and_truck_dealers_used_only',
+  CarRentalAgencies = 'car_rental_agencies',
+  CarWashes = 'car_washes',
+  CarpentryServices = 'carpentry_services',
+  CarpetUpholsteryCleaning = 'carpet_upholstery_cleaning',
+  Caterers = 'caterers',
+  CharitableAndSocialServiceOrganizationsFundraising = 'charitable_and_social_service_organizations_fundraising',
+  ChemicalsAndAlliedProducts = 'chemicals_and_allied_products',
+  ChildCareServices = 'child_care_services',
+  ChildrensAndInfantsWearStores = 'childrens_and_infants_wear_stores',
+  ChiropodistsPodiatrists = 'chiropodists_podiatrists',
+  Chiropractors = 'chiropractors',
+  CigarStoresAndStands = 'cigar_stores_and_stands',
+  CivicSocialFraternalAssociations = 'civic_social_fraternal_associations',
+  CleaningAndMaintenance = 'cleaning_and_maintenance',
+  ClothingRental = 'clothing_rental',
+  CollegesUniversities = 'colleges_universities',
+  CommercialEquipment = 'commercial_equipment',
+  CommercialFootwear = 'commercial_footwear',
+  CommercialPhotographyArtAndGraphics = 'commercial_photography_art_and_graphics',
+  CommuterTransportAndFerries = 'commuter_transport_and_ferries',
+  ComputerNetworkServices = 'computer_network_services',
+  ComputerProgramming = 'computer_programming',
+  ComputerRepair = 'computer_repair',
+  ComputerSoftwareStores = 'computer_software_stores',
+  ComputersPeripheralsAndSoftware = 'computers_peripherals_and_software',
+  ConcreteWorkServices = 'concrete_work_services',
+  ConstructionMaterials = 'construction_materials',
+  ConsultingPublicRelations = 'consulting_public_relations',
+  CorrespondenceSchools = 'correspondence_schools',
+  CosmeticStores = 'cosmetic_stores',
+  CounselingServices = 'counseling_services',
+  CountryClubs = 'country_clubs',
+  CourierServices = 'courier_services',
+  CourtCosts = 'court_costs',
+  CreditReportingAgencies = 'credit_reporting_agencies',
+  CruiseLines = 'cruise_lines',
+  DairyProductsStores = 'dairy_products_stores',
+  DanceHallStudiosSchools = 'dance_hall_studios_schools',
+  DatingEscortServices = 'dating_escort_services',
+  DentistsOrthodontists = 'dentists_orthodontists',
+  DepartmentStores = 'department_stores',
+  DetectiveAgencies = 'detective_agencies',
+  DigitalGoodsApplications = 'digital_goods_applications',
+  DigitalGoodsGames = 'digital_goods_games',
+  DigitalGoodsLargeVolume = 'digital_goods_large_volume',
+  DigitalGoodsMedia = 'digital_goods_media',
+  DirectMarketingCatalogMerchant = 'direct_marketing_catalog_merchant',
+  DirectMarketingCombinationCatalogAndRetailMerchant = 'direct_marketing_combination_catalog_and_retail_merchant',
+  DirectMarketingInboundTelemarketing = 'direct_marketing_inbound_telemarketing',
+  DirectMarketingInsuranceServices = 'direct_marketing_insurance_services',
+  DirectMarketingOther = 'direct_marketing_other',
+  DirectMarketingOutboundTelemarketing = 'direct_marketing_outbound_telemarketing',
+  DirectMarketingSubscription = 'direct_marketing_subscription',
+  DirectMarketingTravel = 'direct_marketing_travel',
+  DiscountStores = 'discount_stores',
+  Doctors = 'doctors',
+  DoorToDoorSales = 'door_to_door_sales',
+  DraperyWindowCoveringAndUpholsteryStores = 'drapery_window_covering_and_upholstery_stores',
+  DrinkingPlaces = 'drinking_places',
+  DrugStoresAndPharmacies = 'drug_stores_and_pharmacies',
+  DrugsDrugProprietariesAndDruggistSundries = 'drugs_drug_proprietaries_and_druggist_sundries',
+  DryCleaners = 'dry_cleaners',
+  DurableGoods = 'durable_goods',
+  DutyFreeStores = 'duty_free_stores',
+  EatingPlacesRestaurants = 'eating_places_restaurants',
+  EducationalServices = 'educational_services',
+  ElectricRazorStores = 'electric_razor_stores',
+  ElectricalPartsAndEquipment = 'electrical_parts_and_equipment',
+  ElectricalServices = 'electrical_services',
+  ElectronicsRepairShops = 'electronics_repair_shops',
+  ElectronicsStores = 'electronics_stores',
+  ElementarySecondarySchools = 'elementary_secondary_schools',
+  EmploymentTempAgencies = 'employment_temp_agencies',
+  EquipmentRental = 'equipment_rental',
+  ExterminatingServices = 'exterminating_services',
+  FamilyClothingStores = 'family_clothing_stores',
+  FastFoodRestaurants = 'fast_food_restaurants',
+  FinancialInstitutions = 'financial_institutions',
+  FinesGovernmentAdministrativeEntities = 'fines_government_administrative_entities',
+  FireplaceFireplaceScreensAndAccessoriesStores = 'fireplace_fireplace_screens_and_accessories_stores',
+  FloorCoveringStores = 'floor_covering_stores',
+  Florists = 'florists',
+  FloristsSuppliesNurseryStockAndFlowers = 'florists_supplies_nursery_stock_and_flowers',
+  FreezerAndLockerMeatProvisioners = 'freezer_and_locker_meat_provisioners',
+  FuelDealersNonAutomotive = 'fuel_dealers_non_automotive',
+  FuneralServicesCrematories = 'funeral_services_crematories',
+  FurnitureHomeFurnishingsAndEquipmentStoresExceptAppliances = 'furniture_home_furnishings_and_equipment_stores_except_appliances',
+  FurnitureRepairRefinishing = 'furniture_repair_refinishing',
+  FurriersAndFurShops = 'furriers_and_fur_shops',
+  GeneralServices = 'general_services',
+  GiftCardNoveltyAndSouvenirShops = 'gift_card_novelty_and_souvenir_shops',
+  GlassPaintAndWallpaperStores = 'glass_paint_and_wallpaper_stores',
+  GlasswareCrystalStores = 'glassware_crystal_stores',
+  GolfCoursesPublic = 'golf_courses_public',
+  GovernmentServices = 'government_services',
+  GroceryStoresSupermarkets = 'grocery_stores_supermarkets',
+  HardwareEquipmentAndSupplies = 'hardware_equipment_and_supplies',
+  HardwareStores = 'hardware_stores',
+  HealthAndBeautySpas = 'health_and_beauty_spas',
+  HearingAidsSalesAndSupplies = 'hearing_aids_sales_and_supplies',
+  HeatingPlumbingAC = 'heating_plumbing_a_c',
+  HobbyToyAndGameShops = 'hobby_toy_and_game_shops',
+  HomeSupplyWarehouseStores = 'home_supply_warehouse_stores',
+  Hospitals = 'hospitals',
+  HotelsMotelsAndResorts = 'hotels_motels_and_resorts',
+  HouseholdApplianceStores = 'household_appliance_stores',
+  IndustrialSupplies = 'industrial_supplies',
+  InformationRetrievalServices = 'information_retrieval_services',
+  InsuranceDefault = 'insurance_default',
+  InsuranceUnderwritingPremiums = 'insurance_underwriting_premiums',
+  IntraCompanyPurchases = 'intra_company_purchases',
+  JewelryStoresWatchesClocksAndSilverwareStores = 'jewelry_stores_watches_clocks_and_silverware_stores',
+  LandscapingServices = 'landscaping_services',
+  Laundries = 'laundries',
+  LaundryCleaningServices = 'laundry_cleaning_services',
+  LegalServicesAttorneys = 'legal_services_attorneys',
+  LuggageAndLeatherGoodsStores = 'luggage_and_leather_goods_stores',
+  LumberBuildingMaterialsStores = 'lumber_building_materials_stores',
+  ManualCashDisburse = 'manual_cash_disburse',
+  MarinasServiceAndSupplies = 'marinas_service_and_supplies',
+  MasonryStoneworkAndPlaster = 'masonry_stonework_and_plaster',
+  MassageParlors = 'massage_parlors',
+  MedicalAndDentalLabs = 'medical_and_dental_labs',
+  MedicalDentalOphthalmicAndHospitalEquipmentAndSupplies = 'medical_dental_ophthalmic_and_hospital_equipment_and_supplies',
+  MedicalServices = 'medical_services',
+  MembershipOrganizations = 'membership_organizations',
+  MensAndBoysClothingAndAccessoriesStores = 'mens_and_boys_clothing_and_accessories_stores',
+  MensWomensClothingStores = 'mens_womens_clothing_stores',
+  MetalServiceCenters = 'metal_service_centers',
+  Miscellaneous = 'miscellaneous',
+  MiscellaneousApparelAndAccessoryShops = 'miscellaneous_apparel_and_accessory_shops',
+  MiscellaneousAutoDealers = 'miscellaneous_auto_dealers',
+  MiscellaneousBusinessServices = 'miscellaneous_business_services',
+  MiscellaneousFoodStores = 'miscellaneous_food_stores',
+  MiscellaneousGeneralMerchandise = 'miscellaneous_general_merchandise',
+  MiscellaneousGeneralServices = 'miscellaneous_general_services',
+  MiscellaneousHomeFurnishingSpecialtyStores = 'miscellaneous_home_furnishing_specialty_stores',
+  MiscellaneousPublishingAndPrinting = 'miscellaneous_publishing_and_printing',
+  MiscellaneousRecreationServices = 'miscellaneous_recreation_services',
+  MiscellaneousRepairShops = 'miscellaneous_repair_shops',
+  MiscellaneousSpecialtyRetail = 'miscellaneous_specialty_retail',
+  MobileHomeDealers = 'mobile_home_dealers',
+  MotionPictureTheaters = 'motion_picture_theaters',
+  MotorFreightCarriersAndTrucking = 'motor_freight_carriers_and_trucking',
+  MotorHomesDealers = 'motor_homes_dealers',
+  MotorVehicleSuppliesAndNewParts = 'motor_vehicle_supplies_and_new_parts',
+  MotorcycleShopsAndDealers = 'motorcycle_shops_and_dealers',
+  MotorcycleShopsDealers = 'motorcycle_shops_dealers',
+  MusicStoresMusicalInstrumentsPianosAndSheetMusic = 'music_stores_musical_instruments_pianos_and_sheet_music',
+  NewsDealersAndNewsstands = 'news_dealers_and_newsstands',
+  NonFiMoneyOrders = 'non_fi_money_orders',
+  NonFiStoredValueCardPurchaseLoad = 'non_fi_stored_value_card_purchase_load',
+  NondurableGoods = 'nondurable_goods',
+  NurseriesLawnAndGardenSupplyStores = 'nurseries_lawn_and_garden_supply_stores',
+  NursingPersonalCare = 'nursing_personal_care',
+  OfficeAndCommercialFurniture = 'office_and_commercial_furniture',
+  OpticiansEyeglasses = 'opticians_eyeglasses',
+  OptometristsOphthalmologist = 'optometrists_ophthalmologist',
+  OrthopedicGoodsProstheticDevices = 'orthopedic_goods_prosthetic_devices',
+  Osteopaths = 'osteopaths',
+  PackageStoresBeerWineAndLiquor = 'package_stores_beer_wine_and_liquor',
+  PaintsVarnishesAndSupplies = 'paints_varnishes_and_supplies',
+  ParkingLotsGarages = 'parking_lots_garages',
+  PassengerRailways = 'passenger_railways',
+  PawnShops = 'pawn_shops',
+  PetShopsPetFoodAndSupplies = 'pet_shops_pet_food_and_supplies',
+  PetroleumAndPetroleumProducts = 'petroleum_and_petroleum_products',
+  PhotoDeveloping = 'photo_developing',
+  PhotographicPhotocopyMicrofilmEquipmentAndSupplies = 'photographic_photocopy_microfilm_equipment_and_supplies',
+  PhotographicStudios = 'photographic_studios',
+  PictureVideoProduction = 'picture_video_production',
+  PieceGoodsNotionsAndOtherDryGoods = 'piece_goods_notions_and_other_dry_goods',
+  PlumbingHeatingEquipmentAndSupplies = 'plumbing_heating_equipment_and_supplies',
+  PoliticalOrganizations = 'political_organizations',
+  PostalServicesGovernmentOnly = 'postal_services_government_only',
+  PreciousStonesAndMetalsWatchesAndJewelry = 'precious_stones_and_metals_watches_and_jewelry',
+  ProfessionalServices = 'professional_services',
+  PublicWarehousingAndStorage = 'public_warehousing_and_storage',
+  QuickCopyReproAndBlueprint = 'quick_copy_repro_and_blueprint',
+  Railroads = 'railroads',
+  RealEstateAgentsAndManagersRentals = 'real_estate_agents_and_managers_rentals',
+  RecordStores = 'record_stores',
+  RecreationalVehicleRentals = 'recreational_vehicle_rentals',
+  ReligiousGoodsStores = 'religious_goods_stores',
+  ReligiousOrganizations = 'religious_organizations',
+  RoofingSidingSheetMetal = 'roofing_siding_sheet_metal',
+  SecretarialSupportServices = 'secretarial_support_services',
+  SecurityBrokersDealers = 'security_brokers_dealers',
+  ServiceStations = 'service_stations',
+  SewingNeedleworkFabricAndPieceGoodsStores = 'sewing_needlework_fabric_and_piece_goods_stores',
+  ShoeRepairHatCleaning = 'shoe_repair_hat_cleaning',
+  ShoeStores = 'shoe_stores',
+  SmallApplianceRepair = 'small_appliance_repair',
+  SnowmobileDealers = 'snowmobile_dealers',
+  SpecialTradeServices = 'special_trade_services',
+  SpecialtyCleaning = 'specialty_cleaning',
+  SportingGoodsStores = 'sporting_goods_stores',
+  SportingRecreationCamps = 'sporting_recreation_camps',
+  SportsAndRidingApparelStores = 'sports_and_riding_apparel_stores',
+  SportsClubsFields = 'sports_clubs_fields',
+  StampAndCoinStores = 'stamp_and_coin_stores',
+  StationaryOfficeSuppliesPrintingAndWritingPaper = 'stationary_office_supplies_printing_and_writing_paper',
+  StationeryStoresOfficeAndSchoolSupplyStores = 'stationery_stores_office_and_school_supply_stores',
+  SwimmingPoolsSales = 'swimming_pools_sales',
+  TUiTravelGermany = 't_ui_travel_germany',
+  TailorsAlterations = 'tailors_alterations',
+  TaxPaymentsGovernmentAgencies = 'tax_payments_government_agencies',
+  TaxPreparationServices = 'tax_preparation_services',
+  TaxicabsLimousines = 'taxicabs_limousines',
+  TelecommunicationEquipmentAndTelephoneSales = 'telecommunication_equipment_and_telephone_sales',
+  TelecommunicationServices = 'telecommunication_services',
+  TelegraphServices = 'telegraph_services',
+  TentAndAwningShops = 'tent_and_awning_shops',
+  TestingLaboratories = 'testing_laboratories',
+  TheatricalTicketAgencies = 'theatrical_ticket_agencies',
+  Timeshares = 'timeshares',
+  TireRetreadingAndRepair = 'tire_retreading_and_repair',
+  TollsBridgeFees = 'tolls_bridge_fees',
+  TouristAttractionsAndExhibits = 'tourist_attractions_and_exhibits',
+  TowingServices = 'towing_services',
+  TrailerParksCampgrounds = 'trailer_parks_campgrounds',
+  TransportationServices = 'transportation_services',
+  TravelAgenciesTourOperators = 'travel_agencies_tour_operators',
+  TruckStopIteration = 'truck_stop_iteration',
+  TruckUtilityTrailerRentals = 'truck_utility_trailer_rentals',
+  TypesettingPlateMakingAndRelatedServices = 'typesetting_plate_making_and_related_services',
+  TypewriterStores = 'typewriter_stores',
+  USFederalGovernmentAgenciesOrDepartments = 'u_s_federal_government_agencies_or_departments',
+  UniformsCommercialClothing = 'uniforms_commercial_clothing',
+  UsedMerchandiseAndSecondhandStores = 'used_merchandise_and_secondhand_stores',
+  Utilities = 'utilities',
+  VarietyStores = 'variety_stores',
+  VeterinaryServices = 'veterinary_services',
+  VideoAmusementGameSupplies = 'video_amusement_game_supplies',
+  VideoGameArcades = 'video_game_arcades',
+  VideoTapeRentalStores = 'video_tape_rental_stores',
+  VocationalTradeSchools = 'vocational_trade_schools',
+  WatchJewelryRepair = 'watch_jewelry_repair',
+  WeldingRepair = 'welding_repair',
+  WholesaleClubs = 'wholesale_clubs',
+  WigAndToupeeStores = 'wig_and_toupee_stores',
+  WiresMoneyOrders = 'wires_money_orders',
+  WomensAccessoryAndSpecialtyShops = 'womens_accessory_and_specialty_shops',
+  WomensReadyToWearStores = 'womens_ready_to_wear_stores',
+  WreckingAndSalvageYards = 'wrecking_and_salvage_yards'
+}
+
+export enum Stripe_IssuingCardholderSpendingLimitIntervalProperty {
+  AllTime = 'all_time',
+  Daily = 'daily',
+  Monthly = 'monthly',
+  PerAuthorization = 'per_authorization',
+  Weekly = 'weekly',
+  Yearly = 'yearly'
+}
+
+export enum Stripe_IssuingCardholderStatusProperty {
+  Active = 'active',
+  Blocked = 'blocked',
+  Inactive = 'inactive'
+}
+
+export enum Stripe_IssuingCardholderTypeProperty {
+  Company = 'company',
+  Individual = 'individual'
+}
+
+export enum Stripe_IssuingCardObjectProperty {
+  IssuingDoTcard = 'issuingDOTcard'
+}
+
+export type Stripe_IssuingCardReplacedByProperty = WrappedString | Stripe_IssuingCard;
+
+export type Stripe_IssuingCardReplacementForProperty = WrappedString | Stripe_IssuingCard;
+
+export enum Stripe_IssuingCardReplacementReasonProperty {
+  Damaged = 'damaged',
+  Expired = 'expired',
+  Lost = 'lost',
+  Stolen = 'stolen'
+}
+
+export type Stripe_IssuingCardShipping = {
+  __typename?: 'Stripe_IssuingCardShipping';
+  address?: Maybe<Stripe_Address>;
+  /** The delivery company that shipped a card. */
+  carrier?: Maybe<Stripe_IssuingCardShippingCarrierProperty>;
+  /** A unix timestamp representing a best estimate of when the card will be delivered. */
+  eta?: Maybe<Scalars['Int']>;
+  /** Recipient name. */
+  name?: Maybe<Scalars['String']>;
+  /** Shipment service, such as `standard` or `express`. */
+  service?: Maybe<Stripe_IssuingCardShippingServiceProperty>;
+  /** The delivery status of the card. */
+  status?: Maybe<Stripe_IssuingCardShippingStatusProperty>;
+  /** A tracking number for a card shipment. */
+  tracking_number?: Maybe<Scalars['String']>;
+  /** A link to the shipping carrier's site where you can view detailed information about a card shipment. */
+  tracking_url?: Maybe<Scalars['String']>;
+  /** Packaging options. */
+  type?: Maybe<Stripe_IssuingCardShippingTypeProperty>;
+};
+
+export enum Stripe_IssuingCardShippingCarrierProperty {
+  Dhl = 'dhl',
+  Fedex = 'fedex',
+  RoyalMail = 'royal_mail',
+  Usps = 'usps'
+}
+
+export enum Stripe_IssuingCardShippingServiceProperty {
+  Express = 'express',
+  Priority = 'priority',
+  Standard = 'standard'
+}
+
+export enum Stripe_IssuingCardShippingStatusProperty {
+  Canceled = 'canceled',
+  Delivered = 'delivered',
+  Failure = 'failure',
+  Pending = 'pending',
+  Returned = 'returned',
+  Shipped = 'shipped'
+}
+
+export enum Stripe_IssuingCardShippingTypeProperty {
+  Bulk = 'bulk',
+  Individual = 'individual'
+}
+
+export type Stripe_IssuingCardAuthorizationControls = {
+  __typename?: 'Stripe_IssuingCardAuthorizationControls';
+  /** Array of strings containing [categories](https://stripe.com/docs/api#issuing_authorization_object-merchant_data-category) of authorizations to allow. All other categories will be blocked. Cannot be set with `blocked_categories`. */
+  allowed_categories?: Maybe<Array<Maybe<Stripe_IssuingCardAuthorizationControlsAllowedCategoriesProperty>>>;
+  /** Array of strings containing [categories](https://stripe.com/docs/api#issuing_authorization_object-merchant_data-category) of authorizations to decline. All other categories will be allowed. Cannot be set with `allowed_categories`. */
+  blocked_categories?: Maybe<Array<Maybe<Stripe_IssuingCardAuthorizationControlsBlockedCategoriesProperty>>>;
+  /** Limit spending with amount-based rules that apply across any cards this card replaced (i.e., its `replacement_for` card and _that_ card's `replacement_for` card, up the chain). */
+  spending_limits?: Maybe<Array<Maybe<Stripe_IssuingCardSpendingLimit>>>;
+  /** Currency of the amounts within `spending_limits`. Always the same as the currency of the card. */
+  spending_limits_currency?: Maybe<Scalars['String']>;
+};
+
+export enum Stripe_IssuingCardAuthorizationControlsAllowedCategoriesProperty {
+  AcRefrigerationRepair = 'ac_refrigeration_repair',
+  AccountingBookkeepingServices = 'accounting_bookkeeping_services',
+  AdvertisingServices = 'advertising_services',
+  AgriculturalCooperative = 'agricultural_cooperative',
+  AirlinesAirCarriers = 'airlines_air_carriers',
+  AirportsFlyingFields = 'airports_flying_fields',
+  AmbulanceServices = 'ambulance_services',
+  AmusementParksCarnivals = 'amusement_parks_carnivals',
+  AntiqueReproductions = 'antique_reproductions',
+  AntiqueShops = 'antique_shops',
+  Aquariums = 'aquariums',
+  ArchitecturalSurveyingServices = 'architectural_surveying_services',
+  ArtDealersAndGalleries = 'art_dealers_and_galleries',
+  ArtistsSupplyAndCraftShops = 'artists_supply_and_craft_shops',
+  AutoAndHomeSupplyStores = 'auto_and_home_supply_stores',
+  AutoBodyRepairShops = 'auto_body_repair_shops',
+  AutoPaintShops = 'auto_paint_shops',
+  AutoServiceShops = 'auto_service_shops',
+  AutomatedCashDisburse = 'automated_cash_disburse',
+  AutomatedFuelDispensers = 'automated_fuel_dispensers',
+  AutomobileAssociations = 'automobile_associations',
+  AutomotivePartsAndAccessoriesStores = 'automotive_parts_and_accessories_stores',
+  AutomotiveTireStores = 'automotive_tire_stores',
+  BailAndBondPayments = 'bail_and_bond_payments',
+  Bakeries = 'bakeries',
+  BandsOrchestras = 'bands_orchestras',
+  BarberAndBeautyShops = 'barber_and_beauty_shops',
+  BettingCasinoGambling = 'betting_casino_gambling',
+  BicycleShops = 'bicycle_shops',
+  BilliardPoolEstablishments = 'billiard_pool_establishments',
+  BoatDealers = 'boat_dealers',
+  BoatRentalsAndLeases = 'boat_rentals_and_leases',
+  BookStores = 'book_stores',
+  BooksPeriodicalsAndNewspapers = 'books_periodicals_and_newspapers',
+  BowlingAlleys = 'bowling_alleys',
+  BusLines = 'bus_lines',
+  BusinessSecretarialSchools = 'business_secretarial_schools',
+  BuyingShoppingServices = 'buying_shopping_services',
+  CableSatelliteAndOtherPayTelevisionAndRadio = 'cable_satellite_and_other_pay_television_and_radio',
+  CameraAndPhotographicSupplyStores = 'camera_and_photographic_supply_stores',
+  CandyNutAndConfectioneryStores = 'candy_nut_and_confectionery_stores',
+  CarAndTruckDealersNewUsed = 'car_and_truck_dealers_new_used',
+  CarAndTruckDealersUsedOnly = 'car_and_truck_dealers_used_only',
+  CarRentalAgencies = 'car_rental_agencies',
+  CarWashes = 'car_washes',
+  CarpentryServices = 'carpentry_services',
+  CarpetUpholsteryCleaning = 'carpet_upholstery_cleaning',
+  Caterers = 'caterers',
+  CharitableAndSocialServiceOrganizationsFundraising = 'charitable_and_social_service_organizations_fundraising',
+  ChemicalsAndAlliedProducts = 'chemicals_and_allied_products',
+  ChildCareServices = 'child_care_services',
+  ChildrensAndInfantsWearStores = 'childrens_and_infants_wear_stores',
+  ChiropodistsPodiatrists = 'chiropodists_podiatrists',
+  Chiropractors = 'chiropractors',
+  CigarStoresAndStands = 'cigar_stores_and_stands',
+  CivicSocialFraternalAssociations = 'civic_social_fraternal_associations',
+  CleaningAndMaintenance = 'cleaning_and_maintenance',
+  ClothingRental = 'clothing_rental',
+  CollegesUniversities = 'colleges_universities',
+  CommercialEquipment = 'commercial_equipment',
+  CommercialFootwear = 'commercial_footwear',
+  CommercialPhotographyArtAndGraphics = 'commercial_photography_art_and_graphics',
+  CommuterTransportAndFerries = 'commuter_transport_and_ferries',
+  ComputerNetworkServices = 'computer_network_services',
+  ComputerProgramming = 'computer_programming',
+  ComputerRepair = 'computer_repair',
+  ComputerSoftwareStores = 'computer_software_stores',
+  ComputersPeripheralsAndSoftware = 'computers_peripherals_and_software',
+  ConcreteWorkServices = 'concrete_work_services',
+  ConstructionMaterials = 'construction_materials',
+  ConsultingPublicRelations = 'consulting_public_relations',
+  CorrespondenceSchools = 'correspondence_schools',
+  CosmeticStores = 'cosmetic_stores',
+  CounselingServices = 'counseling_services',
+  CountryClubs = 'country_clubs',
+  CourierServices = 'courier_services',
+  CourtCosts = 'court_costs',
+  CreditReportingAgencies = 'credit_reporting_agencies',
+  CruiseLines = 'cruise_lines',
+  DairyProductsStores = 'dairy_products_stores',
+  DanceHallStudiosSchools = 'dance_hall_studios_schools',
+  DatingEscortServices = 'dating_escort_services',
+  DentistsOrthodontists = 'dentists_orthodontists',
+  DepartmentStores = 'department_stores',
+  DetectiveAgencies = 'detective_agencies',
+  DigitalGoodsApplications = 'digital_goods_applications',
+  DigitalGoodsGames = 'digital_goods_games',
+  DigitalGoodsLargeVolume = 'digital_goods_large_volume',
+  DigitalGoodsMedia = 'digital_goods_media',
+  DirectMarketingCatalogMerchant = 'direct_marketing_catalog_merchant',
+  DirectMarketingCombinationCatalogAndRetailMerchant = 'direct_marketing_combination_catalog_and_retail_merchant',
+  DirectMarketingInboundTelemarketing = 'direct_marketing_inbound_telemarketing',
+  DirectMarketingInsuranceServices = 'direct_marketing_insurance_services',
+  DirectMarketingOther = 'direct_marketing_other',
+  DirectMarketingOutboundTelemarketing = 'direct_marketing_outbound_telemarketing',
+  DirectMarketingSubscription = 'direct_marketing_subscription',
+  DirectMarketingTravel = 'direct_marketing_travel',
+  DiscountStores = 'discount_stores',
+  Doctors = 'doctors',
+  DoorToDoorSales = 'door_to_door_sales',
+  DraperyWindowCoveringAndUpholsteryStores = 'drapery_window_covering_and_upholstery_stores',
+  DrinkingPlaces = 'drinking_places',
+  DrugStoresAndPharmacies = 'drug_stores_and_pharmacies',
+  DrugsDrugProprietariesAndDruggistSundries = 'drugs_drug_proprietaries_and_druggist_sundries',
+  DryCleaners = 'dry_cleaners',
+  DurableGoods = 'durable_goods',
+  DutyFreeStores = 'duty_free_stores',
+  EatingPlacesRestaurants = 'eating_places_restaurants',
+  EducationalServices = 'educational_services',
+  ElectricRazorStores = 'electric_razor_stores',
+  ElectricalPartsAndEquipment = 'electrical_parts_and_equipment',
+  ElectricalServices = 'electrical_services',
+  ElectronicsRepairShops = 'electronics_repair_shops',
+  ElectronicsStores = 'electronics_stores',
+  ElementarySecondarySchools = 'elementary_secondary_schools',
+  EmploymentTempAgencies = 'employment_temp_agencies',
+  EquipmentRental = 'equipment_rental',
+  ExterminatingServices = 'exterminating_services',
+  FamilyClothingStores = 'family_clothing_stores',
+  FastFoodRestaurants = 'fast_food_restaurants',
+  FinancialInstitutions = 'financial_institutions',
+  FinesGovernmentAdministrativeEntities = 'fines_government_administrative_entities',
+  FireplaceFireplaceScreensAndAccessoriesStores = 'fireplace_fireplace_screens_and_accessories_stores',
+  FloorCoveringStores = 'floor_covering_stores',
+  Florists = 'florists',
+  FloristsSuppliesNurseryStockAndFlowers = 'florists_supplies_nursery_stock_and_flowers',
+  FreezerAndLockerMeatProvisioners = 'freezer_and_locker_meat_provisioners',
+  FuelDealersNonAutomotive = 'fuel_dealers_non_automotive',
+  FuneralServicesCrematories = 'funeral_services_crematories',
+  FurnitureHomeFurnishingsAndEquipmentStoresExceptAppliances = 'furniture_home_furnishings_and_equipment_stores_except_appliances',
+  FurnitureRepairRefinishing = 'furniture_repair_refinishing',
+  FurriersAndFurShops = 'furriers_and_fur_shops',
+  GeneralServices = 'general_services',
+  GiftCardNoveltyAndSouvenirShops = 'gift_card_novelty_and_souvenir_shops',
+  GlassPaintAndWallpaperStores = 'glass_paint_and_wallpaper_stores',
+  GlasswareCrystalStores = 'glassware_crystal_stores',
+  GolfCoursesPublic = 'golf_courses_public',
+  GovernmentServices = 'government_services',
+  GroceryStoresSupermarkets = 'grocery_stores_supermarkets',
+  HardwareEquipmentAndSupplies = 'hardware_equipment_and_supplies',
+  HardwareStores = 'hardware_stores',
+  HealthAndBeautySpas = 'health_and_beauty_spas',
+  HearingAidsSalesAndSupplies = 'hearing_aids_sales_and_supplies',
+  HeatingPlumbingAC = 'heating_plumbing_a_c',
+  HobbyToyAndGameShops = 'hobby_toy_and_game_shops',
+  HomeSupplyWarehouseStores = 'home_supply_warehouse_stores',
+  Hospitals = 'hospitals',
+  HotelsMotelsAndResorts = 'hotels_motels_and_resorts',
+  HouseholdApplianceStores = 'household_appliance_stores',
+  IndustrialSupplies = 'industrial_supplies',
+  InformationRetrievalServices = 'information_retrieval_services',
+  InsuranceDefault = 'insurance_default',
+  InsuranceUnderwritingPremiums = 'insurance_underwriting_premiums',
+  IntraCompanyPurchases = 'intra_company_purchases',
+  JewelryStoresWatchesClocksAndSilverwareStores = 'jewelry_stores_watches_clocks_and_silverware_stores',
+  LandscapingServices = 'landscaping_services',
+  Laundries = 'laundries',
+  LaundryCleaningServices = 'laundry_cleaning_services',
+  LegalServicesAttorneys = 'legal_services_attorneys',
+  LuggageAndLeatherGoodsStores = 'luggage_and_leather_goods_stores',
+  LumberBuildingMaterialsStores = 'lumber_building_materials_stores',
+  ManualCashDisburse = 'manual_cash_disburse',
+  MarinasServiceAndSupplies = 'marinas_service_and_supplies',
+  MasonryStoneworkAndPlaster = 'masonry_stonework_and_plaster',
+  MassageParlors = 'massage_parlors',
+  MedicalAndDentalLabs = 'medical_and_dental_labs',
+  MedicalDentalOphthalmicAndHospitalEquipmentAndSupplies = 'medical_dental_ophthalmic_and_hospital_equipment_and_supplies',
+  MedicalServices = 'medical_services',
+  MembershipOrganizations = 'membership_organizations',
+  MensAndBoysClothingAndAccessoriesStores = 'mens_and_boys_clothing_and_accessories_stores',
+  MensWomensClothingStores = 'mens_womens_clothing_stores',
+  MetalServiceCenters = 'metal_service_centers',
+  Miscellaneous = 'miscellaneous',
+  MiscellaneousApparelAndAccessoryShops = 'miscellaneous_apparel_and_accessory_shops',
+  MiscellaneousAutoDealers = 'miscellaneous_auto_dealers',
+  MiscellaneousBusinessServices = 'miscellaneous_business_services',
+  MiscellaneousFoodStores = 'miscellaneous_food_stores',
+  MiscellaneousGeneralMerchandise = 'miscellaneous_general_merchandise',
+  MiscellaneousGeneralServices = 'miscellaneous_general_services',
+  MiscellaneousHomeFurnishingSpecialtyStores = 'miscellaneous_home_furnishing_specialty_stores',
+  MiscellaneousPublishingAndPrinting = 'miscellaneous_publishing_and_printing',
+  MiscellaneousRecreationServices = 'miscellaneous_recreation_services',
+  MiscellaneousRepairShops = 'miscellaneous_repair_shops',
+  MiscellaneousSpecialtyRetail = 'miscellaneous_specialty_retail',
+  MobileHomeDealers = 'mobile_home_dealers',
+  MotionPictureTheaters = 'motion_picture_theaters',
+  MotorFreightCarriersAndTrucking = 'motor_freight_carriers_and_trucking',
+  MotorHomesDealers = 'motor_homes_dealers',
+  MotorVehicleSuppliesAndNewParts = 'motor_vehicle_supplies_and_new_parts',
+  MotorcycleShopsAndDealers = 'motorcycle_shops_and_dealers',
+  MotorcycleShopsDealers = 'motorcycle_shops_dealers',
+  MusicStoresMusicalInstrumentsPianosAndSheetMusic = 'music_stores_musical_instruments_pianos_and_sheet_music',
+  NewsDealersAndNewsstands = 'news_dealers_and_newsstands',
+  NonFiMoneyOrders = 'non_fi_money_orders',
+  NonFiStoredValueCardPurchaseLoad = 'non_fi_stored_value_card_purchase_load',
+  NondurableGoods = 'nondurable_goods',
+  NurseriesLawnAndGardenSupplyStores = 'nurseries_lawn_and_garden_supply_stores',
+  NursingPersonalCare = 'nursing_personal_care',
+  OfficeAndCommercialFurniture = 'office_and_commercial_furniture',
+  OpticiansEyeglasses = 'opticians_eyeglasses',
+  OptometristsOphthalmologist = 'optometrists_ophthalmologist',
+  OrthopedicGoodsProstheticDevices = 'orthopedic_goods_prosthetic_devices',
+  Osteopaths = 'osteopaths',
+  PackageStoresBeerWineAndLiquor = 'package_stores_beer_wine_and_liquor',
+  PaintsVarnishesAndSupplies = 'paints_varnishes_and_supplies',
+  ParkingLotsGarages = 'parking_lots_garages',
+  PassengerRailways = 'passenger_railways',
+  PawnShops = 'pawn_shops',
+  PetShopsPetFoodAndSupplies = 'pet_shops_pet_food_and_supplies',
+  PetroleumAndPetroleumProducts = 'petroleum_and_petroleum_products',
+  PhotoDeveloping = 'photo_developing',
+  PhotographicPhotocopyMicrofilmEquipmentAndSupplies = 'photographic_photocopy_microfilm_equipment_and_supplies',
+  PhotographicStudios = 'photographic_studios',
+  PictureVideoProduction = 'picture_video_production',
+  PieceGoodsNotionsAndOtherDryGoods = 'piece_goods_notions_and_other_dry_goods',
+  PlumbingHeatingEquipmentAndSupplies = 'plumbing_heating_equipment_and_supplies',
+  PoliticalOrganizations = 'political_organizations',
+  PostalServicesGovernmentOnly = 'postal_services_government_only',
+  PreciousStonesAndMetalsWatchesAndJewelry = 'precious_stones_and_metals_watches_and_jewelry',
+  ProfessionalServices = 'professional_services',
+  PublicWarehousingAndStorage = 'public_warehousing_and_storage',
+  QuickCopyReproAndBlueprint = 'quick_copy_repro_and_blueprint',
+  Railroads = 'railroads',
+  RealEstateAgentsAndManagersRentals = 'real_estate_agents_and_managers_rentals',
+  RecordStores = 'record_stores',
+  RecreationalVehicleRentals = 'recreational_vehicle_rentals',
+  ReligiousGoodsStores = 'religious_goods_stores',
+  ReligiousOrganizations = 'religious_organizations',
+  RoofingSidingSheetMetal = 'roofing_siding_sheet_metal',
+  SecretarialSupportServices = 'secretarial_support_services',
+  SecurityBrokersDealers = 'security_brokers_dealers',
+  ServiceStations = 'service_stations',
+  SewingNeedleworkFabricAndPieceGoodsStores = 'sewing_needlework_fabric_and_piece_goods_stores',
+  ShoeRepairHatCleaning = 'shoe_repair_hat_cleaning',
+  ShoeStores = 'shoe_stores',
+  SmallApplianceRepair = 'small_appliance_repair',
+  SnowmobileDealers = 'snowmobile_dealers',
+  SpecialTradeServices = 'special_trade_services',
+  SpecialtyCleaning = 'specialty_cleaning',
+  SportingGoodsStores = 'sporting_goods_stores',
+  SportingRecreationCamps = 'sporting_recreation_camps',
+  SportsAndRidingApparelStores = 'sports_and_riding_apparel_stores',
+  SportsClubsFields = 'sports_clubs_fields',
+  StampAndCoinStores = 'stamp_and_coin_stores',
+  StationaryOfficeSuppliesPrintingAndWritingPaper = 'stationary_office_supplies_printing_and_writing_paper',
+  StationeryStoresOfficeAndSchoolSupplyStores = 'stationery_stores_office_and_school_supply_stores',
+  SwimmingPoolsSales = 'swimming_pools_sales',
+  TUiTravelGermany = 't_ui_travel_germany',
+  TailorsAlterations = 'tailors_alterations',
+  TaxPaymentsGovernmentAgencies = 'tax_payments_government_agencies',
+  TaxPreparationServices = 'tax_preparation_services',
+  TaxicabsLimousines = 'taxicabs_limousines',
+  TelecommunicationEquipmentAndTelephoneSales = 'telecommunication_equipment_and_telephone_sales',
+  TelecommunicationServices = 'telecommunication_services',
+  TelegraphServices = 'telegraph_services',
+  TentAndAwningShops = 'tent_and_awning_shops',
+  TestingLaboratories = 'testing_laboratories',
+  TheatricalTicketAgencies = 'theatrical_ticket_agencies',
+  Timeshares = 'timeshares',
+  TireRetreadingAndRepair = 'tire_retreading_and_repair',
+  TollsBridgeFees = 'tolls_bridge_fees',
+  TouristAttractionsAndExhibits = 'tourist_attractions_and_exhibits',
+  TowingServices = 'towing_services',
+  TrailerParksCampgrounds = 'trailer_parks_campgrounds',
+  TransportationServices = 'transportation_services',
+  TravelAgenciesTourOperators = 'travel_agencies_tour_operators',
+  TruckStopIteration = 'truck_stop_iteration',
+  TruckUtilityTrailerRentals = 'truck_utility_trailer_rentals',
+  TypesettingPlateMakingAndRelatedServices = 'typesetting_plate_making_and_related_services',
+  TypewriterStores = 'typewriter_stores',
+  USFederalGovernmentAgenciesOrDepartments = 'u_s_federal_government_agencies_or_departments',
+  UniformsCommercialClothing = 'uniforms_commercial_clothing',
+  UsedMerchandiseAndSecondhandStores = 'used_merchandise_and_secondhand_stores',
+  Utilities = 'utilities',
+  VarietyStores = 'variety_stores',
+  VeterinaryServices = 'veterinary_services',
+  VideoAmusementGameSupplies = 'video_amusement_game_supplies',
+  VideoGameArcades = 'video_game_arcades',
+  VideoTapeRentalStores = 'video_tape_rental_stores',
+  VocationalTradeSchools = 'vocational_trade_schools',
+  WatchJewelryRepair = 'watch_jewelry_repair',
+  WeldingRepair = 'welding_repair',
+  WholesaleClubs = 'wholesale_clubs',
+  WigAndToupeeStores = 'wig_and_toupee_stores',
+  WiresMoneyOrders = 'wires_money_orders',
+  WomensAccessoryAndSpecialtyShops = 'womens_accessory_and_specialty_shops',
+  WomensReadyToWearStores = 'womens_ready_to_wear_stores',
+  WreckingAndSalvageYards = 'wrecking_and_salvage_yards'
+}
+
+export enum Stripe_IssuingCardAuthorizationControlsBlockedCategoriesProperty {
+  AcRefrigerationRepair = 'ac_refrigeration_repair',
+  AccountingBookkeepingServices = 'accounting_bookkeeping_services',
+  AdvertisingServices = 'advertising_services',
+  AgriculturalCooperative = 'agricultural_cooperative',
+  AirlinesAirCarriers = 'airlines_air_carriers',
+  AirportsFlyingFields = 'airports_flying_fields',
+  AmbulanceServices = 'ambulance_services',
+  AmusementParksCarnivals = 'amusement_parks_carnivals',
+  AntiqueReproductions = 'antique_reproductions',
+  AntiqueShops = 'antique_shops',
+  Aquariums = 'aquariums',
+  ArchitecturalSurveyingServices = 'architectural_surveying_services',
+  ArtDealersAndGalleries = 'art_dealers_and_galleries',
+  ArtistsSupplyAndCraftShops = 'artists_supply_and_craft_shops',
+  AutoAndHomeSupplyStores = 'auto_and_home_supply_stores',
+  AutoBodyRepairShops = 'auto_body_repair_shops',
+  AutoPaintShops = 'auto_paint_shops',
+  AutoServiceShops = 'auto_service_shops',
+  AutomatedCashDisburse = 'automated_cash_disburse',
+  AutomatedFuelDispensers = 'automated_fuel_dispensers',
+  AutomobileAssociations = 'automobile_associations',
+  AutomotivePartsAndAccessoriesStores = 'automotive_parts_and_accessories_stores',
+  AutomotiveTireStores = 'automotive_tire_stores',
+  BailAndBondPayments = 'bail_and_bond_payments',
+  Bakeries = 'bakeries',
+  BandsOrchestras = 'bands_orchestras',
+  BarberAndBeautyShops = 'barber_and_beauty_shops',
+  BettingCasinoGambling = 'betting_casino_gambling',
+  BicycleShops = 'bicycle_shops',
+  BilliardPoolEstablishments = 'billiard_pool_establishments',
+  BoatDealers = 'boat_dealers',
+  BoatRentalsAndLeases = 'boat_rentals_and_leases',
+  BookStores = 'book_stores',
+  BooksPeriodicalsAndNewspapers = 'books_periodicals_and_newspapers',
+  BowlingAlleys = 'bowling_alleys',
+  BusLines = 'bus_lines',
+  BusinessSecretarialSchools = 'business_secretarial_schools',
+  BuyingShoppingServices = 'buying_shopping_services',
+  CableSatelliteAndOtherPayTelevisionAndRadio = 'cable_satellite_and_other_pay_television_and_radio',
+  CameraAndPhotographicSupplyStores = 'camera_and_photographic_supply_stores',
+  CandyNutAndConfectioneryStores = 'candy_nut_and_confectionery_stores',
+  CarAndTruckDealersNewUsed = 'car_and_truck_dealers_new_used',
+  CarAndTruckDealersUsedOnly = 'car_and_truck_dealers_used_only',
+  CarRentalAgencies = 'car_rental_agencies',
+  CarWashes = 'car_washes',
+  CarpentryServices = 'carpentry_services',
+  CarpetUpholsteryCleaning = 'carpet_upholstery_cleaning',
+  Caterers = 'caterers',
+  CharitableAndSocialServiceOrganizationsFundraising = 'charitable_and_social_service_organizations_fundraising',
+  ChemicalsAndAlliedProducts = 'chemicals_and_allied_products',
+  ChildCareServices = 'child_care_services',
+  ChildrensAndInfantsWearStores = 'childrens_and_infants_wear_stores',
+  ChiropodistsPodiatrists = 'chiropodists_podiatrists',
+  Chiropractors = 'chiropractors',
+  CigarStoresAndStands = 'cigar_stores_and_stands',
+  CivicSocialFraternalAssociations = 'civic_social_fraternal_associations',
+  CleaningAndMaintenance = 'cleaning_and_maintenance',
+  ClothingRental = 'clothing_rental',
+  CollegesUniversities = 'colleges_universities',
+  CommercialEquipment = 'commercial_equipment',
+  CommercialFootwear = 'commercial_footwear',
+  CommercialPhotographyArtAndGraphics = 'commercial_photography_art_and_graphics',
+  CommuterTransportAndFerries = 'commuter_transport_and_ferries',
+  ComputerNetworkServices = 'computer_network_services',
+  ComputerProgramming = 'computer_programming',
+  ComputerRepair = 'computer_repair',
+  ComputerSoftwareStores = 'computer_software_stores',
+  ComputersPeripheralsAndSoftware = 'computers_peripherals_and_software',
+  ConcreteWorkServices = 'concrete_work_services',
+  ConstructionMaterials = 'construction_materials',
+  ConsultingPublicRelations = 'consulting_public_relations',
+  CorrespondenceSchools = 'correspondence_schools',
+  CosmeticStores = 'cosmetic_stores',
+  CounselingServices = 'counseling_services',
+  CountryClubs = 'country_clubs',
+  CourierServices = 'courier_services',
+  CourtCosts = 'court_costs',
+  CreditReportingAgencies = 'credit_reporting_agencies',
+  CruiseLines = 'cruise_lines',
+  DairyProductsStores = 'dairy_products_stores',
+  DanceHallStudiosSchools = 'dance_hall_studios_schools',
+  DatingEscortServices = 'dating_escort_services',
+  DentistsOrthodontists = 'dentists_orthodontists',
+  DepartmentStores = 'department_stores',
+  DetectiveAgencies = 'detective_agencies',
+  DigitalGoodsApplications = 'digital_goods_applications',
+  DigitalGoodsGames = 'digital_goods_games',
+  DigitalGoodsLargeVolume = 'digital_goods_large_volume',
+  DigitalGoodsMedia = 'digital_goods_media',
+  DirectMarketingCatalogMerchant = 'direct_marketing_catalog_merchant',
+  DirectMarketingCombinationCatalogAndRetailMerchant = 'direct_marketing_combination_catalog_and_retail_merchant',
+  DirectMarketingInboundTelemarketing = 'direct_marketing_inbound_telemarketing',
+  DirectMarketingInsuranceServices = 'direct_marketing_insurance_services',
+  DirectMarketingOther = 'direct_marketing_other',
+  DirectMarketingOutboundTelemarketing = 'direct_marketing_outbound_telemarketing',
+  DirectMarketingSubscription = 'direct_marketing_subscription',
+  DirectMarketingTravel = 'direct_marketing_travel',
+  DiscountStores = 'discount_stores',
+  Doctors = 'doctors',
+  DoorToDoorSales = 'door_to_door_sales',
+  DraperyWindowCoveringAndUpholsteryStores = 'drapery_window_covering_and_upholstery_stores',
+  DrinkingPlaces = 'drinking_places',
+  DrugStoresAndPharmacies = 'drug_stores_and_pharmacies',
+  DrugsDrugProprietariesAndDruggistSundries = 'drugs_drug_proprietaries_and_druggist_sundries',
+  DryCleaners = 'dry_cleaners',
+  DurableGoods = 'durable_goods',
+  DutyFreeStores = 'duty_free_stores',
+  EatingPlacesRestaurants = 'eating_places_restaurants',
+  EducationalServices = 'educational_services',
+  ElectricRazorStores = 'electric_razor_stores',
+  ElectricalPartsAndEquipment = 'electrical_parts_and_equipment',
+  ElectricalServices = 'electrical_services',
+  ElectronicsRepairShops = 'electronics_repair_shops',
+  ElectronicsStores = 'electronics_stores',
+  ElementarySecondarySchools = 'elementary_secondary_schools',
+  EmploymentTempAgencies = 'employment_temp_agencies',
+  EquipmentRental = 'equipment_rental',
+  ExterminatingServices = 'exterminating_services',
+  FamilyClothingStores = 'family_clothing_stores',
+  FastFoodRestaurants = 'fast_food_restaurants',
+  FinancialInstitutions = 'financial_institutions',
+  FinesGovernmentAdministrativeEntities = 'fines_government_administrative_entities',
+  FireplaceFireplaceScreensAndAccessoriesStores = 'fireplace_fireplace_screens_and_accessories_stores',
+  FloorCoveringStores = 'floor_covering_stores',
+  Florists = 'florists',
+  FloristsSuppliesNurseryStockAndFlowers = 'florists_supplies_nursery_stock_and_flowers',
+  FreezerAndLockerMeatProvisioners = 'freezer_and_locker_meat_provisioners',
+  FuelDealersNonAutomotive = 'fuel_dealers_non_automotive',
+  FuneralServicesCrematories = 'funeral_services_crematories',
+  FurnitureHomeFurnishingsAndEquipmentStoresExceptAppliances = 'furniture_home_furnishings_and_equipment_stores_except_appliances',
+  FurnitureRepairRefinishing = 'furniture_repair_refinishing',
+  FurriersAndFurShops = 'furriers_and_fur_shops',
+  GeneralServices = 'general_services',
+  GiftCardNoveltyAndSouvenirShops = 'gift_card_novelty_and_souvenir_shops',
+  GlassPaintAndWallpaperStores = 'glass_paint_and_wallpaper_stores',
+  GlasswareCrystalStores = 'glassware_crystal_stores',
+  GolfCoursesPublic = 'golf_courses_public',
+  GovernmentServices = 'government_services',
+  GroceryStoresSupermarkets = 'grocery_stores_supermarkets',
+  HardwareEquipmentAndSupplies = 'hardware_equipment_and_supplies',
+  HardwareStores = 'hardware_stores',
+  HealthAndBeautySpas = 'health_and_beauty_spas',
+  HearingAidsSalesAndSupplies = 'hearing_aids_sales_and_supplies',
+  HeatingPlumbingAC = 'heating_plumbing_a_c',
+  HobbyToyAndGameShops = 'hobby_toy_and_game_shops',
+  HomeSupplyWarehouseStores = 'home_supply_warehouse_stores',
+  Hospitals = 'hospitals',
+  HotelsMotelsAndResorts = 'hotels_motels_and_resorts',
+  HouseholdApplianceStores = 'household_appliance_stores',
+  IndustrialSupplies = 'industrial_supplies',
+  InformationRetrievalServices = 'information_retrieval_services',
+  InsuranceDefault = 'insurance_default',
+  InsuranceUnderwritingPremiums = 'insurance_underwriting_premiums',
+  IntraCompanyPurchases = 'intra_company_purchases',
+  JewelryStoresWatchesClocksAndSilverwareStores = 'jewelry_stores_watches_clocks_and_silverware_stores',
+  LandscapingServices = 'landscaping_services',
+  Laundries = 'laundries',
+  LaundryCleaningServices = 'laundry_cleaning_services',
+  LegalServicesAttorneys = 'legal_services_attorneys',
+  LuggageAndLeatherGoodsStores = 'luggage_and_leather_goods_stores',
+  LumberBuildingMaterialsStores = 'lumber_building_materials_stores',
+  ManualCashDisburse = 'manual_cash_disburse',
+  MarinasServiceAndSupplies = 'marinas_service_and_supplies',
+  MasonryStoneworkAndPlaster = 'masonry_stonework_and_plaster',
+  MassageParlors = 'massage_parlors',
+  MedicalAndDentalLabs = 'medical_and_dental_labs',
+  MedicalDentalOphthalmicAndHospitalEquipmentAndSupplies = 'medical_dental_ophthalmic_and_hospital_equipment_and_supplies',
+  MedicalServices = 'medical_services',
+  MembershipOrganizations = 'membership_organizations',
+  MensAndBoysClothingAndAccessoriesStores = 'mens_and_boys_clothing_and_accessories_stores',
+  MensWomensClothingStores = 'mens_womens_clothing_stores',
+  MetalServiceCenters = 'metal_service_centers',
+  Miscellaneous = 'miscellaneous',
+  MiscellaneousApparelAndAccessoryShops = 'miscellaneous_apparel_and_accessory_shops',
+  MiscellaneousAutoDealers = 'miscellaneous_auto_dealers',
+  MiscellaneousBusinessServices = 'miscellaneous_business_services',
+  MiscellaneousFoodStores = 'miscellaneous_food_stores',
+  MiscellaneousGeneralMerchandise = 'miscellaneous_general_merchandise',
+  MiscellaneousGeneralServices = 'miscellaneous_general_services',
+  MiscellaneousHomeFurnishingSpecialtyStores = 'miscellaneous_home_furnishing_specialty_stores',
+  MiscellaneousPublishingAndPrinting = 'miscellaneous_publishing_and_printing',
+  MiscellaneousRecreationServices = 'miscellaneous_recreation_services',
+  MiscellaneousRepairShops = 'miscellaneous_repair_shops',
+  MiscellaneousSpecialtyRetail = 'miscellaneous_specialty_retail',
+  MobileHomeDealers = 'mobile_home_dealers',
+  MotionPictureTheaters = 'motion_picture_theaters',
+  MotorFreightCarriersAndTrucking = 'motor_freight_carriers_and_trucking',
+  MotorHomesDealers = 'motor_homes_dealers',
+  MotorVehicleSuppliesAndNewParts = 'motor_vehicle_supplies_and_new_parts',
+  MotorcycleShopsAndDealers = 'motorcycle_shops_and_dealers',
+  MotorcycleShopsDealers = 'motorcycle_shops_dealers',
+  MusicStoresMusicalInstrumentsPianosAndSheetMusic = 'music_stores_musical_instruments_pianos_and_sheet_music',
+  NewsDealersAndNewsstands = 'news_dealers_and_newsstands',
+  NonFiMoneyOrders = 'non_fi_money_orders',
+  NonFiStoredValueCardPurchaseLoad = 'non_fi_stored_value_card_purchase_load',
+  NondurableGoods = 'nondurable_goods',
+  NurseriesLawnAndGardenSupplyStores = 'nurseries_lawn_and_garden_supply_stores',
+  NursingPersonalCare = 'nursing_personal_care',
+  OfficeAndCommercialFurniture = 'office_and_commercial_furniture',
+  OpticiansEyeglasses = 'opticians_eyeglasses',
+  OptometristsOphthalmologist = 'optometrists_ophthalmologist',
+  OrthopedicGoodsProstheticDevices = 'orthopedic_goods_prosthetic_devices',
+  Osteopaths = 'osteopaths',
+  PackageStoresBeerWineAndLiquor = 'package_stores_beer_wine_and_liquor',
+  PaintsVarnishesAndSupplies = 'paints_varnishes_and_supplies',
+  ParkingLotsGarages = 'parking_lots_garages',
+  PassengerRailways = 'passenger_railways',
+  PawnShops = 'pawn_shops',
+  PetShopsPetFoodAndSupplies = 'pet_shops_pet_food_and_supplies',
+  PetroleumAndPetroleumProducts = 'petroleum_and_petroleum_products',
+  PhotoDeveloping = 'photo_developing',
+  PhotographicPhotocopyMicrofilmEquipmentAndSupplies = 'photographic_photocopy_microfilm_equipment_and_supplies',
+  PhotographicStudios = 'photographic_studios',
+  PictureVideoProduction = 'picture_video_production',
+  PieceGoodsNotionsAndOtherDryGoods = 'piece_goods_notions_and_other_dry_goods',
+  PlumbingHeatingEquipmentAndSupplies = 'plumbing_heating_equipment_and_supplies',
+  PoliticalOrganizations = 'political_organizations',
+  PostalServicesGovernmentOnly = 'postal_services_government_only',
+  PreciousStonesAndMetalsWatchesAndJewelry = 'precious_stones_and_metals_watches_and_jewelry',
+  ProfessionalServices = 'professional_services',
+  PublicWarehousingAndStorage = 'public_warehousing_and_storage',
+  QuickCopyReproAndBlueprint = 'quick_copy_repro_and_blueprint',
+  Railroads = 'railroads',
+  RealEstateAgentsAndManagersRentals = 'real_estate_agents_and_managers_rentals',
+  RecordStores = 'record_stores',
+  RecreationalVehicleRentals = 'recreational_vehicle_rentals',
+  ReligiousGoodsStores = 'religious_goods_stores',
+  ReligiousOrganizations = 'religious_organizations',
+  RoofingSidingSheetMetal = 'roofing_siding_sheet_metal',
+  SecretarialSupportServices = 'secretarial_support_services',
+  SecurityBrokersDealers = 'security_brokers_dealers',
+  ServiceStations = 'service_stations',
+  SewingNeedleworkFabricAndPieceGoodsStores = 'sewing_needlework_fabric_and_piece_goods_stores',
+  ShoeRepairHatCleaning = 'shoe_repair_hat_cleaning',
+  ShoeStores = 'shoe_stores',
+  SmallApplianceRepair = 'small_appliance_repair',
+  SnowmobileDealers = 'snowmobile_dealers',
+  SpecialTradeServices = 'special_trade_services',
+  SpecialtyCleaning = 'specialty_cleaning',
+  SportingGoodsStores = 'sporting_goods_stores',
+  SportingRecreationCamps = 'sporting_recreation_camps',
+  SportsAndRidingApparelStores = 'sports_and_riding_apparel_stores',
+  SportsClubsFields = 'sports_clubs_fields',
+  StampAndCoinStores = 'stamp_and_coin_stores',
+  StationaryOfficeSuppliesPrintingAndWritingPaper = 'stationary_office_supplies_printing_and_writing_paper',
+  StationeryStoresOfficeAndSchoolSupplyStores = 'stationery_stores_office_and_school_supply_stores',
+  SwimmingPoolsSales = 'swimming_pools_sales',
+  TUiTravelGermany = 't_ui_travel_germany',
+  TailorsAlterations = 'tailors_alterations',
+  TaxPaymentsGovernmentAgencies = 'tax_payments_government_agencies',
+  TaxPreparationServices = 'tax_preparation_services',
+  TaxicabsLimousines = 'taxicabs_limousines',
+  TelecommunicationEquipmentAndTelephoneSales = 'telecommunication_equipment_and_telephone_sales',
+  TelecommunicationServices = 'telecommunication_services',
+  TelegraphServices = 'telegraph_services',
+  TentAndAwningShops = 'tent_and_awning_shops',
+  TestingLaboratories = 'testing_laboratories',
+  TheatricalTicketAgencies = 'theatrical_ticket_agencies',
+  Timeshares = 'timeshares',
+  TireRetreadingAndRepair = 'tire_retreading_and_repair',
+  TollsBridgeFees = 'tolls_bridge_fees',
+  TouristAttractionsAndExhibits = 'tourist_attractions_and_exhibits',
+  TowingServices = 'towing_services',
+  TrailerParksCampgrounds = 'trailer_parks_campgrounds',
+  TransportationServices = 'transportation_services',
+  TravelAgenciesTourOperators = 'travel_agencies_tour_operators',
+  TruckStopIteration = 'truck_stop_iteration',
+  TruckUtilityTrailerRentals = 'truck_utility_trailer_rentals',
+  TypesettingPlateMakingAndRelatedServices = 'typesetting_plate_making_and_related_services',
+  TypewriterStores = 'typewriter_stores',
+  USFederalGovernmentAgenciesOrDepartments = 'u_s_federal_government_agencies_or_departments',
+  UniformsCommercialClothing = 'uniforms_commercial_clothing',
+  UsedMerchandiseAndSecondhandStores = 'used_merchandise_and_secondhand_stores',
+  Utilities = 'utilities',
+  VarietyStores = 'variety_stores',
+  VeterinaryServices = 'veterinary_services',
+  VideoAmusementGameSupplies = 'video_amusement_game_supplies',
+  VideoGameArcades = 'video_game_arcades',
+  VideoTapeRentalStores = 'video_tape_rental_stores',
+  VocationalTradeSchools = 'vocational_trade_schools',
+  WatchJewelryRepair = 'watch_jewelry_repair',
+  WeldingRepair = 'welding_repair',
+  WholesaleClubs = 'wholesale_clubs',
+  WigAndToupeeStores = 'wig_and_toupee_stores',
+  WiresMoneyOrders = 'wires_money_orders',
+  WomensAccessoryAndSpecialtyShops = 'womens_accessory_and_specialty_shops',
+  WomensReadyToWearStores = 'womens_ready_to_wear_stores',
+  WreckingAndSalvageYards = 'wrecking_and_salvage_yards'
+}
+
+export type Stripe_IssuingCardSpendingLimit = {
+  __typename?: 'Stripe_IssuingCardSpendingLimit';
+  /** Maximum amount allowed to spend per interval. */
+  amount?: Maybe<Scalars['Int']>;
+  /** Array of strings containing [categories](https://stripe.com/docs/api#issuing_authorization_object-merchant_data-category) this limit applies to. Omitting this field will apply the limit to all categories. */
+  categories?: Maybe<Array<Maybe<Stripe_IssuingCardSpendingLimitCategoriesProperty>>>;
+  /** Interval (or event) to which the amount applies. */
+  interval?: Maybe<Stripe_IssuingCardSpendingLimitIntervalProperty>;
+};
+
+export enum Stripe_IssuingCardSpendingLimitCategoriesProperty {
+  AcRefrigerationRepair = 'ac_refrigeration_repair',
+  AccountingBookkeepingServices = 'accounting_bookkeeping_services',
+  AdvertisingServices = 'advertising_services',
+  AgriculturalCooperative = 'agricultural_cooperative',
+  AirlinesAirCarriers = 'airlines_air_carriers',
+  AirportsFlyingFields = 'airports_flying_fields',
+  AmbulanceServices = 'ambulance_services',
+  AmusementParksCarnivals = 'amusement_parks_carnivals',
+  AntiqueReproductions = 'antique_reproductions',
+  AntiqueShops = 'antique_shops',
+  Aquariums = 'aquariums',
+  ArchitecturalSurveyingServices = 'architectural_surveying_services',
+  ArtDealersAndGalleries = 'art_dealers_and_galleries',
+  ArtistsSupplyAndCraftShops = 'artists_supply_and_craft_shops',
+  AutoAndHomeSupplyStores = 'auto_and_home_supply_stores',
+  AutoBodyRepairShops = 'auto_body_repair_shops',
+  AutoPaintShops = 'auto_paint_shops',
+  AutoServiceShops = 'auto_service_shops',
+  AutomatedCashDisburse = 'automated_cash_disburse',
+  AutomatedFuelDispensers = 'automated_fuel_dispensers',
+  AutomobileAssociations = 'automobile_associations',
+  AutomotivePartsAndAccessoriesStores = 'automotive_parts_and_accessories_stores',
+  AutomotiveTireStores = 'automotive_tire_stores',
+  BailAndBondPayments = 'bail_and_bond_payments',
+  Bakeries = 'bakeries',
+  BandsOrchestras = 'bands_orchestras',
+  BarberAndBeautyShops = 'barber_and_beauty_shops',
+  BettingCasinoGambling = 'betting_casino_gambling',
+  BicycleShops = 'bicycle_shops',
+  BilliardPoolEstablishments = 'billiard_pool_establishments',
+  BoatDealers = 'boat_dealers',
+  BoatRentalsAndLeases = 'boat_rentals_and_leases',
+  BookStores = 'book_stores',
+  BooksPeriodicalsAndNewspapers = 'books_periodicals_and_newspapers',
+  BowlingAlleys = 'bowling_alleys',
+  BusLines = 'bus_lines',
+  BusinessSecretarialSchools = 'business_secretarial_schools',
+  BuyingShoppingServices = 'buying_shopping_services',
+  CableSatelliteAndOtherPayTelevisionAndRadio = 'cable_satellite_and_other_pay_television_and_radio',
+  CameraAndPhotographicSupplyStores = 'camera_and_photographic_supply_stores',
+  CandyNutAndConfectioneryStores = 'candy_nut_and_confectionery_stores',
+  CarAndTruckDealersNewUsed = 'car_and_truck_dealers_new_used',
+  CarAndTruckDealersUsedOnly = 'car_and_truck_dealers_used_only',
+  CarRentalAgencies = 'car_rental_agencies',
+  CarWashes = 'car_washes',
+  CarpentryServices = 'carpentry_services',
+  CarpetUpholsteryCleaning = 'carpet_upholstery_cleaning',
+  Caterers = 'caterers',
+  CharitableAndSocialServiceOrganizationsFundraising = 'charitable_and_social_service_organizations_fundraising',
+  ChemicalsAndAlliedProducts = 'chemicals_and_allied_products',
+  ChildCareServices = 'child_care_services',
+  ChildrensAndInfantsWearStores = 'childrens_and_infants_wear_stores',
+  ChiropodistsPodiatrists = 'chiropodists_podiatrists',
+  Chiropractors = 'chiropractors',
+  CigarStoresAndStands = 'cigar_stores_and_stands',
+  CivicSocialFraternalAssociations = 'civic_social_fraternal_associations',
+  CleaningAndMaintenance = 'cleaning_and_maintenance',
+  ClothingRental = 'clothing_rental',
+  CollegesUniversities = 'colleges_universities',
+  CommercialEquipment = 'commercial_equipment',
+  CommercialFootwear = 'commercial_footwear',
+  CommercialPhotographyArtAndGraphics = 'commercial_photography_art_and_graphics',
+  CommuterTransportAndFerries = 'commuter_transport_and_ferries',
+  ComputerNetworkServices = 'computer_network_services',
+  ComputerProgramming = 'computer_programming',
+  ComputerRepair = 'computer_repair',
+  ComputerSoftwareStores = 'computer_software_stores',
+  ComputersPeripheralsAndSoftware = 'computers_peripherals_and_software',
+  ConcreteWorkServices = 'concrete_work_services',
+  ConstructionMaterials = 'construction_materials',
+  ConsultingPublicRelations = 'consulting_public_relations',
+  CorrespondenceSchools = 'correspondence_schools',
+  CosmeticStores = 'cosmetic_stores',
+  CounselingServices = 'counseling_services',
+  CountryClubs = 'country_clubs',
+  CourierServices = 'courier_services',
+  CourtCosts = 'court_costs',
+  CreditReportingAgencies = 'credit_reporting_agencies',
+  CruiseLines = 'cruise_lines',
+  DairyProductsStores = 'dairy_products_stores',
+  DanceHallStudiosSchools = 'dance_hall_studios_schools',
+  DatingEscortServices = 'dating_escort_services',
+  DentistsOrthodontists = 'dentists_orthodontists',
+  DepartmentStores = 'department_stores',
+  DetectiveAgencies = 'detective_agencies',
+  DigitalGoodsApplications = 'digital_goods_applications',
+  DigitalGoodsGames = 'digital_goods_games',
+  DigitalGoodsLargeVolume = 'digital_goods_large_volume',
+  DigitalGoodsMedia = 'digital_goods_media',
+  DirectMarketingCatalogMerchant = 'direct_marketing_catalog_merchant',
+  DirectMarketingCombinationCatalogAndRetailMerchant = 'direct_marketing_combination_catalog_and_retail_merchant',
+  DirectMarketingInboundTelemarketing = 'direct_marketing_inbound_telemarketing',
+  DirectMarketingInsuranceServices = 'direct_marketing_insurance_services',
+  DirectMarketingOther = 'direct_marketing_other',
+  DirectMarketingOutboundTelemarketing = 'direct_marketing_outbound_telemarketing',
+  DirectMarketingSubscription = 'direct_marketing_subscription',
+  DirectMarketingTravel = 'direct_marketing_travel',
+  DiscountStores = 'discount_stores',
+  Doctors = 'doctors',
+  DoorToDoorSales = 'door_to_door_sales',
+  DraperyWindowCoveringAndUpholsteryStores = 'drapery_window_covering_and_upholstery_stores',
+  DrinkingPlaces = 'drinking_places',
+  DrugStoresAndPharmacies = 'drug_stores_and_pharmacies',
+  DrugsDrugProprietariesAndDruggistSundries = 'drugs_drug_proprietaries_and_druggist_sundries',
+  DryCleaners = 'dry_cleaners',
+  DurableGoods = 'durable_goods',
+  DutyFreeStores = 'duty_free_stores',
+  EatingPlacesRestaurants = 'eating_places_restaurants',
+  EducationalServices = 'educational_services',
+  ElectricRazorStores = 'electric_razor_stores',
+  ElectricalPartsAndEquipment = 'electrical_parts_and_equipment',
+  ElectricalServices = 'electrical_services',
+  ElectronicsRepairShops = 'electronics_repair_shops',
+  ElectronicsStores = 'electronics_stores',
+  ElementarySecondarySchools = 'elementary_secondary_schools',
+  EmploymentTempAgencies = 'employment_temp_agencies',
+  EquipmentRental = 'equipment_rental',
+  ExterminatingServices = 'exterminating_services',
+  FamilyClothingStores = 'family_clothing_stores',
+  FastFoodRestaurants = 'fast_food_restaurants',
+  FinancialInstitutions = 'financial_institutions',
+  FinesGovernmentAdministrativeEntities = 'fines_government_administrative_entities',
+  FireplaceFireplaceScreensAndAccessoriesStores = 'fireplace_fireplace_screens_and_accessories_stores',
+  FloorCoveringStores = 'floor_covering_stores',
+  Florists = 'florists',
+  FloristsSuppliesNurseryStockAndFlowers = 'florists_supplies_nursery_stock_and_flowers',
+  FreezerAndLockerMeatProvisioners = 'freezer_and_locker_meat_provisioners',
+  FuelDealersNonAutomotive = 'fuel_dealers_non_automotive',
+  FuneralServicesCrematories = 'funeral_services_crematories',
+  FurnitureHomeFurnishingsAndEquipmentStoresExceptAppliances = 'furniture_home_furnishings_and_equipment_stores_except_appliances',
+  FurnitureRepairRefinishing = 'furniture_repair_refinishing',
+  FurriersAndFurShops = 'furriers_and_fur_shops',
+  GeneralServices = 'general_services',
+  GiftCardNoveltyAndSouvenirShops = 'gift_card_novelty_and_souvenir_shops',
+  GlassPaintAndWallpaperStores = 'glass_paint_and_wallpaper_stores',
+  GlasswareCrystalStores = 'glassware_crystal_stores',
+  GolfCoursesPublic = 'golf_courses_public',
+  GovernmentServices = 'government_services',
+  GroceryStoresSupermarkets = 'grocery_stores_supermarkets',
+  HardwareEquipmentAndSupplies = 'hardware_equipment_and_supplies',
+  HardwareStores = 'hardware_stores',
+  HealthAndBeautySpas = 'health_and_beauty_spas',
+  HearingAidsSalesAndSupplies = 'hearing_aids_sales_and_supplies',
+  HeatingPlumbingAC = 'heating_plumbing_a_c',
+  HobbyToyAndGameShops = 'hobby_toy_and_game_shops',
+  HomeSupplyWarehouseStores = 'home_supply_warehouse_stores',
+  Hospitals = 'hospitals',
+  HotelsMotelsAndResorts = 'hotels_motels_and_resorts',
+  HouseholdApplianceStores = 'household_appliance_stores',
+  IndustrialSupplies = 'industrial_supplies',
+  InformationRetrievalServices = 'information_retrieval_services',
+  InsuranceDefault = 'insurance_default',
+  InsuranceUnderwritingPremiums = 'insurance_underwriting_premiums',
+  IntraCompanyPurchases = 'intra_company_purchases',
+  JewelryStoresWatchesClocksAndSilverwareStores = 'jewelry_stores_watches_clocks_and_silverware_stores',
+  LandscapingServices = 'landscaping_services',
+  Laundries = 'laundries',
+  LaundryCleaningServices = 'laundry_cleaning_services',
+  LegalServicesAttorneys = 'legal_services_attorneys',
+  LuggageAndLeatherGoodsStores = 'luggage_and_leather_goods_stores',
+  LumberBuildingMaterialsStores = 'lumber_building_materials_stores',
+  ManualCashDisburse = 'manual_cash_disburse',
+  MarinasServiceAndSupplies = 'marinas_service_and_supplies',
+  MasonryStoneworkAndPlaster = 'masonry_stonework_and_plaster',
+  MassageParlors = 'massage_parlors',
+  MedicalAndDentalLabs = 'medical_and_dental_labs',
+  MedicalDentalOphthalmicAndHospitalEquipmentAndSupplies = 'medical_dental_ophthalmic_and_hospital_equipment_and_supplies',
+  MedicalServices = 'medical_services',
+  MembershipOrganizations = 'membership_organizations',
+  MensAndBoysClothingAndAccessoriesStores = 'mens_and_boys_clothing_and_accessories_stores',
+  MensWomensClothingStores = 'mens_womens_clothing_stores',
+  MetalServiceCenters = 'metal_service_centers',
+  Miscellaneous = 'miscellaneous',
+  MiscellaneousApparelAndAccessoryShops = 'miscellaneous_apparel_and_accessory_shops',
+  MiscellaneousAutoDealers = 'miscellaneous_auto_dealers',
+  MiscellaneousBusinessServices = 'miscellaneous_business_services',
+  MiscellaneousFoodStores = 'miscellaneous_food_stores',
+  MiscellaneousGeneralMerchandise = 'miscellaneous_general_merchandise',
+  MiscellaneousGeneralServices = 'miscellaneous_general_services',
+  MiscellaneousHomeFurnishingSpecialtyStores = 'miscellaneous_home_furnishing_specialty_stores',
+  MiscellaneousPublishingAndPrinting = 'miscellaneous_publishing_and_printing',
+  MiscellaneousRecreationServices = 'miscellaneous_recreation_services',
+  MiscellaneousRepairShops = 'miscellaneous_repair_shops',
+  MiscellaneousSpecialtyRetail = 'miscellaneous_specialty_retail',
+  MobileHomeDealers = 'mobile_home_dealers',
+  MotionPictureTheaters = 'motion_picture_theaters',
+  MotorFreightCarriersAndTrucking = 'motor_freight_carriers_and_trucking',
+  MotorHomesDealers = 'motor_homes_dealers',
+  MotorVehicleSuppliesAndNewParts = 'motor_vehicle_supplies_and_new_parts',
+  MotorcycleShopsAndDealers = 'motorcycle_shops_and_dealers',
+  MotorcycleShopsDealers = 'motorcycle_shops_dealers',
+  MusicStoresMusicalInstrumentsPianosAndSheetMusic = 'music_stores_musical_instruments_pianos_and_sheet_music',
+  NewsDealersAndNewsstands = 'news_dealers_and_newsstands',
+  NonFiMoneyOrders = 'non_fi_money_orders',
+  NonFiStoredValueCardPurchaseLoad = 'non_fi_stored_value_card_purchase_load',
+  NondurableGoods = 'nondurable_goods',
+  NurseriesLawnAndGardenSupplyStores = 'nurseries_lawn_and_garden_supply_stores',
+  NursingPersonalCare = 'nursing_personal_care',
+  OfficeAndCommercialFurniture = 'office_and_commercial_furniture',
+  OpticiansEyeglasses = 'opticians_eyeglasses',
+  OptometristsOphthalmologist = 'optometrists_ophthalmologist',
+  OrthopedicGoodsProstheticDevices = 'orthopedic_goods_prosthetic_devices',
+  Osteopaths = 'osteopaths',
+  PackageStoresBeerWineAndLiquor = 'package_stores_beer_wine_and_liquor',
+  PaintsVarnishesAndSupplies = 'paints_varnishes_and_supplies',
+  ParkingLotsGarages = 'parking_lots_garages',
+  PassengerRailways = 'passenger_railways',
+  PawnShops = 'pawn_shops',
+  PetShopsPetFoodAndSupplies = 'pet_shops_pet_food_and_supplies',
+  PetroleumAndPetroleumProducts = 'petroleum_and_petroleum_products',
+  PhotoDeveloping = 'photo_developing',
+  PhotographicPhotocopyMicrofilmEquipmentAndSupplies = 'photographic_photocopy_microfilm_equipment_and_supplies',
+  PhotographicStudios = 'photographic_studios',
+  PictureVideoProduction = 'picture_video_production',
+  PieceGoodsNotionsAndOtherDryGoods = 'piece_goods_notions_and_other_dry_goods',
+  PlumbingHeatingEquipmentAndSupplies = 'plumbing_heating_equipment_and_supplies',
+  PoliticalOrganizations = 'political_organizations',
+  PostalServicesGovernmentOnly = 'postal_services_government_only',
+  PreciousStonesAndMetalsWatchesAndJewelry = 'precious_stones_and_metals_watches_and_jewelry',
+  ProfessionalServices = 'professional_services',
+  PublicWarehousingAndStorage = 'public_warehousing_and_storage',
+  QuickCopyReproAndBlueprint = 'quick_copy_repro_and_blueprint',
+  Railroads = 'railroads',
+  RealEstateAgentsAndManagersRentals = 'real_estate_agents_and_managers_rentals',
+  RecordStores = 'record_stores',
+  RecreationalVehicleRentals = 'recreational_vehicle_rentals',
+  ReligiousGoodsStores = 'religious_goods_stores',
+  ReligiousOrganizations = 'religious_organizations',
+  RoofingSidingSheetMetal = 'roofing_siding_sheet_metal',
+  SecretarialSupportServices = 'secretarial_support_services',
+  SecurityBrokersDealers = 'security_brokers_dealers',
+  ServiceStations = 'service_stations',
+  SewingNeedleworkFabricAndPieceGoodsStores = 'sewing_needlework_fabric_and_piece_goods_stores',
+  ShoeRepairHatCleaning = 'shoe_repair_hat_cleaning',
+  ShoeStores = 'shoe_stores',
+  SmallApplianceRepair = 'small_appliance_repair',
+  SnowmobileDealers = 'snowmobile_dealers',
+  SpecialTradeServices = 'special_trade_services',
+  SpecialtyCleaning = 'specialty_cleaning',
+  SportingGoodsStores = 'sporting_goods_stores',
+  SportingRecreationCamps = 'sporting_recreation_camps',
+  SportsAndRidingApparelStores = 'sports_and_riding_apparel_stores',
+  SportsClubsFields = 'sports_clubs_fields',
+  StampAndCoinStores = 'stamp_and_coin_stores',
+  StationaryOfficeSuppliesPrintingAndWritingPaper = 'stationary_office_supplies_printing_and_writing_paper',
+  StationeryStoresOfficeAndSchoolSupplyStores = 'stationery_stores_office_and_school_supply_stores',
+  SwimmingPoolsSales = 'swimming_pools_sales',
+  TUiTravelGermany = 't_ui_travel_germany',
+  TailorsAlterations = 'tailors_alterations',
+  TaxPaymentsGovernmentAgencies = 'tax_payments_government_agencies',
+  TaxPreparationServices = 'tax_preparation_services',
+  TaxicabsLimousines = 'taxicabs_limousines',
+  TelecommunicationEquipmentAndTelephoneSales = 'telecommunication_equipment_and_telephone_sales',
+  TelecommunicationServices = 'telecommunication_services',
+  TelegraphServices = 'telegraph_services',
+  TentAndAwningShops = 'tent_and_awning_shops',
+  TestingLaboratories = 'testing_laboratories',
+  TheatricalTicketAgencies = 'theatrical_ticket_agencies',
+  Timeshares = 'timeshares',
+  TireRetreadingAndRepair = 'tire_retreading_and_repair',
+  TollsBridgeFees = 'tolls_bridge_fees',
+  TouristAttractionsAndExhibits = 'tourist_attractions_and_exhibits',
+  TowingServices = 'towing_services',
+  TrailerParksCampgrounds = 'trailer_parks_campgrounds',
+  TransportationServices = 'transportation_services',
+  TravelAgenciesTourOperators = 'travel_agencies_tour_operators',
+  TruckStopIteration = 'truck_stop_iteration',
+  TruckUtilityTrailerRentals = 'truck_utility_trailer_rentals',
+  TypesettingPlateMakingAndRelatedServices = 'typesetting_plate_making_and_related_services',
+  TypewriterStores = 'typewriter_stores',
+  USFederalGovernmentAgenciesOrDepartments = 'u_s_federal_government_agencies_or_departments',
+  UniformsCommercialClothing = 'uniforms_commercial_clothing',
+  UsedMerchandiseAndSecondhandStores = 'used_merchandise_and_secondhand_stores',
+  Utilities = 'utilities',
+  VarietyStores = 'variety_stores',
+  VeterinaryServices = 'veterinary_services',
+  VideoAmusementGameSupplies = 'video_amusement_game_supplies',
+  VideoGameArcades = 'video_game_arcades',
+  VideoTapeRentalStores = 'video_tape_rental_stores',
+  VocationalTradeSchools = 'vocational_trade_schools',
+  WatchJewelryRepair = 'watch_jewelry_repair',
+  WeldingRepair = 'welding_repair',
+  WholesaleClubs = 'wholesale_clubs',
+  WigAndToupeeStores = 'wig_and_toupee_stores',
+  WiresMoneyOrders = 'wires_money_orders',
+  WomensAccessoryAndSpecialtyShops = 'womens_accessory_and_specialty_shops',
+  WomensReadyToWearStores = 'womens_ready_to_wear_stores',
+  WreckingAndSalvageYards = 'wrecking_and_salvage_yards'
+}
+
+export enum Stripe_IssuingCardSpendingLimitIntervalProperty {
+  AllTime = 'all_time',
+  Daily = 'daily',
+  Monthly = 'monthly',
+  PerAuthorization = 'per_authorization',
+  Weekly = 'weekly',
+  Yearly = 'yearly'
+}
+
+export enum Stripe_IssuingCardStatusProperty {
+  Active = 'active',
+  Canceled = 'canceled',
+  Inactive = 'inactive'
+}
+
+export enum Stripe_IssuingCardTypeProperty {
+  Physical = 'physical',
+  Virtual = 'virtual'
+}
+
+export type Stripe_IssuingAuthorizationCardholderProperty = WrappedString | Stripe_IssuingCardholder;
+
+export type Stripe_IssuingAuthorizationMerchantData = {
+  __typename?: 'Stripe_IssuingAuthorizationMerchantData';
+  /** A categorization of the seller's type of business. See our [merchant categories guide](https://stripe.com/docs/issuing/merchant-categories) for a list of possible values. */
+  category?: Maybe<Scalars['String']>;
+  /** City where the seller is located */
+  city?: Maybe<Scalars['String']>;
+  /** Country where the seller is located */
+  country?: Maybe<Scalars['String']>;
+  /** Name of the seller */
+  name?: Maybe<Scalars['String']>;
+  /** Identifier assigned to the seller by the card brand */
+  network_id?: Maybe<Scalars['String']>;
+  /** Postal code where the seller is located */
+  postal_code?: Maybe<Scalars['String']>;
+  /** State where the seller is located */
+  state?: Maybe<Scalars['String']>;
+};
+
+export enum Stripe_IssuingAuthorizationObjectProperty {
+  IssuingDoTauthorization = 'issuingDOTauthorization'
+}
+
+export type Stripe_IssuingAuthorizationPendingRequest = {
+  __typename?: 'Stripe_IssuingAuthorizationPendingRequest';
+  /** The additional amount Stripe will hold if the authorization is approved, in the card's [currency](https://stripe.com/docs/api#issuing_authorization_object-pending-request-currency) and in the [smallest currency unit](https://stripe.com/docs/currencies#zero-decimal). */
+  amount?: Maybe<Scalars['Int']>;
+  amount_details?: Maybe<Stripe_IssuingAuthorizationAmountDetails>;
+  /** Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies). */
+  currency?: Maybe<Scalars['String']>;
+  /** If set `true`, you may provide [amount](https://stripe.com/docs/api/issuing/authorizations/approve#approve_issuing_authorization-amount) to control how much to hold for the authorization. */
+  is_amount_controllable?: Maybe<Scalars['Boolean']>;
+  /** The amount the merchant is requesting to be authorized in the `merchant_currency`. The amount is in the [smallest currency unit](https://stripe.com/docs/currencies#zero-decimal). */
+  merchant_amount?: Maybe<Scalars['Int']>;
+  /** The local currency the merchant is requesting to authorize. */
+  merchant_currency?: Maybe<Scalars['String']>;
+};
+
+export type Stripe_IssuingAuthorizationRequest = {
+  __typename?: 'Stripe_IssuingAuthorizationRequest';
+  /** The `pending_request.amount` at the time of the request, presented in your card's currency and in the [smallest currency unit](https://stripe.com/docs/currencies#zero-decimal). Stripe held this amount from your account to fund the authorization if the request was approved. */
+  amount?: Maybe<Scalars['Int']>;
+  amount_details?: Maybe<Stripe_IssuingAuthorizationAmountDetails>;
+  /** Whether this request was approved. */
+  approved?: Maybe<Scalars['Boolean']>;
+  /** Time at which the object was created. Measured in seconds since the Unix epoch. */
+  created?: Maybe<Scalars['Int']>;
+  /** Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies). */
+  currency?: Maybe<Scalars['String']>;
+  /** The `pending_request.merchant_amount` at the time of the request, presented in the `merchant_currency` and in the [smallest currency unit](https://stripe.com/docs/currencies#zero-decimal). */
+  merchant_amount?: Maybe<Scalars['Int']>;
+  /** The currency that was collected by the merchant and presented to the cardholder for the authorization. Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies). */
+  merchant_currency?: Maybe<Scalars['String']>;
+  /** The reason for the approval or decline. */
+  reason?: Maybe<Stripe_IssuingAuthorizationRequestReasonProperty>;
+};
+
+export enum Stripe_IssuingAuthorizationRequestReasonProperty {
+  AccountDisabled = 'account_disabled',
+  CardActive = 'card_active',
+  CardInactive = 'card_inactive',
+  CardholderInactive = 'cardholder_inactive',
+  CardholderVerificationRequired = 'cardholder_verification_required',
+  InsufficientFunds = 'insufficient_funds',
+  NotAllowed = 'not_allowed',
+  SpendingControls = 'spending_controls',
+  SuspectedFraud = 'suspected_fraud',
+  VerificationFailed = 'verification_failed',
+  WebhookApproved = 'webhook_approved',
+  WebhookDeclined = 'webhook_declined',
+  WebhookTimeout = 'webhook_timeout'
+}
+
+export enum Stripe_IssuingAuthorizationStatusProperty {
+  Closed = 'closed',
+  Pending = 'pending',
+  Reversed = 'reversed'
+}
+
+export type Stripe_IssuingTransaction = {
+  __typename?: 'Stripe_IssuingTransaction';
+  /** The transaction amount, which will be reflected in your balance. This amount is in your currency and in the [smallest currency unit](https://stripe.com/docs/currencies#zero-decimal). */
+  amount?: Maybe<Scalars['Int']>;
+  amount_details?: Maybe<Stripe_IssuingTransactionAmountDetails>;
+  authorization?: Maybe<Stripe_IssuingTransactionAuthorizationProperty>;
+  balance_transaction?: Maybe<Stripe_IssuingTransactionBalanceTransactionProperty>;
+  card?: Maybe<Stripe_IssuingTransactionCardProperty>;
+  cardholder?: Maybe<Stripe_IssuingTransactionCardholderProperty>;
+  /** Time at which the object was created. Measured in seconds since the Unix epoch. */
+  created?: Maybe<Scalars['Int']>;
+  /** Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies). */
+  currency?: Maybe<Scalars['String']>;
+  dispute?: Maybe<Stripe_IssuingTransactionDisputeProperty>;
+  /** Unique identifier for the object. */
+  id?: Maybe<Scalars['String']>;
+  /** Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode. */
+  livemode?: Maybe<Scalars['Boolean']>;
+  /** The amount that the merchant will receive, denominated in `merchant_currency` and in the [smallest currency unit](https://stripe.com/docs/currencies#zero-decimal). It will be different from `amount` if the merchant is taking payment in a different currency. */
+  merchant_amount?: Maybe<Scalars['Int']>;
+  /** The currency with which the merchant is taking payment. */
+  merchant_currency?: Maybe<Scalars['String']>;
+  merchant_data?: Maybe<Stripe_IssuingAuthorizationMerchantData>;
+  /** Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. */
+  metadata?: Maybe<Scalars['JSONObject']>;
+  /** String representing the object's type. Objects of the same type share the same value. */
+  object?: Maybe<Stripe_IssuingTransactionObjectProperty>;
+  purchase_details?: Maybe<Stripe_IssuingTransactionPurchaseDetails>;
+  /** The nature of the transaction. */
+  type?: Maybe<Stripe_IssuingTransactionTypeProperty>;
+  /** The digital wallet used for this transaction. One of `apple_pay`, `google_pay`, or `samsung_pay`. */
+  wallet?: Maybe<Stripe_IssuingTransactionWalletProperty>;
+};
+
+export type Stripe_IssuingTransactionAmountDetails = {
+  __typename?: 'Stripe_IssuingTransactionAmountDetails';
+  /** The fee charged by the ATM for the cash withdrawal. */
+  atm_fee?: Maybe<Scalars['Int']>;
+};
+
+export type Stripe_IssuingTransactionAuthorizationProperty = WrappedString | Stripe_IssuingAuthorization;
+
+export type Stripe_IssuingTransactionBalanceTransactionProperty = WrappedString | Stripe_BalanceTransaction;
+
+export type Stripe_IssuingTransactionCardProperty = WrappedString | Stripe_IssuingCard;
+
+export type Stripe_IssuingTransactionCardholderProperty = WrappedString | Stripe_IssuingCardholder;
+
+export type Stripe_IssuingTransactionDisputeProperty = WrappedString | Stripe_IssuingDispute;
+
+export type Stripe_IssuingDispute = {
+  __typename?: 'Stripe_IssuingDispute';
+  /** Disputed amount. Usually the amount of the `transaction`, but can differ (usually because of currency fluctuation). */
+  amount?: Maybe<Scalars['Int']>;
+  /** List of balance transactions associated with the dispute. */
+  balance_transactions?: Maybe<Array<Maybe<Stripe_BalanceTransaction>>>;
+  /** Time at which the object was created. Measured in seconds since the Unix epoch. */
+  created?: Maybe<Scalars['Int']>;
+  /** The currency the `transaction` was made in. */
+  currency?: Maybe<Scalars['String']>;
+  evidence?: Maybe<Stripe_IssuingDisputeEvidence>;
+  /** Unique identifier for the object. */
+  id?: Maybe<Scalars['String']>;
+  /** Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode. */
+  livemode?: Maybe<Scalars['Boolean']>;
+  /** Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. */
+  metadata?: Maybe<Scalars['JSONObject']>;
+  /** String representing the object's type. Objects of the same type share the same value. */
+  object?: Maybe<Stripe_IssuingDisputeObjectProperty>;
+  /** Current status of the dispute. */
+  status?: Maybe<Stripe_IssuingDisputeStatusProperty>;
+  transaction?: Maybe<Stripe_IssuingDisputeTransactionProperty>;
+};
+
+export type Stripe_IssuingDisputeEvidence = {
+  __typename?: 'Stripe_IssuingDisputeEvidence';
+  canceled?: Maybe<Stripe_IssuingDisputeCanceledEvidence>;
+  duplicate?: Maybe<Stripe_IssuingDisputeDuplicateEvidence>;
+  fraudulent?: Maybe<Stripe_IssuingDisputeFraudulentEvidence>;
+  merchandise_not_as_described?: Maybe<Stripe_IssuingDisputeMerchandiseNotAsDescribedEvidence>;
+  not_received?: Maybe<Stripe_IssuingDisputeNotReceivedEvidence>;
+  other?: Maybe<Stripe_IssuingDisputeOtherEvidence>;
+  /** The reason for filing the dispute. Its value will match the field containing the evidence. */
+  reason?: Maybe<Stripe_IssuingDisputeEvidenceReasonProperty>;
+  service_not_as_described?: Maybe<Stripe_IssuingDisputeServiceNotAsDescribedEvidence>;
+};
+
+export type Stripe_IssuingDisputeCanceledEvidence = {
+  __typename?: 'Stripe_IssuingDisputeCanceledEvidence';
+  additional_documentation?: Maybe<Stripe_IssuingDisputeCanceledEvidenceAdditionalDocumentationProperty>;
+  /** Date when order was canceled. */
+  canceled_at?: Maybe<Scalars['Int']>;
+  /** Whether the cardholder was provided with a cancellation policy. */
+  cancellation_policy_provided?: Maybe<Scalars['Boolean']>;
+  /** Reason for canceling the order. */
+  cancellation_reason?: Maybe<Scalars['String']>;
+  /** Date when the cardholder expected to receive the product. */
+  expected_at?: Maybe<Scalars['Int']>;
+  /** Explanation of why the cardholder is disputing this transaction. */
+  explanation?: Maybe<Scalars['String']>;
+  /** Description of the merchandise or service that was purchased. */
+  product_description?: Maybe<Scalars['String']>;
+  /** Whether the product was a merchandise or service. */
+  product_type?: Maybe<Stripe_IssuingDisputeCanceledEvidenceProductTypeProperty>;
+  /** Result of cardholder's attempt to return the product. */
+  return_status?: Maybe<Stripe_IssuingDisputeCanceledEvidenceReturnStatusProperty>;
+  /** Date when the product was returned or attempted to be returned. */
+  returned_at?: Maybe<Scalars['Int']>;
+};
+
+export type Stripe_IssuingDisputeCanceledEvidenceAdditionalDocumentationProperty = WrappedString | Stripe_File;
+
+export enum Stripe_IssuingDisputeCanceledEvidenceProductTypeProperty {
+  Merchandise = 'merchandise',
+  Service = 'service'
+}
+
+export enum Stripe_IssuingDisputeCanceledEvidenceReturnStatusProperty {
+  MerchantRejected = 'merchant_rejected',
+  Successful = 'successful'
+}
+
+export type Stripe_IssuingDisputeDuplicateEvidence = {
+  __typename?: 'Stripe_IssuingDisputeDuplicateEvidence';
+  additional_documentation?: Maybe<Stripe_IssuingDisputeDuplicateEvidenceAdditionalDocumentationProperty>;
+  card_statement?: Maybe<Stripe_IssuingDisputeDuplicateEvidenceCardStatementProperty>;
+  cash_receipt?: Maybe<Stripe_IssuingDisputeDuplicateEvidenceCashReceiptProperty>;
+  check_image?: Maybe<Stripe_IssuingDisputeDuplicateEvidenceCheckImageProperty>;
+  /** Explanation of why the cardholder is disputing this transaction. */
+  explanation?: Maybe<Scalars['String']>;
+  /** Transaction (e.g., ipi_...) that the disputed transaction is a duplicate of. Of the two or more transactions that are copies of each other, this is original undisputed one. */
+  original_transaction?: Maybe<Scalars['String']>;
+};
+
+export type Stripe_IssuingDisputeDuplicateEvidenceAdditionalDocumentationProperty = WrappedString | Stripe_File;
+
+export type Stripe_IssuingDisputeDuplicateEvidenceCardStatementProperty = WrappedString | Stripe_File;
+
+export type Stripe_IssuingDisputeDuplicateEvidenceCashReceiptProperty = WrappedString | Stripe_File;
+
+export type Stripe_IssuingDisputeDuplicateEvidenceCheckImageProperty = WrappedString | Stripe_File;
+
+export type Stripe_IssuingDisputeFraudulentEvidence = {
+  __typename?: 'Stripe_IssuingDisputeFraudulentEvidence';
+  additional_documentation?: Maybe<Stripe_IssuingDisputeFraudulentEvidenceAdditionalDocumentationProperty>;
+  /** Explanation of why the cardholder is disputing this transaction. */
+  explanation?: Maybe<Scalars['String']>;
+};
+
+export type Stripe_IssuingDisputeFraudulentEvidenceAdditionalDocumentationProperty = WrappedString | Stripe_File;
+
+export type Stripe_IssuingDisputeMerchandiseNotAsDescribedEvidence = {
+  __typename?: 'Stripe_IssuingDisputeMerchandiseNotAsDescribedEvidence';
+  additional_documentation?: Maybe<Stripe_IssuingDisputeMerchandiseNotAsDescribedEvidenceAdditionalDocumentationProperty>;
+  /** Explanation of why the cardholder is disputing this transaction. */
+  explanation?: Maybe<Scalars['String']>;
+  /** Date when the product was received. */
+  received_at?: Maybe<Scalars['Int']>;
+  /** Description of the cardholder's attempt to return the product. */
+  return_description?: Maybe<Scalars['String']>;
+  /** Result of cardholder's attempt to return the product. */
+  return_status?: Maybe<Stripe_IssuingDisputeMerchandiseNotAsDescribedEvidenceReturnStatusProperty>;
+  /** Date when the product was returned or attempted to be returned. */
+  returned_at?: Maybe<Scalars['Int']>;
+};
+
+export type Stripe_IssuingDisputeMerchandiseNotAsDescribedEvidenceAdditionalDocumentationProperty = WrappedString | Stripe_File;
+
+export enum Stripe_IssuingDisputeMerchandiseNotAsDescribedEvidenceReturnStatusProperty {
+  MerchantRejected = 'merchant_rejected',
+  Successful = 'successful'
+}
+
+export type Stripe_IssuingDisputeNotReceivedEvidence = {
+  __typename?: 'Stripe_IssuingDisputeNotReceivedEvidence';
+  additional_documentation?: Maybe<Stripe_IssuingDisputeNotReceivedEvidenceAdditionalDocumentationProperty>;
+  /** Date when the cardholder expected to receive the product. */
+  expected_at?: Maybe<Scalars['Int']>;
+  /** Explanation of why the cardholder is disputing this transaction. */
+  explanation?: Maybe<Scalars['String']>;
+  /** Description of the merchandise or service that was purchased. */
+  product_description?: Maybe<Scalars['String']>;
+  /** Whether the product was a merchandise or service. */
+  product_type?: Maybe<Stripe_IssuingDisputeNotReceivedEvidenceProductTypeProperty>;
+};
+
+export type Stripe_IssuingDisputeNotReceivedEvidenceAdditionalDocumentationProperty = WrappedString | Stripe_File;
+
+export enum Stripe_IssuingDisputeNotReceivedEvidenceProductTypeProperty {
+  Merchandise = 'merchandise',
+  Service = 'service'
+}
+
+export type Stripe_IssuingDisputeOtherEvidence = {
+  __typename?: 'Stripe_IssuingDisputeOtherEvidence';
+  additional_documentation?: Maybe<Stripe_IssuingDisputeOtherEvidenceAdditionalDocumentationProperty>;
+  /** Explanation of why the cardholder is disputing this transaction. */
+  explanation?: Maybe<Scalars['String']>;
+  /** Description of the merchandise or service that was purchased. */
+  product_description?: Maybe<Scalars['String']>;
+  /** Whether the product was a merchandise or service. */
+  product_type?: Maybe<Stripe_IssuingDisputeOtherEvidenceProductTypeProperty>;
+};
+
+export type Stripe_IssuingDisputeOtherEvidenceAdditionalDocumentationProperty = WrappedString | Stripe_File;
+
+export enum Stripe_IssuingDisputeOtherEvidenceProductTypeProperty {
+  Merchandise = 'merchandise',
+  Service = 'service'
+}
+
+export enum Stripe_IssuingDisputeEvidenceReasonProperty {
+  Canceled = 'canceled',
+  Duplicate = 'duplicate',
+  Fraudulent = 'fraudulent',
+  MerchandiseNotAsDescribed = 'merchandise_not_as_described',
+  NotReceived = 'not_received',
+  Other = 'other',
+  ServiceNotAsDescribed = 'service_not_as_described'
+}
+
+export type Stripe_IssuingDisputeServiceNotAsDescribedEvidence = {
+  __typename?: 'Stripe_IssuingDisputeServiceNotAsDescribedEvidence';
+  additional_documentation?: Maybe<Stripe_IssuingDisputeServiceNotAsDescribedEvidenceAdditionalDocumentationProperty>;
+  /** Date when order was canceled. */
+  canceled_at?: Maybe<Scalars['Int']>;
+  /** Reason for canceling the order. */
+  cancellation_reason?: Maybe<Scalars['String']>;
+  /** Explanation of why the cardholder is disputing this transaction. */
+  explanation?: Maybe<Scalars['String']>;
+  /** Date when the product was received. */
+  received_at?: Maybe<Scalars['Int']>;
+};
+
+export type Stripe_IssuingDisputeServiceNotAsDescribedEvidenceAdditionalDocumentationProperty = WrappedString | Stripe_File;
+
+export enum Stripe_IssuingDisputeObjectProperty {
+  IssuingDoTdispute = 'issuingDOTdispute'
+}
+
+export enum Stripe_IssuingDisputeStatusProperty {
+  Expired = 'expired',
+  Lost = 'lost',
+  Submitted = 'submitted',
+  Unsubmitted = 'unsubmitted',
+  Won = 'won'
+}
+
+export type Stripe_IssuingDisputeTransactionProperty = WrappedString | Stripe_IssuingTransaction;
+
+export enum Stripe_IssuingTransactionObjectProperty {
+  IssuingDoTtransaction = 'issuingDOTtransaction'
+}
+
+export type Stripe_IssuingTransactionPurchaseDetails = {
+  __typename?: 'Stripe_IssuingTransactionPurchaseDetails';
+  flight?: Maybe<Stripe_IssuingTransactionFlightData>;
+  fuel?: Maybe<Stripe_IssuingTransactionFuelData>;
+  lodging?: Maybe<Stripe_IssuingTransactionLodgingData>;
+  /** The line items in the purchase. */
+  receipt?: Maybe<Array<Maybe<Stripe_IssuingTransactionReceiptData>>>;
+  /** A merchant-specific order number. */
+  reference?: Maybe<Scalars['String']>;
+};
+
+export type Stripe_IssuingTransactionFlightData = {
+  __typename?: 'Stripe_IssuingTransactionFlightData';
+  /** The time that the flight departed. */
+  departure_at?: Maybe<Scalars['Int']>;
+  /** The name of the passenger. */
+  passenger_name?: Maybe<Scalars['String']>;
+  /** Whether the ticket is refundable. */
+  refundable?: Maybe<Scalars['Boolean']>;
+  /** The legs of the trip. */
+  segments?: Maybe<Array<Maybe<Stripe_IssuingTransactionFlightDataLeg>>>;
+  /** The travel agency that issued the ticket. */
+  travel_agency?: Maybe<Scalars['String']>;
+};
+
+export type Stripe_IssuingTransactionFlightDataLeg = {
+  __typename?: 'Stripe_IssuingTransactionFlightDataLeg';
+  /** The three-letter IATA airport code of the flight's destination. */
+  arrival_airport_code?: Maybe<Scalars['String']>;
+  /** The airline carrier code. */
+  carrier?: Maybe<Scalars['String']>;
+  /** The three-letter IATA airport code that the flight departed from. */
+  departure_airport_code?: Maybe<Scalars['String']>;
+  /** The flight number. */
+  flight_number?: Maybe<Scalars['String']>;
+  /** The flight's service class. */
+  service_class?: Maybe<Scalars['String']>;
+  /** Whether a stopover is allowed on this flight. */
+  stopover_allowed?: Maybe<Scalars['Boolean']>;
+};
+
+export type Stripe_IssuingTransactionFuelData = {
+  __typename?: 'Stripe_IssuingTransactionFuelData';
+  /** The type of fuel that was purchased. One of `diesel`, `unleaded_plus`, `unleaded_regular`, `unleaded_super`, or `other`. */
+  type?: Maybe<Scalars['String']>;
+  /** The units for `volume_decimal`. One of `us_gallon` or `liter`. */
+  unit?: Maybe<Scalars['String']>;
+  /** The cost in cents per each unit of fuel, represented as a decimal string with at most 12 decimal places. */
+  unit_cost_decimal?: Maybe<Scalars['String']>;
+  /** The volume of the fuel that was pumped, represented as a decimal string with at most 12 decimal places. */
+  volume_decimal?: Maybe<Scalars['String']>;
+};
+
+export type Stripe_IssuingTransactionLodgingData = {
+  __typename?: 'Stripe_IssuingTransactionLodgingData';
+  /** The time of checking into the lodging. */
+  check_in_at?: Maybe<Scalars['Int']>;
+  /** The number of nights stayed at the lodging. */
+  nights?: Maybe<Scalars['Int']>;
+};
+
+export type Stripe_IssuingTransactionReceiptData = {
+  __typename?: 'Stripe_IssuingTransactionReceiptData';
+  /** The description of the item. The maximum length of this field is 26 characters. */
+  description?: Maybe<Scalars['String']>;
+  /** The quantity of the item. */
+  quantity?: Maybe<Scalars['Float']>;
+  /** The total for this line item in cents. */
+  total?: Maybe<Scalars['Int']>;
+  /** The unit cost of the item in cents. */
+  unit_cost?: Maybe<Scalars['Int']>;
+};
+
+export enum Stripe_IssuingTransactionTypeProperty {
+  Capture = 'capture',
+  Refund = 'refund'
+}
+
+export enum Stripe_IssuingTransactionWalletProperty {
+  ApplePay = 'apple_pay',
+  GooglePay = 'google_pay',
+  SamsungPay = 'samsung_pay'
+}
+
+export type Stripe_IssuingAuthorizationVerificationData = {
+  __typename?: 'Stripe_IssuingAuthorizationVerificationData';
+  /** Whether the cardholder provided an address first line and if it matched the cardholder’s `billing.address.line1`. */
+  address_line1_check?: Maybe<Stripe_IssuingAuthorizationVerificationDataAddressLine1CheckProperty>;
+  /** Whether the cardholder provided a postal code and if it matched the cardholder’s `billing.address.postal_code`. */
+  address_postal_code_check?: Maybe<Stripe_IssuingAuthorizationVerificationDataAddressPostalCodeCheckProperty>;
+  /** Whether the cardholder provided a CVC and if it matched Stripe’s record. */
+  cvc_check?: Maybe<Stripe_IssuingAuthorizationVerificationDataCvcCheckProperty>;
+  /** Whether the cardholder provided an expiry date and if it matched Stripe’s record. */
+  expiry_check?: Maybe<Stripe_IssuingAuthorizationVerificationDataExpiryCheckProperty>;
+};
+
+export enum Stripe_IssuingAuthorizationVerificationDataAddressLine1CheckProperty {
+  Match = 'match',
+  Mismatch = 'mismatch',
+  NotProvided = 'not_provided'
+}
+
+export enum Stripe_IssuingAuthorizationVerificationDataAddressPostalCodeCheckProperty {
+  Match = 'match',
+  Mismatch = 'mismatch',
+  NotProvided = 'not_provided'
+}
+
+export enum Stripe_IssuingAuthorizationVerificationDataCvcCheckProperty {
+  Match = 'match',
+  Mismatch = 'mismatch',
+  NotProvided = 'not_provided'
+}
+
+export enum Stripe_IssuingAuthorizationVerificationDataExpiryCheckProperty {
+  Match = 'match',
+  Mismatch = 'mismatch',
+  NotProvided = 'not_provided'
+}
+
+export type Stripe_Payout = {
+  __typename?: 'Stripe_Payout';
+  /** Amount (in %s) to be transferred to your bank account or debit card. */
+  amount?: Maybe<Scalars['Int']>;
+  /** Date the payout is expected to arrive in the bank. This factors in delays like weekends or bank holidays. */
+  arrival_date?: Maybe<Scalars['Int']>;
+  /** Returns `true` if the payout was created by an [automated payout schedule](https://stripe.com/docs/payouts#payout-schedule), and `false` if it was [requested manually](https://stripe.com/docs/payouts#manual-payouts). */
+  automatic?: Maybe<Scalars['Boolean']>;
+  balance_transaction?: Maybe<Stripe_PayoutBalanceTransactionProperty>;
+  /** Time at which the object was created. Measured in seconds since the Unix epoch. */
+  created?: Maybe<Scalars['Int']>;
+  /** Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies). */
+  currency?: Maybe<Scalars['String']>;
+  /** An arbitrary string attached to the object. Often useful for displaying to users. */
+  description?: Maybe<Scalars['String']>;
+  destination?: Maybe<Stripe_PayoutDestinationProperty>;
+  failure_balance_transaction?: Maybe<Stripe_PayoutFailureBalanceTransactionProperty>;
+  /** Error code explaining reason for payout failure if available. See [Types of payout failures](https://stripe.com/docs/api#payout_failures) for a list of failure codes. */
+  failure_code?: Maybe<Scalars['String']>;
+  /** Message to user further explaining reason for payout failure if available. */
+  failure_message?: Maybe<Scalars['String']>;
+  /** Unique identifier for the object. */
+  id?: Maybe<Scalars['String']>;
+  /** Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode. */
+  livemode?: Maybe<Scalars['Boolean']>;
+  /** Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. */
+  metadata?: Maybe<Scalars['JSONObject']>;
+  /** The method used to send this payout, which can be `standard` or `instant`. `instant` is only supported for payouts to debit cards. (See [Instant payouts for marketplaces](https://stripe.com/blog/instant-payouts-for-marketplaces) for more information.) */
+  method?: Maybe<Scalars['String']>;
+  /** String representing the object's type. Objects of the same type share the same value. */
+  object?: Maybe<Stripe_PayoutObjectProperty>;
+  original_payout?: Maybe<Stripe_PayoutOriginalPayoutProperty>;
+  reversed_by?: Maybe<Stripe_PayoutReversedByProperty>;
+  /** The source balance this payout came from. One of `card`, `fpx`, or `bank_account`. */
+  source_type?: Maybe<Scalars['String']>;
+  /** Extra information about a payout to be displayed on the user's bank statement. */
+  statement_descriptor?: Maybe<Scalars['String']>;
+  /** Current status of the payout: `paid`, `pending`, `in_transit`, `canceled` or `failed`. A payout is `pending` until it is submitted to the bank, when it becomes `in_transit`. The status then changes to `paid` if the transaction goes through, or to `failed` or `canceled` (within 5 business days). Some failed payouts may initially show as `paid` but then change to `failed`. */
+  status?: Maybe<Scalars['String']>;
+  /** Can be `bank_account` or `card`. */
+  type?: Maybe<Stripe_PayoutTypeProperty>;
+};
+
+export type Stripe_PayoutBalanceTransactionProperty = WrappedString | Stripe_BalanceTransaction;
+
+export type Stripe_PayoutDestinationProperty = WrappedString | Stripe_BankAccount | Stripe_Card | Stripe_DeletedBankAccount | Stripe_DeletedCard;
+
+export type Stripe_DeletedBankAccount = {
+  __typename?: 'Stripe_DeletedBankAccount';
+  /** Three-letter [ISO code for the currency](https://stripe.com/docs/payouts) paid out to the bank account. */
+  currency?: Maybe<Scalars['String']>;
+  /** Unique identifier for the object. */
+  id?: Maybe<Scalars['String']>;
+  /** String representing the object's type. Objects of the same type share the same value. */
+  object?: Maybe<Stripe_DeletedBankAccountObjectProperty>;
+};
+
+export enum Stripe_DeletedBankAccountObjectProperty {
+  BankAccount = 'bank_account'
+}
+
+export type Stripe_DeletedCard = {
+  __typename?: 'Stripe_DeletedCard';
+  /** Three-letter [ISO code for the currency](https://stripe.com/docs/payouts) paid out to the bank account. */
+  currency?: Maybe<Scalars['String']>;
+  /** Unique identifier for the object. */
+  id?: Maybe<Scalars['String']>;
+  /** String representing the object's type. Objects of the same type share the same value. */
+  object?: Maybe<Stripe_DeletedCardObjectProperty>;
+};
+
+export enum Stripe_DeletedCardObjectProperty {
+  Card = 'card'
+}
+
+export type Stripe_PayoutFailureBalanceTransactionProperty = WrappedString | Stripe_BalanceTransaction;
+
+export enum Stripe_PayoutObjectProperty {
+  Payout = 'payout'
+}
+
+export type Stripe_PayoutOriginalPayoutProperty = WrappedString | Stripe_Payout;
+
+export type Stripe_PayoutReversedByProperty = WrappedString | Stripe_Payout;
+
+export enum Stripe_PayoutTypeProperty {
+  BankAccount = 'bank_account',
+  Card = 'card'
+}
+
+export type Stripe_PlatformTaxFee = {
+  __typename?: 'Stripe_PlatformTaxFee';
+  /** The Connected account that incurred this charge. */
+  account?: Maybe<Scalars['String']>;
+  /** Unique identifier for the object. */
+  id?: Maybe<Scalars['String']>;
+  /** String representing the object's type. Objects of the same type share the same value. */
+  object?: Maybe<Stripe_PlatformTaxFeeObjectProperty>;
+  /** The payment object that caused this tax to be inflicted. */
+  source_transaction?: Maybe<Scalars['String']>;
+  /** The type of tax (VAT). */
+  type?: Maybe<Scalars['String']>;
+};
+
+export enum Stripe_PlatformTaxFeeObjectProperty {
+  PlatformTaxFee = 'platform_tax_fee'
+}
+
+export type Stripe_Refund = {
+  __typename?: 'Stripe_Refund';
+  /** Amount, in %s. */
+  amount?: Maybe<Scalars['Int']>;
+  balance_transaction?: Maybe<Stripe_RefundBalanceTransactionProperty>;
+  charge?: Maybe<Stripe_RefundChargeProperty>;
+  /** Time at which the object was created. Measured in seconds since the Unix epoch. */
+  created?: Maybe<Scalars['Int']>;
+  /** Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies). */
+  currency?: Maybe<Scalars['String']>;
+  /** An arbitrary string attached to the object. Often useful for displaying to users. (Available on non-card refunds only) */
+  description?: Maybe<Scalars['String']>;
+  failure_balance_transaction?: Maybe<Stripe_RefundFailureBalanceTransactionProperty>;
+  /** If the refund failed, the reason for refund failure if known. Possible values are `lost_or_stolen_card`, `expired_or_canceled_card`, or `unknown`. */
+  failure_reason?: Maybe<Scalars['String']>;
+  /** Unique identifier for the object. */
+  id?: Maybe<Scalars['String']>;
+  /** Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. */
+  metadata?: Maybe<Scalars['JSONObject']>;
+  /** String representing the object's type. Objects of the same type share the same value. */
+  object?: Maybe<Stripe_RefundObjectProperty>;
+  payment_intent?: Maybe<Stripe_RefundPaymentIntentProperty>;
+  /** Reason for the refund, either user-provided (`duplicate`, `fraudulent`, or `requested_by_customer`) or generated by Stripe internally (`expired_uncaptured_charge`). */
+  reason?: Maybe<Scalars['String']>;
+  /** This is the transaction number that appears on email receipts sent for this refund. */
+  receipt_number?: Maybe<Scalars['String']>;
+  source_transfer_reversal?: Maybe<Stripe_RefundSourceTransferReversalProperty>;
+  /** Status of the refund. For credit card refunds, this can be `pending`, `succeeded`, or `failed`. For other types of refunds, it can be `pending`, `succeeded`, `failed`, or `canceled`. Refer to our [refunds](https://stripe.com/docs/refunds#failed-refunds) documentation for more details. */
+  status?: Maybe<Scalars['String']>;
+  transfer_reversal?: Maybe<Stripe_RefundTransferReversalProperty>;
+};
+
+export type Stripe_RefundBalanceTransactionProperty = WrappedString | Stripe_BalanceTransaction;
+
+export type Stripe_RefundChargeProperty = WrappedString | Stripe_Charge;
+
+export type Stripe_RefundFailureBalanceTransactionProperty = WrappedString | Stripe_BalanceTransaction;
+
+export enum Stripe_RefundObjectProperty {
+  Refund = 'refund'
+}
+
+export type Stripe_RefundPaymentIntentProperty = WrappedString | Stripe_PaymentIntent;
+
+export type Stripe_RefundSourceTransferReversalProperty = WrappedString | Stripe_TransferReversal;
+
+export type Stripe_TransferReversal = {
+  __typename?: 'Stripe_TransferReversal';
+  /** Amount, in %s. */
+  amount?: Maybe<Scalars['Int']>;
+  balance_transaction?: Maybe<Stripe_TransferReversalBalanceTransactionProperty>;
+  /** Time at which the object was created. Measured in seconds since the Unix epoch. */
+  created?: Maybe<Scalars['Int']>;
+  /** Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies). */
+  currency?: Maybe<Scalars['String']>;
+  destination_payment_refund?: Maybe<Stripe_TransferReversalDestinationPaymentRefundProperty>;
+  /** Unique identifier for the object. */
+  id?: Maybe<Scalars['String']>;
+  /** Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. */
+  metadata?: Maybe<Scalars['JSONObject']>;
+  /** String representing the object's type. Objects of the same type share the same value. */
+  object?: Maybe<Stripe_TransferReversalObjectProperty>;
+  source_refund?: Maybe<Stripe_TransferReversalSourceRefundProperty>;
+  transfer?: Maybe<Stripe_TransferReversalTransferProperty>;
+};
+
+export type Stripe_TransferReversalBalanceTransactionProperty = WrappedString | Stripe_BalanceTransaction;
+
+export type Stripe_TransferReversalDestinationPaymentRefundProperty = WrappedString | Stripe_Refund;
+
+export enum Stripe_TransferReversalObjectProperty {
+  TransferReversal = 'transfer_reversal'
+}
+
+export type Stripe_TransferReversalSourceRefundProperty = WrappedString | Stripe_Refund;
+
+export type Stripe_TransferReversalTransferProperty = WrappedString | Stripe_Transfer;
+
+export type Stripe_Transfer = {
+  __typename?: 'Stripe_Transfer';
+  /** Amount in %s to be transferred. */
+  amount?: Maybe<Scalars['Int']>;
+  /** Amount in %s reversed (can be less than the amount attribute on the transfer if a partial reversal was issued). */
+  amount_reversed?: Maybe<Scalars['Int']>;
+  balance_transaction?: Maybe<Stripe_TransferBalanceTransactionProperty>;
+  /** Time that this record of the transfer was first created. */
+  created?: Maybe<Scalars['Int']>;
+  /** Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies). */
+  currency?: Maybe<Scalars['String']>;
+  /** An arbitrary string attached to the object. Often useful for displaying to users. */
+  description?: Maybe<Scalars['String']>;
+  destination?: Maybe<Stripe_TransferDestinationProperty>;
+  destination_payment?: Maybe<Stripe_TransferDestinationPaymentProperty>;
+  /** Unique identifier for the object. */
+  id?: Maybe<Scalars['String']>;
+  /** Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode. */
+  livemode?: Maybe<Scalars['Boolean']>;
+  /** Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. */
+  metadata?: Maybe<Scalars['JSONObject']>;
+  /** String representing the object's type. Objects of the same type share the same value. */
+  object?: Maybe<Stripe_TransferObjectProperty>;
+  /** A list of reversals that have been applied to the transfer. */
+  reversals?: Maybe<Stripe_TransferReversalsProperty>;
+  /** Whether the transfer has been fully reversed. If the transfer is only partially reversed, this attribute will still be false. */
+  reversed?: Maybe<Scalars['Boolean']>;
+  source_transaction?: Maybe<Stripe_TransferSourceTransactionProperty>;
+  /** The source balance this transfer came from. One of `card`, `fpx`, or `bank_account`. */
+  source_type?: Maybe<Scalars['String']>;
+  /** A string that identifies this transaction as part of a group. See the [Connect documentation](https://stripe.com/docs/connect/charges-transfers#transfer-options) for details. */
+  transfer_group?: Maybe<Scalars['String']>;
+};
+
+export type Stripe_TransferBalanceTransactionProperty = WrappedString | Stripe_BalanceTransaction;
+
+export type Stripe_TransferDestinationProperty = WrappedString | Stripe_Account;
+
+export type Stripe_TransferDestinationPaymentProperty = WrappedString | Stripe_Charge;
+
+export enum Stripe_TransferObjectProperty {
+  Transfer = 'transfer'
+}
+
+/** A list of reversals that have been applied to the transfer. */
+export type Stripe_TransferReversalsProperty = {
+  __typename?: 'Stripe_TransferReversalsProperty';
+  /** Details about each object. */
+  data: Array<Stripe_TransferReversal>;
+  /** True if this list has another page of items after this one that can be fetched. */
+  has_more: Scalars['Boolean'];
+  /** String representing the object's type. Objects of the same type share the same value. Always has the value `list`. */
+  object: Stripe_TransferReversalsObjectProperty;
+  /** The URL where this list can be accessed. */
+  url: Scalars['String'];
+};
+
+export enum Stripe_TransferReversalsObjectProperty {
+  List = 'list'
+}
+
+export type Stripe_TransferSourceTransactionProperty = WrappedString | Stripe_Charge;
+
+export type Stripe_RefundTransferReversalProperty = WrappedString | Stripe_TransferReversal;
+
+export type Stripe_ReserveTransaction = {
+  __typename?: 'Stripe_ReserveTransaction';
+  amount?: Maybe<Scalars['Int']>;
+  /** Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies). */
+  currency?: Maybe<Scalars['String']>;
+  /** An arbitrary string attached to the object. Often useful for displaying to users. */
+  description?: Maybe<Scalars['String']>;
+  /** Unique identifier for the object. */
+  id?: Maybe<Scalars['String']>;
+  /** String representing the object's type. Objects of the same type share the same value. */
+  object?: Maybe<Stripe_ReserveTransactionObjectProperty>;
+};
+
+export enum Stripe_ReserveTransactionObjectProperty {
+  ReserveTransaction = 'reserve_transaction'
+}
+
+export type Stripe_TaxDeductedAtSource = {
+  __typename?: 'Stripe_TaxDeductedAtSource';
+  /** Unique identifier for the object. */
+  id?: Maybe<Scalars['String']>;
+  /** String representing the object's type. Objects of the same type share the same value. */
+  object?: Maybe<Stripe_TaxDeductedAtSourceObjectProperty>;
+  /** The end of the invoicing period. This TDS applies to Stripe fees collected during this invoicing period. */
+  period_end?: Maybe<Scalars['Int']>;
+  /** The start of the invoicing period. This TDS applies to Stripe fees collected during this invoicing period. */
+  period_start?: Maybe<Scalars['Int']>;
+  /** The TAN that was supplied to Stripe when TDS was assessed */
+  tax_deduction_account_number?: Maybe<Scalars['String']>;
+};
+
+export enum Stripe_TaxDeductedAtSourceObjectProperty {
+  TaxDeductedAtSource = 'tax_deducted_at_source'
+}
+
+export type Stripe_Topup = {
+  __typename?: 'Stripe_Topup';
+  /** Amount transferred. */
+  amount?: Maybe<Scalars['Int']>;
+  balance_transaction?: Maybe<Stripe_TopupBalanceTransactionProperty>;
+  /** Time at which the object was created. Measured in seconds since the Unix epoch. */
+  created?: Maybe<Scalars['Int']>;
+  /** Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies). */
+  currency?: Maybe<Scalars['String']>;
+  /** An arbitrary string attached to the object. Often useful for displaying to users. */
+  description?: Maybe<Scalars['String']>;
+  /** Date the funds are expected to arrive in your Stripe account for payouts. This factors in delays like weekends or bank holidays. May not be specified depending on status of top-up. */
+  expected_availability_date?: Maybe<Scalars['Int']>;
+  /** Error code explaining reason for top-up failure if available (see [the errors section](https://stripe.com/docs/api#errors) for a list of codes). */
+  failure_code?: Maybe<Scalars['String']>;
+  /** Message to user further explaining reason for top-up failure if available. */
+  failure_message?: Maybe<Scalars['String']>;
+  /** Unique identifier for the object. */
+  id?: Maybe<Scalars['String']>;
+  /** Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode. */
+  livemode?: Maybe<Scalars['Boolean']>;
+  /** Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. */
+  metadata?: Maybe<Scalars['JSONObject']>;
+  /** String representing the object's type. Objects of the same type share the same value. */
+  object?: Maybe<Stripe_TopupObjectProperty>;
+  source?: Maybe<Stripe_Source>;
+  /** Extra information about a top-up. This will appear on your source's bank statement. It must contain at least one letter. */
+  statement_descriptor?: Maybe<Scalars['String']>;
+  /** The status of the top-up is either `canceled`, `failed`, `pending`, `reversed`, or `succeeded`. */
+  status?: Maybe<Stripe_TopupStatusProperty>;
+  /** A string that identifies this top-up as part of a group. */
+  transfer_group?: Maybe<Scalars['String']>;
+};
+
+export type Stripe_TopupBalanceTransactionProperty = WrappedString | Stripe_BalanceTransaction;
+
+export enum Stripe_TopupObjectProperty {
+  Topup = 'topup'
+}
+
+export enum Stripe_TopupStatusProperty {
+  Canceled = 'canceled',
+  Failed = 'failed',
+  Pending = 'pending',
+  Reversed = 'reversed',
+  Succeeded = 'succeeded'
+}
+
+export enum Stripe_BalanceTransactionTypeProperty {
+  Adjustment = 'adjustment',
+  Advance = 'advance',
+  AdvanceFunding = 'advance_funding',
+  AnticipationRepayment = 'anticipation_repayment',
+  ApplicationFee = 'application_fee',
+  ApplicationFeeRefund = 'application_fee_refund',
+  Charge = 'charge',
+  ConnectCollectionTransfer = 'connect_collection_transfer',
+  Contribution = 'contribution',
+  IssuingAuthorizationHold = 'issuing_authorization_hold',
+  IssuingAuthorizationRelease = 'issuing_authorization_release',
+  IssuingDispute = 'issuing_dispute',
+  IssuingTransaction = 'issuing_transaction',
+  Payment = 'payment',
+  PaymentFailureRefund = 'payment_failure_refund',
+  PaymentRefund = 'payment_refund',
+  Payout = 'payout',
+  PayoutCancel = 'payout_cancel',
+  PayoutFailure = 'payout_failure',
+  Refund = 'refund',
+  RefundFailure = 'refund_failure',
+  ReserveTransaction = 'reserve_transaction',
+  ReservedFunds = 'reserved_funds',
+  StripeFee = 'stripe_fee',
+  StripeFxFee = 'stripe_fx_fee',
+  TaxFee = 'tax_fee',
+  Topup = 'topup',
+  TopupReversal = 'topup_reversal',
+  Transfer = 'transfer',
+  TransferCancel = 'transfer_cancel',
+  TransferFailure = 'transfer_failure',
+  TransferRefund = 'transfer_refund'
+}
+
+export type Stripe_ApplicationFeeChargeProperty = WrappedString | Stripe_Charge;
+
+export enum Stripe_ApplicationFeeObjectProperty {
+  ApplicationFee = 'application_fee'
+}
+
+export type Stripe_ApplicationFeeOriginatingTransactionProperty = WrappedString | Stripe_Charge;
+
+/** A list of refunds that have been applied to the fee. */
+export type Stripe_ApplicationFeeRefundsProperty = {
+  __typename?: 'Stripe_ApplicationFeeRefundsProperty';
+  /** Details about each object. */
+  data: Array<Stripe_FeeRefund>;
+  /** True if this list has another page of items after this one that can be fetched. */
+  has_more: Scalars['Boolean'];
+  /** String representing the object's type. Objects of the same type share the same value. Always has the value `list`. */
+  object: Stripe_ApplicationFeeRefundsObjectProperty;
+  /** The URL where this list can be accessed. */
+  url: Scalars['String'];
+};
+
+export enum Stripe_ApplicationFeeRefundsObjectProperty {
+  List = 'list'
+}
+
+export type Stripe_ChargeBalanceTransactionProperty = WrappedString | Stripe_BalanceTransaction;
+
+export type Stripe_ChargeCustomerProperty = WrappedString | Stripe_Customer | Stripe_DeletedCustomer;
+
+export type Stripe_ChargeFraudDetails = {
+  __typename?: 'Stripe_ChargeFraudDetails';
+  /** Assessments from Stripe. If set, the value is `fraudulent`. */
+  stripe_report?: Maybe<Scalars['String']>;
+  /** Assessments reported by you. If set, possible values of are `safe` and `fraudulent`. */
+  user_report?: Maybe<Scalars['String']>;
+};
+
+export type Stripe_ChargeInvoiceProperty = WrappedString | Stripe_Invoice;
+
+export type Stripe_Invoice = {
+  __typename?: 'Stripe_Invoice';
+  /** The country of the business associated with this invoice, most often the business creating the invoice. */
+  account_country?: Maybe<Scalars['String']>;
+  /** The public name of the business associated with this invoice, most often the business creating the invoice. */
+  account_name?: Maybe<Scalars['String']>;
+  /** The account tax IDs associated with the invoice. Only editable when the invoice is a draft. */
+  account_tax_ids?: Maybe<Array<Maybe<Stripe_InvoiceAccountTaxIdsProperty>>>;
+  /** Final amount due at this time for this invoice. If the invoice's total is smaller than the minimum charge amount, for example, or if there is account credit that can be applied to the invoice, the `amount_due` may be 0. If there is a positive `starting_balance` for the invoice (the customer owes money), the `amount_due` will also take that into account. The charge that gets generated for the invoice will be for the amount specified in `amount_due`. */
+  amount_due?: Maybe<Scalars['Int']>;
+  /** The amount, in %s, that was paid. */
+  amount_paid?: Maybe<Scalars['Int']>;
+  /** The amount remaining, in %s, that is due. */
+  amount_remaining?: Maybe<Scalars['Int']>;
+  /** The fee in %s that will be applied to the invoice and transferred to the application owner's Stripe account when the invoice is paid. */
+  application_fee_amount?: Maybe<Scalars['Int']>;
+  /** Number of payment attempts made for this invoice, from the perspective of the payment retry schedule. Any payment attempt counts as the first attempt, and subsequently only automatic retries increment the attempt count. In other words, manual payment attempts after the first attempt do not affect the retry schedule. */
+  attempt_count?: Maybe<Scalars['Int']>;
+  /** Whether an attempt has been made to pay the invoice. An invoice is not attempted until 1 hour after the `invoice.created` webhook, for example, so you might not want to display that invoice as unpaid to your users. */
+  attempted?: Maybe<Scalars['Boolean']>;
+  /** Controls whether Stripe will perform [automatic collection](https://stripe.com/docs/billing/invoices/workflow/#auto_advance) of the invoice. When `false`, the invoice's state will not automatically advance without an explicit action. */
+  auto_advance?: Maybe<Scalars['Boolean']>;
+  automatic_tax?: Maybe<Stripe_AutomaticTax>;
+  /** Indicates the reason why the invoice was created. `subscription_cycle` indicates an invoice created by a subscription advancing into a new period. `subscription_create` indicates an invoice created due to creating a subscription. `subscription_update` indicates an invoice created due to updating a subscription. `subscription` is set for all old invoices to indicate either a change to a subscription or a period advancement. `manual` is set for all invoices unrelated to a subscription (for example: created via the invoice editor). The `upcoming` value is reserved for simulated invoices per the upcoming invoice endpoint. `subscription_threshold` indicates an invoice created due to a billing threshold being reached. */
+  billing_reason?: Maybe<Stripe_InvoiceBillingReasonProperty>;
+  charge?: Maybe<Stripe_InvoiceChargeProperty>;
+  /** Either `charge_automatically`, or `send_invoice`. When charging automatically, Stripe will attempt to pay this invoice using the default source attached to the customer. When sending an invoice, Stripe will email this invoice to the customer with payment instructions. */
+  collection_method?: Maybe<Stripe_InvoiceCollectionMethodProperty>;
+  /** Time at which the object was created. Measured in seconds since the Unix epoch. */
+  created?: Maybe<Scalars['Int']>;
+  /** Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies). */
+  currency?: Maybe<Scalars['String']>;
+  /** Custom fields displayed on the invoice. */
+  custom_fields?: Maybe<Array<Maybe<Stripe_InvoiceSettingCustomField>>>;
+  customer?: Maybe<Stripe_InvoiceCustomerProperty>;
+  customer_address?: Maybe<Stripe_Address>;
+  /** The customer's email. Until the invoice is finalized, this field will equal `customer.email`. Once the invoice is finalized, this field will no longer be updated. */
+  customer_email?: Maybe<Scalars['String']>;
+  /** The customer's name. Until the invoice is finalized, this field will equal `customer.name`. Once the invoice is finalized, this field will no longer be updated. */
+  customer_name?: Maybe<Scalars['String']>;
+  /** The customer's phone number. Until the invoice is finalized, this field will equal `customer.phone`. Once the invoice is finalized, this field will no longer be updated. */
+  customer_phone?: Maybe<Scalars['String']>;
+  customer_shipping?: Maybe<Stripe_Shipping>;
+  /** The customer's tax exempt status. Until the invoice is finalized, this field will equal `customer.tax_exempt`. Once the invoice is finalized, this field will no longer be updated. */
+  customer_tax_exempt?: Maybe<Stripe_InvoiceCustomerTaxExemptProperty>;
+  /** The customer's tax IDs. Until the invoice is finalized, this field will contain the same tax IDs as `customer.tax_ids`. Once the invoice is finalized, this field will no longer be updated. */
+  customer_tax_ids?: Maybe<Array<Maybe<Stripe_InvoicesResourceInvoiceTaxId>>>;
+  default_payment_method?: Maybe<Stripe_InvoiceDefaultPaymentMethodProperty>;
+  default_source?: Maybe<Stripe_InvoiceDefaultSourceProperty>;
+  /** The tax rates applied to this invoice, if any. */
+  default_tax_rates?: Maybe<Array<Maybe<Stripe_TaxRate>>>;
+  /** An arbitrary string attached to the object. Often useful for displaying to users. Referenced as 'memo' in the Dashboard. */
+  description?: Maybe<Scalars['String']>;
+  discount?: Maybe<Stripe_Discount>;
+  /** The discounts applied to the invoice. Line item discounts are applied before invoice discounts. Use `expand[]=discounts` to expand each discount. */
+  discounts?: Maybe<Array<Maybe<Stripe_InvoiceDiscountsProperty>>>;
+  /** The date on which payment for this invoice is due. This value will be `null` for invoices where `collection_method=charge_automatically`. */
+  due_date?: Maybe<Scalars['Int']>;
+  /** Ending customer balance after the invoice is finalized. Invoices are finalized approximately an hour after successful webhook delivery or when payment collection is attempted for the invoice. If the invoice has not been finalized yet, this will be null. */
+  ending_balance?: Maybe<Scalars['Int']>;
+  /** Footer displayed on the invoice. */
+  footer?: Maybe<Scalars['String']>;
+  /** The URL for the hosted invoice page, which allows customers to view and pay an invoice. If the invoice has not been finalized yet, this will be null. */
+  hosted_invoice_url?: Maybe<Scalars['String']>;
+  /** Unique identifier for the object. */
+  id?: Maybe<Scalars['String']>;
+  /** The link to download the PDF for the invoice. If the invoice has not been finalized yet, this will be null. */
+  invoice_pdf?: Maybe<Scalars['String']>;
+  last_finalization_error?: Maybe<Stripe_ApiErrors>;
+  /** The individual line items that make up the invoice. `lines` is sorted as follows: invoice items in reverse chronological order, followed by the subscription, if any. */
+  lines?: Maybe<Stripe_InvoiceLinesProperty>;
+  /** Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode. */
+  livemode?: Maybe<Scalars['Boolean']>;
+  /** Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. */
+  metadata?: Maybe<Scalars['JSONObject']>;
+  /** The time at which payment will next be attempted. This value will be `null` for invoices where `collection_method=send_invoice`. */
+  next_payment_attempt?: Maybe<Scalars['Int']>;
+  /** A unique, identifying string that appears on emails sent to the customer for this invoice. This starts with the customer's unique invoice_prefix if it is specified. */
+  number?: Maybe<Scalars['String']>;
+  /** String representing the object's type. Objects of the same type share the same value. */
+  object?: Maybe<Stripe_InvoiceObjectProperty>;
+  on_behalf_of?: Maybe<Stripe_InvoiceOnBehalfOfProperty>;
+  /** Whether payment was successfully collected for this invoice. An invoice can be paid (most commonly) with a charge or with credit from the customer's account balance. */
+  paid?: Maybe<Scalars['Boolean']>;
+  payment_intent?: Maybe<Stripe_InvoicePaymentIntentProperty>;
+  payment_settings?: Maybe<Stripe_InvoicesPaymentSettings>;
+  /** End of the usage period during which invoice items were added to this invoice. */
+  period_end?: Maybe<Scalars['Int']>;
+  /** Start of the usage period during which invoice items were added to this invoice. */
+  period_start?: Maybe<Scalars['Int']>;
+  /** Total amount of all post-payment credit notes issued for this invoice. */
+  post_payment_credit_notes_amount?: Maybe<Scalars['Int']>;
+  /** Total amount of all pre-payment credit notes issued for this invoice. */
+  pre_payment_credit_notes_amount?: Maybe<Scalars['Int']>;
+  quote?: Maybe<Stripe_InvoiceQuoteProperty>;
+  /** This is the transaction number that appears on email receipts sent for this invoice. */
+  receipt_number?: Maybe<Scalars['String']>;
+  /** Starting customer balance before the invoice is finalized. If the invoice has not been finalized yet, this will be the current customer balance. */
+  starting_balance?: Maybe<Scalars['Int']>;
+  /** Extra information about an invoice for the customer's credit card statement. */
+  statement_descriptor?: Maybe<Scalars['String']>;
+  /** The status of the invoice, one of `draft`, `open`, `paid`, `uncollectible`, or `void`. [Learn more](https://stripe.com/docs/billing/invoices/workflow#workflow-overview) */
+  status?: Maybe<Stripe_InvoiceStatusProperty>;
+  status_transitions?: Maybe<Stripe_InvoicesStatusTransitions>;
+  subscription?: Maybe<Stripe_InvoiceSubscriptionProperty>;
+  /** Only set for upcoming invoices that preview prorations. The time used to calculate prorations. */
+  subscription_proration_date?: Maybe<Scalars['Int']>;
+  /** Total of all subscriptions, invoice items, and prorations on the invoice before any invoice level discount or tax is applied. Item discounts are already incorporated */
+  subtotal?: Maybe<Scalars['Int']>;
+  /** The amount of tax on this invoice. This is the sum of all the tax amounts on this invoice. */
+  tax?: Maybe<Scalars['Int']>;
+  threshold_reason?: Maybe<Stripe_InvoiceThresholdReason>;
+  /** Total after discounts and taxes. */
+  total?: Maybe<Scalars['Int']>;
+  /** The aggregate amounts calculated per discount across all line items. */
+  total_discount_amounts?: Maybe<Array<Maybe<Stripe_DiscountsResourceDiscountAmount>>>;
+  /** The aggregate amounts calculated per tax rate for all line items. */
+  total_tax_amounts?: Maybe<Array<Maybe<Stripe_InvoiceTaxAmount>>>;
+  transfer_data?: Maybe<Stripe_InvoiceTransferData>;
+  /** Invoices are automatically paid or sent 1 hour after webhooks are delivered, or until all webhook delivery attempts have [been exhausted](https://stripe.com/docs/billing/webhooks#understand). This field tracks the time when webhooks for this invoice were successfully delivered. If the invoice had no webhooks to deliver, this will be set while the invoice is being created. */
+  webhooks_delivered_at?: Maybe<Scalars['Int']>;
+};
+
+export type Stripe_InvoiceAccountTaxIdsProperty = WrappedString | Stripe_TaxId;
+
+export type Stripe_TaxId = {
+  __typename?: 'Stripe_TaxId';
+  /** Two-letter ISO code representing the country of the tax ID. */
+  country?: Maybe<Scalars['String']>;
+  /** Time at which the object was created. Measured in seconds since the Unix epoch. */
+  created?: Maybe<Scalars['Int']>;
+  customer?: Maybe<Stripe_TaxIdCustomerProperty>;
+  /** Unique identifier for the object. */
+  id?: Maybe<Scalars['String']>;
+  /** Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode. */
+  livemode?: Maybe<Scalars['Boolean']>;
+  /** String representing the object's type. Objects of the same type share the same value. */
+  object?: Maybe<Stripe_TaxIdObjectProperty>;
+  /** Type of the tax ID, one of `ae_trn`, `au_abn`, `br_cnpj`, `br_cpf`, `ca_bn`, `ca_gst_hst`, `ca_pst_bc`, `ca_pst_mb`, `ca_pst_sk`, `ca_qst`, `ch_vat`, `cl_tin`, `es_cif`, `eu_vat`, `gb_vat`, `hk_br`, `id_npwp`, `il_vat`, `in_gst`, `jp_cn`, `jp_rn`, `kr_brn`, `li_uid`, `mx_rfc`, `my_frp`, `my_itn`, `my_sst`, `no_vat`, `nz_gst`, `ru_inn`, `ru_kpp`, `sa_vat`, `sg_gst`, `sg_uen`, `th_vat`, `tw_vat`, `us_ein`, or `za_vat`. Note that some legacy tax IDs have type `unknown` */
+  type?: Maybe<Stripe_TaxIdTypeProperty>;
+  /** Value of the tax ID. */
+  value?: Maybe<Scalars['String']>;
+  verification?: Maybe<Stripe_TaxIdVerification>;
+};
+
+export type Stripe_TaxIdCustomerProperty = WrappedString | Stripe_Customer;
+
+export enum Stripe_TaxIdObjectProperty {
+  TaxId = 'tax_id'
+}
+
+export enum Stripe_TaxIdTypeProperty {
+  AeTrn = 'ae_trn',
+  AuAbn = 'au_abn',
+  BrCnpj = 'br_cnpj',
+  BrCpf = 'br_cpf',
+  CaBn = 'ca_bn',
+  CaGstHst = 'ca_gst_hst',
+  CaPstBc = 'ca_pst_bc',
+  CaPstMb = 'ca_pst_mb',
+  CaPstSk = 'ca_pst_sk',
+  CaQst = 'ca_qst',
+  ChVat = 'ch_vat',
+  ClTin = 'cl_tin',
+  EsCif = 'es_cif',
+  EuVat = 'eu_vat',
+  GbVat = 'gb_vat',
+  HkBr = 'hk_br',
+  IdNpwp = 'id_npwp',
+  IlVat = 'il_vat',
+  InGst = 'in_gst',
+  JpCn = 'jp_cn',
+  JpRn = 'jp_rn',
+  KrBrn = 'kr_brn',
+  LiUid = 'li_uid',
+  MxRfc = 'mx_rfc',
+  MyFrp = 'my_frp',
+  MyItn = 'my_itn',
+  MySst = 'my_sst',
+  NoVat = 'no_vat',
+  NzGst = 'nz_gst',
+  RuInn = 'ru_inn',
+  RuKpp = 'ru_kpp',
+  SaVat = 'sa_vat',
+  SgGst = 'sg_gst',
+  SgUen = 'sg_uen',
+  ThVat = 'th_vat',
+  TwVat = 'tw_vat',
+  Unknown = 'unknown',
+  UsEin = 'us_ein',
+  ZaVat = 'za_vat'
+}
+
+export type Stripe_TaxIdVerification = {
+  __typename?: 'Stripe_TaxIdVerification';
+  /** Verification status, one of `pending`, `verified`, `unverified`, or `unavailable`. */
+  status?: Maybe<Stripe_TaxIdVerificationStatusProperty>;
+  /** Verified address. */
+  verified_address?: Maybe<Scalars['String']>;
+  /** Verified name. */
+  verified_name?: Maybe<Scalars['String']>;
+};
+
+export enum Stripe_TaxIdVerificationStatusProperty {
+  Pending = 'pending',
+  Unavailable = 'unavailable',
+  Unverified = 'unverified',
+  Verified = 'verified'
+}
+
+export type Stripe_AutomaticTax = {
+  __typename?: 'Stripe_AutomaticTax';
+  /** Whether Stripe automatically computes tax on this invoice. */
+  enabled?: Maybe<Scalars['Boolean']>;
+  /** The status of the most recent automated tax calculation for this invoice. */
+  status?: Maybe<Stripe_AutomaticTaxStatusProperty>;
+};
+
+export enum Stripe_AutomaticTaxStatusProperty {
+  Complete = 'complete',
+  Failed = 'failed',
+  RequiresLocationInputs = 'requires_location_inputs'
+}
+
+export enum Stripe_InvoiceBillingReasonProperty {
+  AutomaticPendingInvoiceItemInvoice = 'automatic_pending_invoice_item_invoice',
+  Manual = 'manual',
+  QuoteAccept = 'quote_accept',
+  Subscription = 'subscription',
+  SubscriptionCreate = 'subscription_create',
+  SubscriptionCycle = 'subscription_cycle',
+  SubscriptionThreshold = 'subscription_threshold',
+  SubscriptionUpdate = 'subscription_update',
+  Upcoming = 'upcoming'
+}
+
+export type Stripe_InvoiceChargeProperty = WrappedString | Stripe_Charge;
+
+export enum Stripe_InvoiceCollectionMethodProperty {
+  ChargeAutomatically = 'charge_automatically',
+  SendInvoice = 'send_invoice'
+}
+
+export type Stripe_InvoiceCustomerProperty = WrappedString | Stripe_Customer | Stripe_DeletedCustomer;
+
+export enum Stripe_InvoiceCustomerTaxExemptProperty {
+  Exempt = 'exempt',
+  None = 'none',
+  Reverse = 'reverse'
+}
+
+export type Stripe_InvoicesResourceInvoiceTaxId = {
+  __typename?: 'Stripe_InvoicesResourceInvoiceTaxId';
+  /** The type of the tax ID, one of `eu_vat`, `br_cnpj`, `br_cpf`, `gb_vat`, `nz_gst`, `au_abn`, `in_gst`, `no_vat`, `za_vat`, `ch_vat`, `mx_rfc`, `sg_uen`, `ru_inn`, `ru_kpp`, `ca_bn`, `hk_br`, `es_cif`, `tw_vat`, `th_vat`, `jp_cn`, `jp_rn`, `li_uid`, `my_itn`, `us_ein`, `kr_brn`, `ca_qst`, `ca_gst_hst`, `ca_pst_bc`, `ca_pst_mb`, `ca_pst_sk`, `my_sst`, `sg_gst`, `ae_trn`, `cl_tin`, `sa_vat`, `id_npwp`, `my_frp`, `il_vat`, or `unknown` */
+  type?: Maybe<Stripe_InvoicesResourceInvoiceTaxIdTypeProperty>;
+  /** The value of the tax ID. */
+  value?: Maybe<Scalars['String']>;
+};
+
+export enum Stripe_InvoicesResourceInvoiceTaxIdTypeProperty {
+  AeTrn = 'ae_trn',
+  AuAbn = 'au_abn',
+  BrCnpj = 'br_cnpj',
+  BrCpf = 'br_cpf',
+  CaBn = 'ca_bn',
+  CaGstHst = 'ca_gst_hst',
+  CaPstBc = 'ca_pst_bc',
+  CaPstMb = 'ca_pst_mb',
+  CaPstSk = 'ca_pst_sk',
+  CaQst = 'ca_qst',
+  ChVat = 'ch_vat',
+  ClTin = 'cl_tin',
+  EsCif = 'es_cif',
+  EuVat = 'eu_vat',
+  GbVat = 'gb_vat',
+  HkBr = 'hk_br',
+  IdNpwp = 'id_npwp',
+  IlVat = 'il_vat',
+  InGst = 'in_gst',
+  JpCn = 'jp_cn',
+  JpRn = 'jp_rn',
+  KrBrn = 'kr_brn',
+  LiUid = 'li_uid',
+  MxRfc = 'mx_rfc',
+  MyFrp = 'my_frp',
+  MyItn = 'my_itn',
+  MySst = 'my_sst',
+  NoVat = 'no_vat',
+  NzGst = 'nz_gst',
+  RuInn = 'ru_inn',
+  RuKpp = 'ru_kpp',
+  SaVat = 'sa_vat',
+  SgGst = 'sg_gst',
+  SgUen = 'sg_uen',
+  ThVat = 'th_vat',
+  TwVat = 'tw_vat',
+  Unknown = 'unknown',
+  UsEin = 'us_ein',
+  ZaVat = 'za_vat'
+}
+
+export type Stripe_InvoiceDefaultPaymentMethodProperty = WrappedString | Stripe_PaymentMethod;
+
+export type Stripe_InvoiceDefaultSourceProperty = WrappedString | Stripe_AlipayAccount | Stripe_BankAccount | Stripe_BitcoinReceiver | Stripe_Card | Stripe_Source;
+
+export type Stripe_TaxRate = {
+  __typename?: 'Stripe_TaxRate';
+  /** Defaults to `true`. When set to `false`, this tax rate cannot be used with new applications or Checkout Sessions, but will still work for subscriptions and invoices that already have it set. */
+  active?: Maybe<Scalars['Boolean']>;
+  /** Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)). */
+  country?: Maybe<Scalars['String']>;
+  /** Time at which the object was created. Measured in seconds since the Unix epoch. */
+  created?: Maybe<Scalars['Int']>;
+  /** An arbitrary string attached to the tax rate for your internal use only. It will not be visible to your customers. */
+  description?: Maybe<Scalars['String']>;
+  /** The display name of the tax rates as it will appear to your customer on their receipt email, PDF, and the hosted invoice page. */
+  display_name?: Maybe<Scalars['String']>;
+  /** Unique identifier for the object. */
+  id?: Maybe<Scalars['String']>;
+  /** This specifies if the tax rate is inclusive or exclusive. */
+  inclusive?: Maybe<Scalars['Boolean']>;
+  /** The jurisdiction for the tax rate. You can use this label field for tax reporting purposes. It also appears on your customer’s invoice. */
+  jurisdiction?: Maybe<Scalars['String']>;
+  /** Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode. */
+  livemode?: Maybe<Scalars['Boolean']>;
+  /** Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. */
+  metadata?: Maybe<Scalars['JSONObject']>;
+  /** String representing the object's type. Objects of the same type share the same value. */
+  object?: Maybe<Stripe_TaxRateObjectProperty>;
+  /** This represents the tax rate percent out of 100. */
+  percentage?: Maybe<Scalars['Float']>;
+  /** [ISO 3166-2 subdivision code](https://en.wikipedia.org/wiki/ISO_3166-2:US), without country prefix. For example, "NY" for New York, United States. */
+  state?: Maybe<Scalars['String']>;
+  /** The high-level tax type, such as `vat` or `sales_tax`. */
+  tax_type?: Maybe<Stripe_TaxRateTaxTypeProperty>;
+};
+
+export enum Stripe_TaxRateObjectProperty {
+  TaxRate = 'tax_rate'
+}
+
+export enum Stripe_TaxRateTaxTypeProperty {
+  Gst = 'gst',
+  Hst = 'hst',
+  Pst = 'pst',
+  Qst = 'qst',
+  SalesTax = 'sales_tax',
+  Vat = 'vat'
+}
+
+export type Stripe_InvoiceDiscountsProperty = WrappedString | Stripe_Discount | Stripe_DeletedDiscount;
+
+export type Stripe_DeletedDiscount = {
+  __typename?: 'Stripe_DeletedDiscount';
+  /** The Checkout session that this coupon is applied to, if it is applied to a particular session in payment mode. Will not be present for subscription mode. */
+  checkout_session?: Maybe<Scalars['String']>;
+  coupon?: Maybe<Stripe_Coupon>;
+  customer?: Maybe<Stripe_DeletedDiscountCustomerProperty>;
+  /** The ID of the discount object. Discounts cannot be fetched by ID. Use `expand[]=discounts` in API calls to expand discount IDs in an array. */
+  id?: Maybe<Scalars['String']>;
+  /** The invoice that the discount's coupon was applied to, if it was applied directly to a particular invoice. */
+  invoice?: Maybe<Scalars['String']>;
+  /** The invoice item `id` (or invoice line item `id` for invoice line items of type='subscription') that the discount's coupon was applied to, if it was applied directly to a particular invoice item or invoice line item. */
+  invoice_item?: Maybe<Scalars['String']>;
+  /** String representing the object's type. Objects of the same type share the same value. */
+  object?: Maybe<Stripe_DeletedDiscountObjectProperty>;
+  promotion_code?: Maybe<Stripe_DeletedDiscountPromotionCodeProperty>;
+  /** Date that the coupon was applied. */
+  start?: Maybe<Scalars['Int']>;
+  /** The subscription that this coupon is applied to, if it is applied to a particular subscription. */
+  subscription?: Maybe<Scalars['String']>;
+};
+
+export type Stripe_DeletedDiscountCustomerProperty = WrappedString | Stripe_Customer | Stripe_DeletedCustomer;
+
+export enum Stripe_DeletedDiscountObjectProperty {
+  Discount = 'discount'
+}
+
+export type Stripe_DeletedDiscountPromotionCodeProperty = WrappedString | Stripe_PromotionCode;
+
+/** The individual line items that make up the invoice. `lines` is sorted as follows: invoice items in reverse chronological order, followed by the subscription, if any. */
+export type Stripe_InvoiceLinesProperty = {
+  __typename?: 'Stripe_InvoiceLinesProperty';
+  /** Details about each object. */
+  data: Array<Stripe_LineItem>;
+  /** True if this list has another page of items after this one that can be fetched. */
+  has_more: Scalars['Boolean'];
+  /** String representing the object's type. Objects of the same type share the same value. Always has the value `list`. */
+  object: Stripe_InvoiceLinesObjectProperty;
+  /** The URL where this list can be accessed. */
+  url: Scalars['String'];
+};
+
+export type Stripe_LineItem = {
+  __typename?: 'Stripe_LineItem';
+  /** The amount, in %s. */
+  amount?: Maybe<Scalars['Int']>;
+  /** Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies). */
+  currency?: Maybe<Scalars['String']>;
+  /** An arbitrary string attached to the object. Often useful for displaying to users. */
+  description?: Maybe<Scalars['String']>;
+  /** The amount of discount calculated per discount for this line item. */
+  discount_amounts?: Maybe<Array<Maybe<Stripe_DiscountsResourceDiscountAmount>>>;
+  /** If true, discounts will apply to this line item. Always false for prorations. */
+  discountable?: Maybe<Scalars['Boolean']>;
+  /** The discounts applied to the invoice line item. Line item discounts are applied before invoice discounts. Use `expand[]=discounts` to expand each discount. */
+  discounts?: Maybe<Array<Maybe<Stripe_LineItemDiscountsProperty>>>;
+  /** Unique identifier for the object. */
+  id?: Maybe<Scalars['String']>;
+  /** The ID of the [invoice item](https://stripe.com/docs/api/invoiceitems) associated with this line item if any. */
+  invoice_item?: Maybe<Scalars['String']>;
+  /** Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode. */
+  livemode?: Maybe<Scalars['Boolean']>;
+  /** Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Note that for line items with `type=subscription` this will reflect the metadata of the subscription that caused the line item to be created. */
+  metadata?: Maybe<Scalars['JSONObject']>;
+  /** String representing the object's type. Objects of the same type share the same value. */
+  object?: Maybe<Stripe_LineItemObjectProperty>;
+  period?: Maybe<Stripe_InvoiceLineItemPeriod>;
+  price?: Maybe<Stripe_Price>;
+  /** Whether this is a proration. */
+  proration?: Maybe<Scalars['Boolean']>;
+  /** The quantity of the subscription, if the line item is a subscription or a proration. */
+  quantity?: Maybe<Scalars['Int']>;
+  /** The subscription that the invoice item pertains to, if any. */
+  subscription?: Maybe<Scalars['String']>;
+  /** The subscription item that generated this invoice item. Left empty if the line item is not an explicit result of a subscription. */
+  subscription_item?: Maybe<Scalars['String']>;
+  /** The amount of tax calculated per tax rate for this line item */
+  tax_amounts?: Maybe<Array<Maybe<Stripe_InvoiceTaxAmount>>>;
+  /** The tax rates which apply to the line item. */
+  tax_rates?: Maybe<Array<Maybe<Stripe_TaxRate>>>;
+  /** A string identifying the type of the source of this line item, either an `invoiceitem` or a `subscription`. */
+  type?: Maybe<Stripe_LineItemTypeProperty>;
+};
+
+export type Stripe_DiscountsResourceDiscountAmount = {
+  __typename?: 'Stripe_DiscountsResourceDiscountAmount';
+  /** The amount, in %s, of the discount. */
+  amount?: Maybe<Scalars['Int']>;
+  discount?: Maybe<Stripe_DiscountsResourceDiscountAmountDiscountProperty>;
+};
+
+export type Stripe_DiscountsResourceDiscountAmountDiscountProperty = WrappedString | Stripe_Discount | Stripe_DeletedDiscount;
+
+export type Stripe_LineItemDiscountsProperty = WrappedString | Stripe_Discount;
+
+export enum Stripe_LineItemObjectProperty {
+  LineItem = 'line_item'
+}
+
+export type Stripe_InvoiceLineItemPeriod = {
+  __typename?: 'Stripe_InvoiceLineItemPeriod';
+  /** End of the line item's billing period */
+  end?: Maybe<Scalars['Int']>;
+  /** Start of the line item's billing period */
+  start?: Maybe<Scalars['Int']>;
+};
+
+export type Stripe_InvoiceTaxAmount = {
+  __typename?: 'Stripe_InvoiceTaxAmount';
+  /** The amount, in %s, of the tax. */
+  amount?: Maybe<Scalars['Int']>;
+  /** Whether this tax amount is inclusive or exclusive. */
+  inclusive?: Maybe<Scalars['Boolean']>;
+  tax_rate?: Maybe<Stripe_InvoiceTaxAmountTaxRateProperty>;
+};
+
+export type Stripe_InvoiceTaxAmountTaxRateProperty = WrappedString | Stripe_TaxRate;
+
+export enum Stripe_LineItemTypeProperty {
+  Invoiceitem = 'invoiceitem',
+  Subscription = 'subscription'
+}
+
+export enum Stripe_InvoiceLinesObjectProperty {
+  List = 'list'
+}
+
+export enum Stripe_InvoiceObjectProperty {
+  Invoice = 'invoice'
+}
+
+export type Stripe_InvoiceOnBehalfOfProperty = WrappedString | Stripe_Account;
+
+export type Stripe_InvoicePaymentIntentProperty = WrappedString | Stripe_PaymentIntent;
+
+export type Stripe_InvoicesPaymentSettings = {
+  __typename?: 'Stripe_InvoicesPaymentSettings';
+  payment_method_options?: Maybe<Stripe_InvoicesPaymentMethodOptions>;
+  /** The list of payment method types (e.g. card) to provide to the invoice’s PaymentIntent. If not set, Stripe attempts to automatically determine the types to use by looking at the invoice’s default payment method, the subscription’s default payment method, the customer’s default payment method, and your [invoice template settings](https://dashboard.stripe.com/settings/billing/invoice). */
+  payment_method_types?: Maybe<Array<Maybe<Stripe_InvoicesPaymentSettingsPaymentMethodTypesProperty>>>;
+};
+
+export type Stripe_InvoicesPaymentMethodOptions = {
+  __typename?: 'Stripe_InvoicesPaymentMethodOptions';
+  bancontact?: Maybe<Stripe_InvoicePaymentMethodOptionsBancontact>;
+  card?: Maybe<Stripe_InvoicePaymentMethodOptionsCard>;
+};
+
+export type Stripe_InvoicePaymentMethodOptionsBancontact = {
+  __typename?: 'Stripe_InvoicePaymentMethodOptionsBancontact';
+  /** Preferred language of the Bancontact authorization page that the customer is redirected to. */
+  preferred_language?: Maybe<Stripe_InvoicePaymentMethodOptionsBancontactPreferredLanguageProperty>;
+};
+
+export enum Stripe_InvoicePaymentMethodOptionsBancontactPreferredLanguageProperty {
+  De = 'de',
+  En = 'en',
+  Fr = 'fr',
+  Nl = 'nl'
+}
+
+export type Stripe_InvoicePaymentMethodOptionsCard = {
+  __typename?: 'Stripe_InvoicePaymentMethodOptionsCard';
+  /** We strongly recommend that you rely on our SCA Engine to automatically prompt your customers for authentication based on risk level and [other requirements](https://stripe.com/docs/strong-customer-authentication). However, if you wish to request 3D Secure based on logic from your own fraud engine, provide this option. Read our guide on [manually requesting 3D Secure](https://stripe.com/docs/payments/3d-secure#manual-three-ds) for more information on how this configuration interacts with Radar and our SCA Engine. */
+  request_three_d_secure?: Maybe<Stripe_InvoicePaymentMethodOptionsCardRequestThreeDSecureProperty>;
+};
+
+export enum Stripe_InvoicePaymentMethodOptionsCardRequestThreeDSecureProperty {
+  Any = 'any',
+  Automatic = 'automatic'
+}
+
+export enum Stripe_InvoicesPaymentSettingsPaymentMethodTypesProperty {
+  AchCreditTransfer = 'ach_credit_transfer',
+  AchDebit = 'ach_debit',
+  AuBecsDebit = 'au_becs_debit',
+  BacsDebit = 'bacs_debit',
+  Bancontact = 'bancontact',
+  Boleto = 'boleto',
+  Card = 'card',
+  Fpx = 'fpx',
+  Giropay = 'giropay',
+  Ideal = 'ideal',
+  SepaDebit = 'sepa_debit',
+  Sofort = 'sofort',
+  WechatPay = 'wechat_pay'
+}
+
+export type Stripe_InvoiceQuoteProperty = WrappedString | Stripe_Quote;
+
+export type Stripe_Quote = {
+  __typename?: 'Stripe_Quote';
+  /** Total before any discounts or taxes are applied. */
+  amount_subtotal?: Maybe<Scalars['Int']>;
+  /** Total after discounts and taxes are applied. */
+  amount_total?: Maybe<Scalars['Int']>;
+  /** The amount of the application fee (if any) that will be requested to be applied to the payment and transferred to the application owner's Stripe account. Only applicable if there are no line items with recurring prices on the quote. */
+  application_fee_amount?: Maybe<Scalars['Int']>;
+  /** A non-negative decimal between 0 and 100, with at most two decimal places. This represents the percentage of the subscription invoice subtotal that will be transferred to the application owner's Stripe account. Only applicable if there are line items with recurring prices on the quote. */
+  application_fee_percent?: Maybe<Scalars['Float']>;
+  automatic_tax?: Maybe<Stripe_QuotesResourceAutomaticTax>;
+  /** Either `charge_automatically`, or `send_invoice`. When charging automatically, Stripe will attempt to pay invoices at the end of the subscription cycle or on finalization using the default payment method attached to the subscription or customer. When sending an invoice, Stripe will email your customer an invoice with payment instructions. Defaults to `charge_automatically`. */
+  collection_method?: Maybe<Stripe_QuoteCollectionMethodProperty>;
+  computed?: Maybe<Stripe_QuotesResourceComputed>;
+  /** Time at which the object was created. Measured in seconds since the Unix epoch. */
+  created?: Maybe<Scalars['Int']>;
+  /** Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies). */
+  currency?: Maybe<Scalars['String']>;
+  customer?: Maybe<Stripe_QuoteCustomerProperty>;
+  /** The tax rates applied to this quote. */
+  default_tax_rates?: Maybe<Array<Maybe<Stripe_QuoteDefaultTaxRatesProperty>>>;
+  /** A description that will be displayed on the quote PDF. */
+  description?: Maybe<Scalars['String']>;
+  /** The discounts applied to this quote. */
+  discounts?: Maybe<Array<Maybe<Stripe_QuoteDiscountsProperty>>>;
+  /** The date on which the quote will be canceled if in `open` or `draft` status. Measured in seconds since the Unix epoch. */
+  expires_at?: Maybe<Scalars['Int']>;
+  /** A footer that will be displayed on the quote PDF. */
+  footer?: Maybe<Scalars['String']>;
+  from_quote?: Maybe<Stripe_QuotesResourceFromQuote>;
+  /** A header that will be displayed on the quote PDF. */
+  header?: Maybe<Scalars['String']>;
+  /** Unique identifier for the object. */
+  id?: Maybe<Scalars['String']>;
+  invoice?: Maybe<Stripe_QuoteInvoiceProperty>;
+  invoice_settings?: Maybe<Stripe_InvoiceSettingQuoteSetting>;
+  /** A list of items the customer is being quoted for. */
+  line_items?: Maybe<Stripe_QuoteLineItemsProperty>;
+  /** Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode. */
+  livemode?: Maybe<Scalars['Boolean']>;
+  /** Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. */
+  metadata?: Maybe<Scalars['JSONObject']>;
+  /** A unique number that identifies this particular quote. This number is assigned once the quote is [finalized](https://stripe.com/docs/quotes/overview#finalize). */
+  number?: Maybe<Scalars['String']>;
+  /** String representing the object's type. Objects of the same type share the same value. */
+  object?: Maybe<Stripe_QuoteObjectProperty>;
+  on_behalf_of?: Maybe<Stripe_QuoteOnBehalfOfProperty>;
+  /** The status of the quote. */
+  status?: Maybe<Stripe_QuoteStatusProperty>;
+  status_transitions?: Maybe<Stripe_QuotesResourceStatusTransitions>;
+  subscription?: Maybe<Stripe_QuoteSubscriptionProperty>;
+  subscription_data?: Maybe<Stripe_QuotesResourceSubscriptionData>;
+  subscription_schedule?: Maybe<Stripe_QuoteSubscriptionScheduleProperty>;
+  total_details?: Maybe<Stripe_QuotesResourceTotalDetails>;
+  transfer_data?: Maybe<Stripe_QuotesResourceTransferData>;
+};
+
+export type Stripe_QuotesResourceAutomaticTax = {
+  __typename?: 'Stripe_QuotesResourceAutomaticTax';
+  /** Automatically calculate taxes */
+  enabled?: Maybe<Scalars['Boolean']>;
+  /** The status of the most recent automated tax calculation for this quote. */
+  status?: Maybe<Stripe_QuotesResourceAutomaticTaxStatusProperty>;
+};
+
+export enum Stripe_QuotesResourceAutomaticTaxStatusProperty {
+  Complete = 'complete',
+  Failed = 'failed',
+  RequiresLocationInputs = 'requires_location_inputs'
+}
+
+export enum Stripe_QuoteCollectionMethodProperty {
+  ChargeAutomatically = 'charge_automatically',
+  SendInvoice = 'send_invoice'
+}
+
+export type Stripe_QuotesResourceComputed = {
+  __typename?: 'Stripe_QuotesResourceComputed';
+  recurring?: Maybe<Stripe_QuotesResourceRecurring>;
+  upfront?: Maybe<Stripe_QuotesResourceUpfront>;
+};
+
+export type Stripe_QuotesResourceRecurring = {
+  __typename?: 'Stripe_QuotesResourceRecurring';
+  /** Total before any discounts or taxes are applied. */
+  amount_subtotal?: Maybe<Scalars['Int']>;
+  /** Total after discounts and taxes are applied. */
+  amount_total?: Maybe<Scalars['Int']>;
+  /** The frequency at which a subscription is billed. One of `day`, `week`, `month` or `year`. */
+  interval?: Maybe<Stripe_QuotesResourceRecurringIntervalProperty>;
+  /** The number of intervals (specified in the `interval` attribute) between subscription billings. For example, `interval=month` and `interval_count=3` bills every 3 months. */
+  interval_count?: Maybe<Scalars['Int']>;
+  total_details?: Maybe<Stripe_QuotesResourceTotalDetails>;
+};
+
+export enum Stripe_QuotesResourceRecurringIntervalProperty {
+  Day = 'day',
+  Month = 'month',
+  Week = 'week',
+  Year = 'year'
+}
+
+export type Stripe_QuotesResourceTotalDetails = {
+  __typename?: 'Stripe_QuotesResourceTotalDetails';
+  /** This is the sum of all the line item discounts. */
+  amount_discount?: Maybe<Scalars['Int']>;
+  /** This is the sum of all the line item shipping amounts. */
+  amount_shipping?: Maybe<Scalars['Int']>;
+  /** This is the sum of all the line item tax amounts. */
+  amount_tax?: Maybe<Scalars['Int']>;
+  breakdown?: Maybe<Stripe_QuotesResourceTotalDetailsResourceBreakdown>;
+};
+
+export type Stripe_QuotesResourceTotalDetailsResourceBreakdown = {
+  __typename?: 'Stripe_QuotesResourceTotalDetailsResourceBreakdown';
+  /** The aggregated line item discounts. */
+  discounts?: Maybe<Array<Maybe<Stripe_LineItemsDiscountAmount>>>;
+  /** The aggregated line item tax amounts by rate. */
+  taxes?: Maybe<Array<Maybe<Stripe_LineItemsTaxAmount>>>;
+};
+
+export type Stripe_LineItemsDiscountAmount = {
+  __typename?: 'Stripe_LineItemsDiscountAmount';
+  /** The amount discounted. */
+  amount?: Maybe<Scalars['Int']>;
+  discount?: Maybe<Stripe_Discount>;
+};
+
+export type Stripe_LineItemsTaxAmount = {
+  __typename?: 'Stripe_LineItemsTaxAmount';
+  /** Amount of tax applied for this rate. */
+  amount?: Maybe<Scalars['Int']>;
+  rate?: Maybe<Stripe_TaxRate>;
+};
+
+export type Stripe_QuotesResourceUpfront = {
+  __typename?: 'Stripe_QuotesResourceUpfront';
+  /** Total before any discounts or taxes are applied. */
+  amount_subtotal?: Maybe<Scalars['Int']>;
+  /** Total after discounts and taxes are applied. */
+  amount_total?: Maybe<Scalars['Int']>;
+  /** The line items that will appear on the next invoice after this quote is accepted. This does not include pending invoice items that exist on the customer but may still be included in the next invoice. */
+  line_items?: Maybe<Stripe_QuotesResourceUpfrontLineItemsProperty>;
+  total_details?: Maybe<Stripe_QuotesResourceTotalDetails>;
+};
+
+/** The line items that will appear on the next invoice after this quote is accepted. This does not include pending invoice items that exist on the customer but may still be included in the next invoice. */
+export type Stripe_QuotesResourceUpfrontLineItemsProperty = {
+  __typename?: 'Stripe_QuotesResourceUpfrontLineItemsProperty';
+  /** Details about each object. */
+  data: Array<Stripe_Item>;
+  /** True if this list has another page of items after this one that can be fetched. */
+  has_more: Scalars['Boolean'];
+  /** String representing the object's type. Objects of the same type share the same value. Always has the value `list`. */
+  object: Stripe_QuotesResourceUpfrontLineItemsObjectProperty;
+  /** The URL where this list can be accessed. */
+  url: Scalars['String'];
+};
+
+export type Stripe_Item = {
+  __typename?: 'Stripe_Item';
+  /** Total before any discounts or taxes are applied. */
+  amount_subtotal?: Maybe<Scalars['Int']>;
+  /** Total after discounts and taxes. */
+  amount_total?: Maybe<Scalars['Int']>;
+  /** Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies). */
+  currency?: Maybe<Scalars['String']>;
+  /** An arbitrary string attached to the object. Often useful for displaying to users. Defaults to product name. */
+  description?: Maybe<Scalars['String']>;
+  /** The discounts applied to the line item. */
+  discounts?: Maybe<Array<Maybe<Stripe_LineItemsDiscountAmount>>>;
+  /** Unique identifier for the object. */
+  id?: Maybe<Scalars['String']>;
+  /** String representing the object's type. Objects of the same type share the same value. */
+  object?: Maybe<Stripe_ItemObjectProperty>;
+  price?: Maybe<Stripe_Price>;
+  /** The quantity of products being purchased. */
+  quantity?: Maybe<Scalars['Int']>;
+  /** The taxes applied to the line item. */
+  taxes?: Maybe<Array<Maybe<Stripe_LineItemsTaxAmount>>>;
+};
+
+export enum Stripe_ItemObjectProperty {
+  Item = 'item'
+}
+
+export enum Stripe_QuotesResourceUpfrontLineItemsObjectProperty {
+  List = 'list'
+}
+
+export type Stripe_QuoteCustomerProperty = WrappedString | Stripe_Customer | Stripe_DeletedCustomer;
+
+export type Stripe_QuoteDefaultTaxRatesProperty = WrappedString | Stripe_TaxRate;
+
+export type Stripe_QuoteDiscountsProperty = WrappedString | Stripe_Discount;
+
+export type Stripe_QuotesResourceFromQuote = {
+  __typename?: 'Stripe_QuotesResourceFromQuote';
+  /** Whether this quote is a revision of a different quote. */
+  is_revision?: Maybe<Scalars['Boolean']>;
+  quote?: Maybe<Stripe_QuotesResourceFromQuoteQuoteProperty>;
+};
+
+export type Stripe_QuotesResourceFromQuoteQuoteProperty = WrappedString | Stripe_Quote;
+
+export type Stripe_QuoteInvoiceProperty = WrappedString | Stripe_Invoice | Stripe_DeletedInvoice;
+
+export type Stripe_DeletedInvoice = {
+  __typename?: 'Stripe_DeletedInvoice';
+  /** Unique identifier for the object. */
+  id?: Maybe<Scalars['String']>;
+  /** String representing the object's type. Objects of the same type share the same value. */
+  object?: Maybe<Stripe_DeletedInvoiceObjectProperty>;
+};
+
+export enum Stripe_DeletedInvoiceObjectProperty {
+  Invoice = 'invoice'
+}
+
+export type Stripe_InvoiceSettingQuoteSetting = {
+  __typename?: 'Stripe_InvoiceSettingQuoteSetting';
+  /** Number of days within which a customer must pay invoices generated by this quote. This value will be `null` for quotes where `collection_method=charge_automatically`. */
+  days_until_due?: Maybe<Scalars['Int']>;
+};
+
+/** A list of items the customer is being quoted for. */
+export type Stripe_QuoteLineItemsProperty = {
+  __typename?: 'Stripe_QuoteLineItemsProperty';
+  /** Details about each object. */
+  data: Array<Stripe_Item>;
+  /** True if this list has another page of items after this one that can be fetched. */
+  has_more: Scalars['Boolean'];
+  /** String representing the object's type. Objects of the same type share the same value. Always has the value `list`. */
+  object: Stripe_QuoteLineItemsObjectProperty;
+  /** The URL where this list can be accessed. */
+  url: Scalars['String'];
+};
+
+export enum Stripe_QuoteLineItemsObjectProperty {
+  List = 'list'
+}
+
+export enum Stripe_QuoteObjectProperty {
+  Quote = 'quote'
+}
+
+export type Stripe_QuoteOnBehalfOfProperty = WrappedString | Stripe_Account;
+
+export enum Stripe_QuoteStatusProperty {
+  Accepted = 'accepted',
+  Canceled = 'canceled',
+  Draft = 'draft',
+  Open = 'open'
+}
+
+export type Stripe_QuotesResourceStatusTransitions = {
+  __typename?: 'Stripe_QuotesResourceStatusTransitions';
+  /** The time that the quote was accepted. Measured in seconds since Unix epoch. */
+  accepted_at?: Maybe<Scalars['Int']>;
+  /** The time that the quote was canceled. Measured in seconds since Unix epoch. */
+  canceled_at?: Maybe<Scalars['Int']>;
+  /** The time that the quote was finalized. Measured in seconds since Unix epoch. */
+  finalized_at?: Maybe<Scalars['Int']>;
+};
+
+export type Stripe_QuoteSubscriptionProperty = WrappedString | Stripe_Subscription;
+
+export type Stripe_Subscription = {
+  __typename?: 'Stripe_Subscription';
+  /** A non-negative decimal between 0 and 100, with at most two decimal places. This represents the percentage of the subscription invoice subtotal that will be transferred to the application owner's Stripe account. */
+  application_fee_percent?: Maybe<Scalars['Float']>;
+  automatic_tax?: Maybe<Stripe_SubscriptionAutomaticTax>;
+  /** Determines the date of the first full invoice, and, for plans with `month` or `year` intervals, the day of the month for subsequent invoices. */
+  billing_cycle_anchor?: Maybe<Scalars['Int']>;
+  billing_thresholds?: Maybe<Stripe_SubscriptionBillingThresholds>;
+  /** A date in the future at which the subscription will automatically get canceled */
+  cancel_at?: Maybe<Scalars['Int']>;
+  /** If the subscription has been canceled with the `at_period_end` flag set to `true`, `cancel_at_period_end` on the subscription will be true. You can use this attribute to determine whether a subscription that has a status of active is scheduled to be canceled at the end of the current period. */
+  cancel_at_period_end?: Maybe<Scalars['Boolean']>;
+  /** If the subscription has been canceled, the date of that cancellation. If the subscription was canceled with `cancel_at_period_end`, `canceled_at` will reflect the time of the most recent update request, not the end of the subscription period when the subscription is automatically moved to a canceled state. */
+  canceled_at?: Maybe<Scalars['Int']>;
+  /** Either `charge_automatically`, or `send_invoice`. When charging automatically, Stripe will attempt to pay this subscription at the end of the cycle using the default source attached to the customer. When sending an invoice, Stripe will email your customer an invoice with payment instructions. */
+  collection_method?: Maybe<Stripe_SubscriptionCollectionMethodProperty>;
+  /** Time at which the object was created. Measured in seconds since the Unix epoch. */
+  created?: Maybe<Scalars['Int']>;
+  /** End of the current period that the subscription has been invoiced for. At the end of this period, a new invoice will be created. */
+  current_period_end?: Maybe<Scalars['Int']>;
+  /** Start of the current period that the subscription has been invoiced for. */
+  current_period_start?: Maybe<Scalars['Int']>;
+  customer?: Maybe<Stripe_SubscriptionCustomerProperty>;
+  /** Number of days a customer has to pay invoices generated by this subscription. This value will be `null` for subscriptions where `collection_method=charge_automatically`. */
+  days_until_due?: Maybe<Scalars['Int']>;
+  default_payment_method?: Maybe<Stripe_SubscriptionDefaultPaymentMethodProperty>;
+  default_source?: Maybe<Stripe_SubscriptionDefaultSourceProperty>;
+  /** The tax rates that will apply to any subscription item that does not have `tax_rates` set. Invoices created will have their `default_tax_rates` populated from the subscription. */
+  default_tax_rates?: Maybe<Array<Maybe<Stripe_TaxRate>>>;
+  discount?: Maybe<Stripe_Discount>;
+  /** If the subscription has ended, the date the subscription ended. */
+  ended_at?: Maybe<Scalars['Int']>;
+  /** Unique identifier for the object. */
+  id?: Maybe<Scalars['String']>;
+  /** List of subscription items, each with an attached price. */
+  items?: Maybe<Stripe_SubscriptionItemsProperty>;
+  latest_invoice?: Maybe<Stripe_SubscriptionLatestInvoiceProperty>;
+  /** Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode. */
+  livemode?: Maybe<Scalars['Boolean']>;
+  /** Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. */
+  metadata?: Maybe<Scalars['JSONObject']>;
+  /** Specifies the approximate timestamp on which any pending invoice items will be billed according to the schedule provided at `pending_invoice_item_interval`. */
+  next_pending_invoice_item_invoice?: Maybe<Scalars['Int']>;
+  /** String representing the object's type. Objects of the same type share the same value. */
+  object?: Maybe<Stripe_SubscriptionObjectProperty>;
+  pause_collection?: Maybe<Stripe_SubscriptionsResourcePauseCollection>;
+  payment_settings?: Maybe<Stripe_SubscriptionsResourcePaymentSettings>;
+  pending_invoice_item_interval?: Maybe<Stripe_SubscriptionPendingInvoiceItemInterval>;
+  pending_setup_intent?: Maybe<Stripe_SubscriptionPendingSetupIntentProperty>;
+  pending_update?: Maybe<Stripe_SubscriptionsResourcePendingUpdate>;
+  schedule?: Maybe<Stripe_SubscriptionScheduleProperty>;
+  /** Date when the subscription was first created. The date might differ from the `created` date due to backdating. */
+  start_date?: Maybe<Scalars['Int']>;
+  /**
+   * Possible values are `incomplete`, `incomplete_expired`, `trialing`, `active`, `past_due`, `canceled`, or `unpaid`.
+   *
+   * For `collection_method=charge_automatically` a subscription moves into `incomplete` if the initial payment attempt fails. A subscription in this state can only have metadata and default_source updated. Once the first invoice is paid, the subscription moves into an `active` state. If the first invoice is not paid within 23 hours, the subscription transitions to `incomplete_expired`. This is a terminal state, the open invoice will be voided and no further invoices will be generated.
+   *
+   * A subscription that is currently in a trial period is `trialing` and moves to `active` when the trial period is over.
+   *
+   * If subscription `collection_method=charge_automatically` it becomes `past_due` when payment to renew it fails and `canceled` or `unpaid` (depending on your subscriptions settings) when Stripe has exhausted all payment retry attempts.
+   *
+   * If subscription `collection_method=send_invoice` it becomes `past_due` when its invoice is not paid by the due date, and `canceled` or `unpaid` if it is still not paid by an additional deadline after that. Note that when a subscription has a status of `unpaid`, no subsequent invoices will be attempted (invoices will be created, but then immediately automatically closed). After receiving updated payment information from a customer, you may choose to reopen and pay their closed invoices.
+   */
+  status?: Maybe<Stripe_SubscriptionStatusProperty>;
+  transfer_data?: Maybe<Stripe_SubscriptionTransferData>;
+  /** If the subscription has a trial, the end of that trial. */
+  trial_end?: Maybe<Scalars['Int']>;
+  /** If the subscription has a trial, the beginning of that trial. */
+  trial_start?: Maybe<Scalars['Int']>;
+};
+
+export type Stripe_SubscriptionAutomaticTax = {
+  __typename?: 'Stripe_SubscriptionAutomaticTax';
+  /** Whether Stripe automatically computes tax on this subscription. */
+  enabled?: Maybe<Scalars['Boolean']>;
+};
+
+export type Stripe_SubscriptionBillingThresholds = {
+  __typename?: 'Stripe_SubscriptionBillingThresholds';
+  /** Monetary threshold that triggers the subscription to create an invoice */
+  amount_gte?: Maybe<Scalars['Int']>;
+  /** Indicates if the `billing_cycle_anchor` should be reset when a threshold is reached. If true, `billing_cycle_anchor` will be updated to the date/time the threshold was last reached; otherwise, the value will remain unchanged. This value may not be `true` if the subscription contains items with plans that have `aggregate_usage=last_ever`. */
+  reset_billing_cycle_anchor?: Maybe<Scalars['Boolean']>;
+};
+
+export enum Stripe_SubscriptionCollectionMethodProperty {
+  ChargeAutomatically = 'charge_automatically',
+  SendInvoice = 'send_invoice'
+}
+
+export type Stripe_SubscriptionCustomerProperty = WrappedString | Stripe_Customer | Stripe_DeletedCustomer;
+
+export type Stripe_SubscriptionDefaultPaymentMethodProperty = WrappedString | Stripe_PaymentMethod;
+
+export type Stripe_SubscriptionDefaultSourceProperty = WrappedString | Stripe_AlipayAccount | Stripe_BankAccount | Stripe_BitcoinReceiver | Stripe_Card | Stripe_Source;
+
+/** List of subscription items, each with an attached price. */
+export type Stripe_SubscriptionItemsProperty = {
+  __typename?: 'Stripe_SubscriptionItemsProperty';
+  /** Details about each object. */
+  data: Array<Stripe_SubscriptionItem>;
+  /** True if this list has another page of items after this one that can be fetched. */
+  has_more: Scalars['Boolean'];
+  /** String representing the object's type. Objects of the same type share the same value. Always has the value `list`. */
+  object: Stripe_SubscriptionItemsObjectProperty;
+  /** The URL where this list can be accessed. */
+  url: Scalars['String'];
+};
+
+export type Stripe_SubscriptionItem = {
+  __typename?: 'Stripe_SubscriptionItem';
+  billing_thresholds?: Maybe<Stripe_SubscriptionItemBillingThresholds>;
+  /** Time at which the object was created. Measured in seconds since the Unix epoch. */
+  created?: Maybe<Scalars['Int']>;
+  /** Unique identifier for the object. */
+  id?: Maybe<Scalars['String']>;
+  /** Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. */
+  metadata?: Maybe<Scalars['JSONObject']>;
+  /** String representing the object's type. Objects of the same type share the same value. */
+  object?: Maybe<Stripe_SubscriptionItemObjectProperty>;
+  price?: Maybe<Stripe_Price>;
+  /** The [quantity](https://stripe.com/docs/subscriptions/quantities) of the plan to which the customer should be subscribed. */
+  quantity?: Maybe<Scalars['Int']>;
+  /** The `subscription` this `subscription_item` belongs to. */
+  subscription?: Maybe<Scalars['String']>;
+  /** The tax rates which apply to this `subscription_item`. When set, the `default_tax_rates` on the subscription do not apply to this `subscription_item`. */
+  tax_rates?: Maybe<Array<Maybe<Stripe_TaxRate>>>;
+};
+
+export type Stripe_SubscriptionItemBillingThresholds = {
+  __typename?: 'Stripe_SubscriptionItemBillingThresholds';
+  /** Usage threshold that triggers the subscription to create an invoice */
+  usage_gte?: Maybe<Scalars['Int']>;
+};
+
+export enum Stripe_SubscriptionItemObjectProperty {
+  SubscriptionItem = 'subscription_item'
+}
+
+export enum Stripe_SubscriptionItemsObjectProperty {
+  List = 'list'
+}
+
+export type Stripe_SubscriptionLatestInvoiceProperty = WrappedString | Stripe_Invoice;
+
+export enum Stripe_SubscriptionObjectProperty {
+  Subscription = 'subscription'
+}
+
+export type Stripe_SubscriptionsResourcePauseCollection = {
+  __typename?: 'Stripe_SubscriptionsResourcePauseCollection';
+  /** The payment collection behavior for this subscription while paused. One of `keep_as_draft`, `mark_uncollectible`, or `void`. */
+  behavior?: Maybe<Stripe_SubscriptionsResourcePauseCollectionBehaviorProperty>;
+  /** The time after which the subscription will resume collecting payments. */
+  resumes_at?: Maybe<Scalars['Int']>;
+};
+
+export enum Stripe_SubscriptionsResourcePauseCollectionBehaviorProperty {
+  KeepAsDraft = 'keep_as_draft',
+  MarkUncollectible = 'mark_uncollectible',
+  Void = 'void'
+}
+
+export type Stripe_SubscriptionsResourcePaymentSettings = {
+  __typename?: 'Stripe_SubscriptionsResourcePaymentSettings';
+  payment_method_options?: Maybe<Stripe_SubscriptionsResourcePaymentMethodOptions>;
+  /** The list of payment method types to provide to every invoice created by the subscription. If not set, Stripe attempts to automatically determine the types to use by looking at the invoice’s default payment method, the subscription’s default payment method, the customer’s default payment method, and your [invoice template settings](https://dashboard.stripe.com/settings/billing/invoice). */
+  payment_method_types?: Maybe<Array<Maybe<Stripe_SubscriptionsResourcePaymentSettingsPaymentMethodTypesProperty>>>;
+};
+
+export type Stripe_SubscriptionsResourcePaymentMethodOptions = {
+  __typename?: 'Stripe_SubscriptionsResourcePaymentMethodOptions';
+  bancontact?: Maybe<Stripe_InvoicePaymentMethodOptionsBancontact>;
+  card?: Maybe<Stripe_InvoicePaymentMethodOptionsCard>;
+};
+
+export enum Stripe_SubscriptionsResourcePaymentSettingsPaymentMethodTypesProperty {
+  AchCreditTransfer = 'ach_credit_transfer',
+  AchDebit = 'ach_debit',
+  AuBecsDebit = 'au_becs_debit',
+  BacsDebit = 'bacs_debit',
+  Bancontact = 'bancontact',
+  Boleto = 'boleto',
+  Card = 'card',
+  Fpx = 'fpx',
+  Giropay = 'giropay',
+  Ideal = 'ideal',
+  SepaDebit = 'sepa_debit',
+  Sofort = 'sofort',
+  WechatPay = 'wechat_pay'
+}
+
+export type Stripe_SubscriptionPendingInvoiceItemInterval = {
+  __typename?: 'Stripe_SubscriptionPendingInvoiceItemInterval';
+  /** Specifies invoicing frequency. Either `day`, `week`, `month` or `year`. */
+  interval?: Maybe<Stripe_SubscriptionPendingInvoiceItemIntervalIntervalProperty>;
+  /** The number of intervals between invoices. For example, `interval=month` and `interval_count=3` bills every 3 months. Maximum of one year interval allowed (1 year, 12 months, or 52 weeks). */
+  interval_count?: Maybe<Scalars['Int']>;
+};
+
+export enum Stripe_SubscriptionPendingInvoiceItemIntervalIntervalProperty {
+  Day = 'day',
+  Month = 'month',
+  Week = 'week',
+  Year = 'year'
+}
+
+export type Stripe_SubscriptionPendingSetupIntentProperty = WrappedString | Stripe_SetupIntent;
+
+export type Stripe_SetupIntent = {
+  __typename?: 'Stripe_SetupIntent';
+  application?: Maybe<Stripe_SetupIntentApplicationProperty>;
+  /** Reason for cancellation of this SetupIntent, one of `abandoned`, `requested_by_customer`, or `duplicate`. */
+  cancellation_reason?: Maybe<Stripe_SetupIntentCancellationReasonProperty>;
+  /**
+   * The client secret of this SetupIntent. Used for client-side retrieval using a publishable key.
+   *
+   * The client secret can be used to complete payment setup from your frontend. It should not be stored, logged, embedded in URLs, or exposed to anyone other than the customer. Make sure that you have TLS enabled on any page that includes the client secret.
+   */
+  client_secret?: Maybe<Scalars['String']>;
+  /** Time at which the object was created. Measured in seconds since the Unix epoch. */
+  created?: Maybe<Scalars['Int']>;
+  customer?: Maybe<Stripe_SetupIntentCustomerProperty>;
+  /** An arbitrary string attached to the object. Often useful for displaying to users. */
+  description?: Maybe<Scalars['String']>;
+  /** Unique identifier for the object. */
+  id?: Maybe<Scalars['String']>;
+  last_setup_error?: Maybe<Stripe_ApiErrors>;
+  latest_attempt?: Maybe<Stripe_SetupIntentLatestAttemptProperty>;
+  /** Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode. */
+  livemode?: Maybe<Scalars['Boolean']>;
+  mandate?: Maybe<Stripe_SetupIntentMandateProperty>;
+  /** Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. */
+  metadata?: Maybe<Scalars['JSONObject']>;
+  next_action?: Maybe<Stripe_SetupIntentNextAction>;
+  /** String representing the object's type. Objects of the same type share the same value. */
+  object?: Maybe<Stripe_SetupIntentObjectProperty>;
+  on_behalf_of?: Maybe<Stripe_SetupIntentOnBehalfOfProperty>;
+  payment_method?: Maybe<Stripe_SetupIntentPaymentMethodProperty>;
+  payment_method_options?: Maybe<Stripe_SetupIntentPaymentMethodOptions>;
+  /** The list of payment method types (e.g. card) that this SetupIntent is allowed to set up. */
+  payment_method_types?: Maybe<Array<Maybe<Scalars['String']>>>;
+  single_use_mandate?: Maybe<Stripe_SetupIntentSingleUseMandateProperty>;
+  /** [Status](https://stripe.com/docs/payments/intents#intent-statuses) of this SetupIntent, one of `requires_payment_method`, `requires_confirmation`, `requires_action`, `processing`, `canceled`, or `succeeded`. */
+  status?: Maybe<Stripe_SetupIntentStatusProperty>;
+  /**
+   * Indicates how the payment method is intended to be used in the future.
+   *
+   * Use `on_session` if you intend to only reuse the payment method when the customer is in your checkout flow. Use `off_session` if your customer may or may not be in your checkout flow. If not provided, this value defaults to `off_session`.
+   */
+  usage?: Maybe<Scalars['String']>;
+};
+
+export type Stripe_SetupIntentApplicationProperty = WrappedString | Stripe_Application;
+
+export enum Stripe_SetupIntentCancellationReasonProperty {
+  Abandoned = 'abandoned',
+  Duplicate = 'duplicate',
+  RequestedByCustomer = 'requested_by_customer'
+}
+
+export type Stripe_SetupIntentCustomerProperty = WrappedString | Stripe_Customer | Stripe_DeletedCustomer;
+
+export type Stripe_SetupIntentLatestAttemptProperty = WrappedString | Stripe_SetupAttempt;
+
+export type Stripe_SetupIntentMandateProperty = WrappedString | Stripe_Mandate;
+
+export type Stripe_SetupIntentNextAction = {
+  __typename?: 'Stripe_SetupIntentNextAction';
+  redirect_to_url?: Maybe<Stripe_SetupIntentNextActionRedirectToUrl>;
+  /** Type of the next action to perform, one of `redirect_to_url`, `use_stripe_sdk`, `alipay_handle_redirect`, or `oxxo_display_details`. */
+  type?: Maybe<Scalars['String']>;
+  /** When confirming a SetupIntent with Stripe.js, Stripe.js depends on the contents of this dictionary to invoke authentication flows. The shape of the contents is subject to change and is only intended to be used by Stripe.js. */
+  use_stripe_sdk?: Maybe<Scalars['JSONObject']>;
+  verify_with_microdeposits?: Maybe<Stripe_SetupIntentNextActionVerifyWithMicrodeposits>;
+};
+
+export type Stripe_SetupIntentNextActionRedirectToUrl = {
+  __typename?: 'Stripe_SetupIntentNextActionRedirectToUrl';
+  /** If the customer does not exit their browser while authenticating, they will be redirected to this specified URL after completion. */
+  return_url?: Maybe<Scalars['String']>;
+  /** The URL you must redirect your customer to in order to authenticate. */
+  url?: Maybe<Scalars['String']>;
+};
+
+export type Stripe_SetupIntentNextActionVerifyWithMicrodeposits = {
+  __typename?: 'Stripe_SetupIntentNextActionVerifyWithMicrodeposits';
+  /** The timestamp when the microdeposits are expected to land. */
+  arrival_date?: Maybe<Scalars['Int']>;
+  /** The URL for the hosted verification page, which allows customers to verify their bank account. */
+  hosted_verification_url?: Maybe<Scalars['String']>;
+};
+
+export enum Stripe_SetupIntentObjectProperty {
+  SetupIntent = 'setup_intent'
+}
+
+export type Stripe_SetupIntentOnBehalfOfProperty = WrappedString | Stripe_Account;
+
+export type Stripe_SetupIntentPaymentMethodProperty = WrappedString | Stripe_PaymentMethod;
+
+export type Stripe_SetupIntentPaymentMethodOptions = {
+  __typename?: 'Stripe_SetupIntentPaymentMethodOptions';
+  acss_debit?: Maybe<Stripe_SetupIntentPaymentMethodOptionsAcssDebit>;
+  card?: Maybe<Stripe_SetupIntentPaymentMethodOptionsCard>;
+  sepa_debit?: Maybe<Stripe_SetupIntentPaymentMethodOptionsSepaDebit>;
+};
+
+export type Stripe_SetupIntentPaymentMethodOptionsAcssDebit = {
+  __typename?: 'Stripe_SetupIntentPaymentMethodOptionsAcssDebit';
+  /** Currency supported by the bank account */
+  currency?: Maybe<Stripe_SetupIntentPaymentMethodOptionsAcssDebitCurrencyProperty>;
+  mandate_options?: Maybe<Stripe_SetupIntentPaymentMethodOptionsMandateOptionsAcssDebit>;
+  /** Bank account verification method. */
+  verification_method?: Maybe<Stripe_SetupIntentPaymentMethodOptionsAcssDebitVerificationMethodProperty>;
+};
+
+export enum Stripe_SetupIntentPaymentMethodOptionsAcssDebitCurrencyProperty {
+  Cad = 'cad',
+  Usd = 'usd'
+}
+
+export type Stripe_SetupIntentPaymentMethodOptionsMandateOptionsAcssDebit = {
+  __typename?: 'Stripe_SetupIntentPaymentMethodOptionsMandateOptionsAcssDebit';
+  /** A URL for custom mandate text */
+  custom_mandate_url?: Maybe<Scalars['String']>;
+  /** Description of the interval. Only required if 'payment_schedule' parmeter is 'interval' or 'combined'. */
+  interval_description?: Maybe<Scalars['String']>;
+  /** Payment schedule for the mandate. */
+  payment_schedule?: Maybe<Stripe_SetupIntentPaymentMethodOptionsMandateOptionsAcssDebitPaymentScheduleProperty>;
+  /** Transaction type of the mandate. */
+  transaction_type?: Maybe<Stripe_SetupIntentPaymentMethodOptionsMandateOptionsAcssDebitTransactionTypeProperty>;
+};
+
+export enum Stripe_SetupIntentPaymentMethodOptionsMandateOptionsAcssDebitPaymentScheduleProperty {
+  Combined = 'combined',
+  Interval = 'interval',
+  Sporadic = 'sporadic'
+}
+
+export enum Stripe_SetupIntentPaymentMethodOptionsMandateOptionsAcssDebitTransactionTypeProperty {
+  Business = 'business',
+  Personal = 'personal'
+}
+
+export enum Stripe_SetupIntentPaymentMethodOptionsAcssDebitVerificationMethodProperty {
+  Automatic = 'automatic',
+  Instant = 'instant',
+  Microdeposits = 'microdeposits'
+}
+
+export type Stripe_SetupIntentPaymentMethodOptionsCard = {
+  __typename?: 'Stripe_SetupIntentPaymentMethodOptionsCard';
+  /** We strongly recommend that you rely on our SCA Engine to automatically prompt your customers for authentication based on risk level and [other requirements](https://stripe.com/docs/strong-customer-authentication). However, if you wish to request 3D Secure based on logic from your own fraud engine, provide this option. Permitted values include: `automatic` or `any`. If not provided, defaults to `automatic`. Read our guide on [manually requesting 3D Secure](https://stripe.com/docs/payments/3d-secure#manual-three-ds) for more information on how this configuration interacts with Radar and our SCA Engine. */
+  request_three_d_secure?: Maybe<Stripe_SetupIntentPaymentMethodOptionsCardRequestThreeDSecureProperty>;
+};
+
+export enum Stripe_SetupIntentPaymentMethodOptionsCardRequestThreeDSecureProperty {
+  Any = 'any',
+  Automatic = 'automatic',
+  ChallengeOnly = 'challenge_only'
+}
+
+export type Stripe_SetupIntentPaymentMethodOptionsSepaDebit = {
+  __typename?: 'Stripe_SetupIntentPaymentMethodOptionsSepaDebit';
+  mandate_options?: Maybe<Stripe_SetupIntentPaymentMethodOptionsMandateOptionsSepaDebit>;
+};
+
+export type Stripe_SetupIntentPaymentMethodOptionsMandateOptionsSepaDebit = {
+  __typename?: 'Stripe_SetupIntentPaymentMethodOptionsMandateOptionsSepaDebit';
+  result?: Maybe<Scalars['JSONObject']>;
+};
+
+export type Stripe_SetupIntentSingleUseMandateProperty = WrappedString | Stripe_Mandate;
+
+export enum Stripe_SetupIntentStatusProperty {
+  Canceled = 'canceled',
+  Processing = 'processing',
+  RequiresAction = 'requires_action',
+  RequiresConfirmation = 'requires_confirmation',
+  RequiresPaymentMethod = 'requires_payment_method',
+  Succeeded = 'succeeded'
+}
+
+export type Stripe_SubscriptionsResourcePendingUpdate = {
+  __typename?: 'Stripe_SubscriptionsResourcePendingUpdate';
+  /** If the update is applied, determines the date of the first full invoice, and, for plans with `month` or `year` intervals, the day of the month for subsequent invoices. */
+  billing_cycle_anchor?: Maybe<Scalars['Int']>;
+  /** The point after which the changes reflected by this update will be discarded and no longer applied. */
+  expires_at?: Maybe<Scalars['Int']>;
+  /** List of subscription items, each with an attached plan, that will be set if the update is applied. */
+  subscription_items?: Maybe<Array<Maybe<Stripe_SubscriptionItem>>>;
+  /** Unix timestamp representing the end of the trial period the customer will get before being charged for the first time, if the update is applied. */
+  trial_end?: Maybe<Scalars['Int']>;
+  /** Indicates if a plan's `trial_period_days` should be applied to the subscription. Setting `trial_end` per subscription is preferred, and this defaults to `false`. Setting this flag to `true` together with `trial_end` is not allowed. */
+  trial_from_plan?: Maybe<Scalars['Boolean']>;
+};
+
+export type Stripe_SubscriptionScheduleProperty = WrappedString | Stripe_SubscriptionSchedule;
+
+export type Stripe_SubscriptionSchedule = {
+  __typename?: 'Stripe_SubscriptionSchedule';
+  /** Time at which the subscription schedule was canceled. Measured in seconds since the Unix epoch. */
+  canceled_at?: Maybe<Scalars['Int']>;
+  /** Time at which the subscription schedule was completed. Measured in seconds since the Unix epoch. */
+  completed_at?: Maybe<Scalars['Int']>;
+  /** Time at which the object was created. Measured in seconds since the Unix epoch. */
+  created?: Maybe<Scalars['Int']>;
+  current_phase?: Maybe<Stripe_SubscriptionScheduleCurrentPhase>;
+  customer?: Maybe<Stripe_SubscriptionScheduleCustomerProperty>;
+  default_settings?: Maybe<Stripe_SubscriptionSchedulesResourceDefaultSettings>;
+  /** Behavior of the subscription schedule and underlying subscription when it ends. Possible values are `release` and `cancel`. */
+  end_behavior?: Maybe<Stripe_SubscriptionScheduleEndBehaviorProperty>;
+  /** Unique identifier for the object. */
+  id?: Maybe<Scalars['String']>;
+  /** Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode. */
+  livemode?: Maybe<Scalars['Boolean']>;
+  /** Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. */
+  metadata?: Maybe<Scalars['JSONObject']>;
+  /** String representing the object's type. Objects of the same type share the same value. */
+  object?: Maybe<Stripe_SubscriptionScheduleObjectProperty>;
+  /** Configuration for the subscription schedule's phases. */
+  phases?: Maybe<Array<Maybe<Stripe_SubscriptionSchedulePhaseConfiguration>>>;
+  /** Time at which the subscription schedule was released. Measured in seconds since the Unix epoch. */
+  released_at?: Maybe<Scalars['Int']>;
+  /** ID of the subscription once managed by the subscription schedule (if it is released). */
+  released_subscription?: Maybe<Scalars['String']>;
+  /** The present status of the subscription schedule. Possible values are `not_started`, `active`, `completed`, `released`, and `canceled`. You can read more about the different states in our [behavior guide](https://stripe.com/docs/billing/subscriptions/subscription-schedules). */
+  status?: Maybe<Stripe_SubscriptionScheduleStatusProperty>;
+  subscription?: Maybe<Stripe_SubscriptionScheduleSubscriptionProperty>;
+};
+
+export type Stripe_SubscriptionScheduleCurrentPhase = {
+  __typename?: 'Stripe_SubscriptionScheduleCurrentPhase';
+  /** The end of this phase of the subscription schedule. */
+  end_date?: Maybe<Scalars['Int']>;
+  /** The start of this phase of the subscription schedule. */
+  start_date?: Maybe<Scalars['Int']>;
+};
+
+export type Stripe_SubscriptionScheduleCustomerProperty = WrappedString | Stripe_Customer | Stripe_DeletedCustomer;
+
+export type Stripe_SubscriptionSchedulesResourceDefaultSettings = {
+  __typename?: 'Stripe_SubscriptionSchedulesResourceDefaultSettings';
+  /** A non-negative decimal between 0 and 100, with at most two decimal places. This represents the percentage of the subscription invoice subtotal that will be transferred to the application owner's Stripe account during this phase of the schedule. */
+  application_fee_percent?: Maybe<Scalars['Float']>;
+  automatic_tax?: Maybe<Stripe_SubscriptionSchedulesResourceDefaultSettingsAutomaticTax>;
+  /** Possible values are `phase_start` or `automatic`. If `phase_start` then billing cycle anchor of the subscription is set to the start of the phase when entering the phase. If `automatic` then the billing cycle anchor is automatically modified as needed when entering the phase. For more information, see the billing cycle [documentation](https://stripe.com/docs/billing/subscriptions/billing-cycle). */
+  billing_cycle_anchor?: Maybe<Stripe_SubscriptionSchedulesResourceDefaultSettingsBillingCycleAnchorProperty>;
+  billing_thresholds?: Maybe<Stripe_SubscriptionBillingThresholds>;
+  /** Either `charge_automatically`, or `send_invoice`. When charging automatically, Stripe will attempt to pay the underlying subscription at the end of each billing cycle using the default source attached to the customer. When sending an invoice, Stripe will email your customer an invoice with payment instructions. */
+  collection_method?: Maybe<Stripe_SubscriptionSchedulesResourceDefaultSettingsCollectionMethodProperty>;
+  default_payment_method?: Maybe<Stripe_SubscriptionSchedulesResourceDefaultSettingsDefaultPaymentMethodProperty>;
+  invoice_settings?: Maybe<Stripe_InvoiceSettingSubscriptionScheduleSetting>;
+  transfer_data?: Maybe<Stripe_SubscriptionTransferData>;
+};
+
+export type Stripe_SubscriptionSchedulesResourceDefaultSettingsAutomaticTax = {
+  __typename?: 'Stripe_SubscriptionSchedulesResourceDefaultSettingsAutomaticTax';
+  /** Whether Stripe automatically computes tax on invoices created during this phase. */
+  enabled?: Maybe<Scalars['Boolean']>;
+};
+
+export enum Stripe_SubscriptionSchedulesResourceDefaultSettingsBillingCycleAnchorProperty {
+  Automatic = 'automatic',
+  PhaseStart = 'phase_start'
+}
+
+export enum Stripe_SubscriptionSchedulesResourceDefaultSettingsCollectionMethodProperty {
+  ChargeAutomatically = 'charge_automatically',
+  SendInvoice = 'send_invoice'
+}
+
+export type Stripe_SubscriptionSchedulesResourceDefaultSettingsDefaultPaymentMethodProperty = WrappedString | Stripe_PaymentMethod;
+
+export type Stripe_InvoiceSettingSubscriptionScheduleSetting = {
+  __typename?: 'Stripe_InvoiceSettingSubscriptionScheduleSetting';
+  /** Number of days within which a customer must pay invoices generated by this subscription schedule. This value will be `null` for subscription schedules where `billing=charge_automatically`. */
+  days_until_due?: Maybe<Scalars['Int']>;
+};
+
+export type Stripe_SubscriptionTransferData = {
+  __typename?: 'Stripe_SubscriptionTransferData';
+  /** A non-negative decimal between 0 and 100, with at most two decimal places. This represents the percentage of the subscription invoice subtotal that will be transferred to the destination account. By default, the entire amount is transferred to the destination. */
+  amount_percent?: Maybe<Scalars['Float']>;
+  destination?: Maybe<Stripe_SubscriptionTransferDataDestinationProperty>;
+};
+
+export type Stripe_SubscriptionTransferDataDestinationProperty = WrappedString | Stripe_Account;
+
+export enum Stripe_SubscriptionScheduleEndBehaviorProperty {
+  Cancel = 'cancel',
+  None = 'none',
+  Release = 'release',
+  Renew = 'renew'
+}
+
+export enum Stripe_SubscriptionScheduleObjectProperty {
+  SubscriptionSchedule = 'subscription_schedule'
+}
+
+export type Stripe_SubscriptionSchedulePhaseConfiguration = {
+  __typename?: 'Stripe_SubscriptionSchedulePhaseConfiguration';
+  /** A list of prices and quantities that will generate invoice items appended to the first invoice for this phase. */
+  add_invoice_items?: Maybe<Array<Maybe<Stripe_SubscriptionScheduleAddInvoiceItem>>>;
+  /** A non-negative decimal between 0 and 100, with at most two decimal places. This represents the percentage of the subscription invoice subtotal that will be transferred to the application owner's Stripe account during this phase of the schedule. */
+  application_fee_percent?: Maybe<Scalars['Float']>;
+  automatic_tax?: Maybe<Stripe_SchedulesPhaseAutomaticTax>;
+  /** Possible values are `phase_start` or `automatic`. If `phase_start` then billing cycle anchor of the subscription is set to the start of the phase when entering the phase. If `automatic` then the billing cycle anchor is automatically modified as needed when entering the phase. For more information, see the billing cycle [documentation](https://stripe.com/docs/billing/subscriptions/billing-cycle). */
+  billing_cycle_anchor?: Maybe<Stripe_SubscriptionSchedulePhaseConfigurationBillingCycleAnchorProperty>;
+  billing_thresholds?: Maybe<Stripe_SubscriptionBillingThresholds>;
+  /** Either `charge_automatically`, or `send_invoice`. When charging automatically, Stripe will attempt to pay the underlying subscription at the end of each billing cycle using the default source attached to the customer. When sending an invoice, Stripe will email your customer an invoice with payment instructions. */
+  collection_method?: Maybe<Stripe_SubscriptionSchedulePhaseConfigurationCollectionMethodProperty>;
+  coupon?: Maybe<Stripe_SubscriptionSchedulePhaseConfigurationCouponProperty>;
+  default_payment_method?: Maybe<Stripe_SubscriptionSchedulePhaseConfigurationDefaultPaymentMethodProperty>;
+  /** The default tax rates to apply to the subscription during this phase of the subscription schedule. */
+  default_tax_rates?: Maybe<Array<Maybe<Stripe_TaxRate>>>;
+  /** The end of this phase of the subscription schedule. */
+  end_date?: Maybe<Scalars['Int']>;
+  invoice_settings?: Maybe<Stripe_InvoiceSettingSubscriptionScheduleSetting>;
+  /** Subscription items to configure the subscription to during this phase of the subscription schedule. */
+  items?: Maybe<Array<Maybe<Stripe_SubscriptionScheduleConfigurationItem>>>;
+  /** If the subscription schedule will prorate when transitioning to this phase. Possible values are `create_prorations` and `none`. */
+  proration_behavior?: Maybe<Stripe_SubscriptionSchedulePhaseConfigurationProrationBehaviorProperty>;
+  /** The start of this phase of the subscription schedule. */
+  start_date?: Maybe<Scalars['Int']>;
+  transfer_data?: Maybe<Stripe_SubscriptionTransferData>;
+  /** When the trial ends within the phase. */
+  trial_end?: Maybe<Scalars['Int']>;
+};
+
+export type Stripe_SubscriptionScheduleAddInvoiceItem = {
+  __typename?: 'Stripe_SubscriptionScheduleAddInvoiceItem';
+  price?: Maybe<Stripe_SubscriptionScheduleAddInvoiceItemPriceProperty>;
+  /** The quantity of the invoice item. */
+  quantity?: Maybe<Scalars['Int']>;
+  /** The tax rates which apply to the item. When set, the `default_tax_rates` do not apply to this item. */
+  tax_rates?: Maybe<Array<Maybe<Stripe_TaxRate>>>;
+};
+
+export type Stripe_SubscriptionScheduleAddInvoiceItemPriceProperty = WrappedString | Stripe_Price | Stripe_DeletedPrice;
+
+export type Stripe_DeletedPrice = {
+  __typename?: 'Stripe_DeletedPrice';
+  /** Unique identifier for the object. */
+  id?: Maybe<Scalars['String']>;
+  /** String representing the object's type. Objects of the same type share the same value. */
+  object?: Maybe<Stripe_DeletedPriceObjectProperty>;
+};
+
+export enum Stripe_DeletedPriceObjectProperty {
+  Price = 'price'
+}
+
+export type Stripe_SchedulesPhaseAutomaticTax = {
+  __typename?: 'Stripe_SchedulesPhaseAutomaticTax';
+  /** Whether Stripe automatically computes tax on invoices created during this phase. */
+  enabled?: Maybe<Scalars['Boolean']>;
+};
+
+export enum Stripe_SubscriptionSchedulePhaseConfigurationBillingCycleAnchorProperty {
+  Automatic = 'automatic',
+  PhaseStart = 'phase_start'
+}
+
+export enum Stripe_SubscriptionSchedulePhaseConfigurationCollectionMethodProperty {
+  ChargeAutomatically = 'charge_automatically',
+  SendInvoice = 'send_invoice'
+}
+
+export type Stripe_SubscriptionSchedulePhaseConfigurationCouponProperty = WrappedString | Stripe_Coupon | Stripe_DeletedCoupon;
+
+export type Stripe_DeletedCoupon = {
+  __typename?: 'Stripe_DeletedCoupon';
+  /** Unique identifier for the object. */
+  id?: Maybe<Scalars['String']>;
+  /** String representing the object's type. Objects of the same type share the same value. */
+  object?: Maybe<Stripe_DeletedCouponObjectProperty>;
+};
+
+export enum Stripe_DeletedCouponObjectProperty {
+  Coupon = 'coupon'
+}
+
+export type Stripe_SubscriptionSchedulePhaseConfigurationDefaultPaymentMethodProperty = WrappedString | Stripe_PaymentMethod;
+
+export type Stripe_SubscriptionScheduleConfigurationItem = {
+  __typename?: 'Stripe_SubscriptionScheduleConfigurationItem';
+  billing_thresholds?: Maybe<Stripe_SubscriptionItemBillingThresholds>;
+  price?: Maybe<Stripe_SubscriptionScheduleConfigurationItemPriceProperty>;
+  /** Quantity of the plan to which the customer should be subscribed. */
+  quantity?: Maybe<Scalars['Int']>;
+  /** The tax rates which apply to this `phase_item`. When set, the `default_tax_rates` on the phase do not apply to this `phase_item`. */
+  tax_rates?: Maybe<Array<Maybe<Stripe_TaxRate>>>;
+};
+
+export type Stripe_SubscriptionScheduleConfigurationItemPriceProperty = WrappedString | Stripe_Price | Stripe_DeletedPrice;
+
+export enum Stripe_SubscriptionSchedulePhaseConfigurationProrationBehaviorProperty {
+  AlwaysInvoice = 'always_invoice',
+  CreateProrations = 'create_prorations',
+  None = 'none'
+}
+
+export enum Stripe_SubscriptionScheduleStatusProperty {
+  Active = 'active',
+  Canceled = 'canceled',
+  Completed = 'completed',
+  NotStarted = 'not_started',
+  Released = 'released'
+}
+
+export type Stripe_SubscriptionScheduleSubscriptionProperty = WrappedString | Stripe_Subscription;
+
+export enum Stripe_SubscriptionStatusProperty {
+  Active = 'active',
+  Canceled = 'canceled',
+  Incomplete = 'incomplete',
+  IncompleteExpired = 'incomplete_expired',
+  PastDue = 'past_due',
+  Trialing = 'trialing',
+  Unpaid = 'unpaid'
+}
+
+export type Stripe_QuotesResourceSubscriptionData = {
+  __typename?: 'Stripe_QuotesResourceSubscriptionData';
+  /** When creating a new subscription, the date of which the subscription schedule will start after the quote is accepted. This date is ignored if it is in the past when the quote is accepted. Measured in seconds since the Unix epoch. */
+  effective_date?: Maybe<Scalars['Int']>;
+  /** Integer representing the number of trial period days before the customer is charged for the first time. */
+  trial_period_days?: Maybe<Scalars['Int']>;
+};
+
+export type Stripe_QuoteSubscriptionScheduleProperty = WrappedString | Stripe_SubscriptionSchedule;
+
+export type Stripe_QuotesResourceTransferData = {
+  __typename?: 'Stripe_QuotesResourceTransferData';
+  /** The amount in %s that will be transferred to the destination account when the invoice is paid. By default, the entire amount is transferred to the destination. */
+  amount?: Maybe<Scalars['Int']>;
+  /** A non-negative decimal between 0 and 100, with at most two decimal places. This represents the percentage of the subscription invoice subtotal that will be transferred to the destination account. By default, the entire amount will be transferred to the destination. */
+  amount_percent?: Maybe<Scalars['Float']>;
+  destination?: Maybe<Stripe_QuotesResourceTransferDataDestinationProperty>;
+};
+
+export type Stripe_QuotesResourceTransferDataDestinationProperty = WrappedString | Stripe_Account;
+
+export enum Stripe_InvoiceStatusProperty {
+  Deleted = 'deleted',
+  Draft = 'draft',
+  Open = 'open',
+  Paid = 'paid',
+  Uncollectible = 'uncollectible',
+  Void = 'void'
+}
+
+export type Stripe_InvoicesStatusTransitions = {
+  __typename?: 'Stripe_InvoicesStatusTransitions';
+  /** The time that the invoice draft was finalized. */
+  finalized_at?: Maybe<Scalars['Int']>;
+  /** The time that the invoice was marked uncollectible. */
+  marked_uncollectible_at?: Maybe<Scalars['Int']>;
+  /** The time that the invoice was paid. */
+  paid_at?: Maybe<Scalars['Int']>;
+  /** The time that the invoice was voided. */
+  voided_at?: Maybe<Scalars['Int']>;
+};
+
+export type Stripe_InvoiceSubscriptionProperty = WrappedString | Stripe_Subscription;
+
+export type Stripe_InvoiceThresholdReason = {
+  __typename?: 'Stripe_InvoiceThresholdReason';
+  /** The total invoice amount threshold boundary if it triggered the threshold invoice. */
+  amount_gte?: Maybe<Scalars['Int']>;
+  /** Indicates which line items triggered a threshold invoice. */
+  item_reasons?: Maybe<Array<Maybe<Stripe_InvoiceItemThresholdReason>>>;
+};
+
+export type Stripe_InvoiceItemThresholdReason = {
+  __typename?: 'Stripe_InvoiceItemThresholdReason';
+  /** The IDs of the line items that triggered the threshold invoice. */
+  line_item_ids?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** The quantity threshold boundary that applied to the given line item. */
+  usage_gte?: Maybe<Scalars['Int']>;
+};
+
+export type Stripe_InvoiceTransferData = {
+  __typename?: 'Stripe_InvoiceTransferData';
+  /** The amount in %s that will be transferred to the destination account when the invoice is paid. By default, the entire amount is transferred to the destination. */
+  amount?: Maybe<Scalars['Int']>;
+  destination?: Maybe<Stripe_InvoiceTransferDataDestinationProperty>;
+};
+
+export type Stripe_InvoiceTransferDataDestinationProperty = WrappedString | Stripe_Account;
+
+export enum Stripe_ChargeObjectProperty {
+  Charge = 'charge'
+}
+
+export type Stripe_ChargeOnBehalfOfProperty = WrappedString | Stripe_Account;
+
+export type Stripe_ChargeOrderProperty = WrappedString | Stripe_Order;
+
+export type Stripe_Order = {
+  __typename?: 'Stripe_Order';
+  /** A positive integer in the smallest currency unit (that is, 100 cents for $1.00, or 1 for ¥1, Japanese Yen being a zero-decimal currency) representing the total amount for the order. */
+  amount?: Maybe<Scalars['Int']>;
+  /** The total amount that was returned to the customer. */
+  amount_returned?: Maybe<Scalars['Int']>;
+  /** ID of the Connect Application that created the order. */
+  application?: Maybe<Scalars['String']>;
+  /** A fee in cents that will be applied to the order and transferred to the application owner’s Stripe account. The request must be made with an OAuth key or the Stripe-Account header in order to take an application fee. For more information, see the application fees documentation. */
+  application_fee?: Maybe<Scalars['Int']>;
+  charge?: Maybe<Stripe_OrderChargeProperty>;
+  /** Time at which the object was created. Measured in seconds since the Unix epoch. */
+  created?: Maybe<Scalars['Int']>;
+  /** Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies). */
+  currency?: Maybe<Scalars['String']>;
+  customer?: Maybe<Stripe_OrderCustomerProperty>;
+  /** The email address of the customer placing the order. */
+  email?: Maybe<Scalars['String']>;
+  /** External coupon code to load for this order. */
+  external_coupon_code?: Maybe<Scalars['String']>;
+  /** Unique identifier for the object. */
+  id?: Maybe<Scalars['String']>;
+  /** List of items constituting the order. An order can have up to 25 items. */
+  items?: Maybe<Array<Maybe<Stripe_OrderItem>>>;
+  /** Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode. */
+  livemode?: Maybe<Scalars['Boolean']>;
+  /** Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. */
+  metadata?: Maybe<Scalars['JSONObject']>;
+  /** String representing the object's type. Objects of the same type share the same value. */
+  object?: Maybe<Stripe_OrderObjectProperty>;
+  /** A list of returns that have taken place for this order. */
+  returns?: Maybe<Stripe_OrderReturnsProperty>;
+  /** The shipping method that is currently selected for this order, if any. If present, it is equal to one of the `id`s of shipping methods in the `shipping_methods` array. At order creation time, if there are multiple shipping methods, Stripe will automatically selected the first method. */
+  selected_shipping_method?: Maybe<Scalars['String']>;
+  shipping?: Maybe<Stripe_Shipping>;
+  /** A list of supported shipping methods for this order. The desired shipping method can be specified either by updating the order, or when paying it. */
+  shipping_methods?: Maybe<Array<Maybe<Stripe_ShippingMethod>>>;
+  /** Current order status. One of `created`, `paid`, `canceled`, `fulfilled`, or `returned`. More details in the [Orders Guide](https://stripe.com/docs/orders/guide#understanding-order-statuses). */
+  status?: Maybe<Scalars['String']>;
+  status_transitions?: Maybe<Stripe_StatusTransitions>;
+  /** Time at which the object was last updated. Measured in seconds since the Unix epoch. */
+  updated?: Maybe<Scalars['Int']>;
+  /** The user's order ID if it is different from the Stripe order ID. */
+  upstream_id?: Maybe<Scalars['String']>;
+};
+
+export type Stripe_OrderChargeProperty = WrappedString | Stripe_Charge;
+
+export type Stripe_OrderCustomerProperty = WrappedString | Stripe_Customer | Stripe_DeletedCustomer;
+
+export type Stripe_OrderItem = {
+  __typename?: 'Stripe_OrderItem';
+  /** A positive integer in the smallest currency unit (that is, 100 cents for $1.00, or 1 for ¥1, Japanese Yen being a zero-decimal currency) representing the total amount for the line item. */
+  amount?: Maybe<Scalars['Int']>;
+  /** Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies). */
+  currency?: Maybe<Scalars['String']>;
+  /** Description of the line item, meant to be displayable to the user (e.g., `"Express shipping"`). */
+  description?: Maybe<Scalars['String']>;
+  /** String representing the object's type. Objects of the same type share the same value. */
+  object?: Maybe<Stripe_OrderItemObjectProperty>;
+  parent?: Maybe<Stripe_OrderItemParentProperty>;
+  /** A positive integer representing the number of instances of `parent` that are included in this order item. Applicable/present only if `type` is `sku`. */
+  quantity?: Maybe<Scalars['Int']>;
+  /** The type of line item. One of `sku`, `tax`, `shipping`, or `discount`. */
+  type?: Maybe<Scalars['String']>;
+};
+
+export enum Stripe_OrderItemObjectProperty {
+  OrderItem = 'order_item'
+}
+
+export type Stripe_OrderItemParentProperty = WrappedString | Stripe_Sku;
+
+export type Stripe_Sku = {
+  __typename?: 'Stripe_Sku';
+  /** Whether the SKU is available for purchase. */
+  active?: Maybe<Scalars['Boolean']>;
+  /** A dictionary of attributes and values for the attributes defined by the product. If, for example, a product's attributes are `["size", "gender"]`, a valid SKU has the following dictionary of attributes: `{"size": "Medium", "gender": "Unisex"}`. */
+  attributes?: Maybe<Scalars['JSONObject']>;
+  /** Time at which the object was created. Measured in seconds since the Unix epoch. */
+  created?: Maybe<Scalars['Int']>;
+  /** Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies). */
+  currency?: Maybe<Scalars['String']>;
+  /** Unique identifier for the object. */
+  id?: Maybe<Scalars['String']>;
+  /** The URL of an image for this SKU, meant to be displayable to the customer. */
+  image?: Maybe<Scalars['String']>;
+  inventory?: Maybe<Stripe_SkuInventory>;
+  /** Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode. */
+  livemode?: Maybe<Scalars['Boolean']>;
+  /** Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. */
+  metadata?: Maybe<Scalars['JSONObject']>;
+  /** String representing the object's type. Objects of the same type share the same value. */
+  object?: Maybe<Stripe_SkuObjectProperty>;
+  package_dimensions?: Maybe<Stripe_PackageDimensions>;
+  /** The cost of the item as a positive integer in the smallest currency unit (that is, 100 cents to charge $1.00, or 100 to charge ¥100, Japanese Yen being a zero-decimal currency). */
+  price?: Maybe<Scalars['Int']>;
+  product?: Maybe<Stripe_SkuProductProperty>;
+  /** Time at which the object was last updated. Measured in seconds since the Unix epoch. */
+  updated?: Maybe<Scalars['Int']>;
+};
+
+export type Stripe_SkuInventory = {
+  __typename?: 'Stripe_SkuInventory';
+  /** The count of inventory available. Will be present if and only if `type` is `finite`. */
+  quantity?: Maybe<Scalars['Int']>;
+  /** Inventory type. Possible values are `finite`, `bucket` (not quantified), and `infinite`. */
+  type?: Maybe<Scalars['String']>;
+  /** An indicator of the inventory available. Possible values are `in_stock`, `limited`, and `out_of_stock`. Will be present if and only if `type` is `bucket`. */
+  value?: Maybe<Scalars['String']>;
+};
+
+export enum Stripe_SkuObjectProperty {
+  Sku = 'sku'
+}
+
+export type Stripe_SkuProductProperty = WrappedString | Stripe_Product;
+
+export enum Stripe_OrderObjectProperty {
+  Order = 'order'
+}
+
+/** A list of returns that have taken place for this order. */
+export type Stripe_OrderReturnsProperty = {
+  __typename?: 'Stripe_OrderReturnsProperty';
+  /** Details about each object. */
+  data: Array<Stripe_OrderReturn>;
+  /** True if this list has another page of items after this one that can be fetched. */
+  has_more: Scalars['Boolean'];
+  /** String representing the object's type. Objects of the same type share the same value. Always has the value `list`. */
+  object: Stripe_OrderReturnsObjectProperty;
+  /** The URL where this list can be accessed. */
+  url: Scalars['String'];
+};
+
+export type Stripe_OrderReturn = {
+  __typename?: 'Stripe_OrderReturn';
+  /** A positive integer in the smallest currency unit (that is, 100 cents for $1.00, or 1 for ¥1, Japanese Yen being a zero-decimal currency) representing the total amount for the returned line item. */
+  amount?: Maybe<Scalars['Int']>;
+  /** Time at which the object was created. Measured in seconds since the Unix epoch. */
+  created?: Maybe<Scalars['Int']>;
+  /** Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies). */
+  currency?: Maybe<Scalars['String']>;
+  /** Unique identifier for the object. */
+  id?: Maybe<Scalars['String']>;
+  /** The items included in this order return. */
+  items?: Maybe<Array<Maybe<Stripe_OrderItem>>>;
+  /** Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode. */
+  livemode?: Maybe<Scalars['Boolean']>;
+  /** String representing the object's type. Objects of the same type share the same value. */
+  object?: Maybe<Stripe_OrderReturnObjectProperty>;
+  order?: Maybe<Stripe_OrderReturnOrderProperty>;
+  refund?: Maybe<Stripe_OrderReturnRefundProperty>;
+};
+
+export enum Stripe_OrderReturnObjectProperty {
+  OrderReturn = 'order_return'
+}
+
+export type Stripe_OrderReturnOrderProperty = WrappedString | Stripe_Order;
+
+export type Stripe_OrderReturnRefundProperty = WrappedString | Stripe_Refund;
+
+export enum Stripe_OrderReturnsObjectProperty {
+  List = 'list'
+}
+
+export type Stripe_ShippingMethod = {
+  __typename?: 'Stripe_ShippingMethod';
+  /** A positive integer in the smallest currency unit (that is, 100 cents for $1.00, or 1 for ¥1, Japanese Yen being a zero-decimal currency) representing the total amount for the line item. */
+  amount?: Maybe<Scalars['Int']>;
+  /** Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies). */
+  currency?: Maybe<Scalars['String']>;
+  delivery_estimate?: Maybe<Stripe_DeliveryEstimate>;
+  /** An arbitrary string attached to the object. Often useful for displaying to users. */
+  description?: Maybe<Scalars['String']>;
+  /** Unique identifier for the object. */
+  id?: Maybe<Scalars['String']>;
+};
+
+export type Stripe_DeliveryEstimate = {
+  __typename?: 'Stripe_DeliveryEstimate';
+  /** If `type` is `"exact"`, `date` will be the expected delivery date in the format YYYY-MM-DD. */
+  date?: Maybe<Scalars['String']>;
+  /** If `type` is `"range"`, `earliest` will be be the earliest delivery date in the format YYYY-MM-DD. */
+  earliest?: Maybe<Scalars['String']>;
+  /** If `type` is `"range"`, `latest` will be the latest delivery date in the format YYYY-MM-DD. */
+  latest?: Maybe<Scalars['String']>;
+  /** The type of estimate. Must be either `"range"` or `"exact"`. */
+  type?: Maybe<Scalars['String']>;
+};
+
+export type Stripe_StatusTransitions = {
+  __typename?: 'Stripe_StatusTransitions';
+  /** The time that the order was canceled. */
+  canceled?: Maybe<Scalars['Int']>;
+  /** The time that the order was fulfilled. */
+  fulfiled?: Maybe<Scalars['Int']>;
+  /** The time that the order was paid. */
+  paid?: Maybe<Scalars['Int']>;
+  /** The time that the order was returned. */
+  returned?: Maybe<Scalars['Int']>;
+};
+
+export type Stripe_ChargeOutcome = {
+  __typename?: 'Stripe_ChargeOutcome';
+  /** Possible values are `approved_by_network`, `declined_by_network`, `not_sent_to_network`, and `reversed_after_approval`. The value `reversed_after_approval` indicates the payment was [blocked by Stripe](https://stripe.com/docs/declines#blocked-payments) after bank authorization, and may temporarily appear as "pending" on a cardholder's statement. */
+  network_status?: Maybe<Scalars['String']>;
+  /** An enumerated value providing a more detailed explanation of the outcome's `type`. Charges blocked by Radar's default block rule have the value `highest_risk_level`. Charges placed in review by Radar's default review rule have the value `elevated_risk_level`. Charges authorized, blocked, or placed in review by custom rules have the value `rule`. See [understanding declines](https://stripe.com/docs/declines) for more details. */
+  reason?: Maybe<Scalars['String']>;
+  /** Stripe Radar's evaluation of the riskiness of the payment. Possible values for evaluated payments are `normal`, `elevated`, `highest`. For non-card payments, and card-based payments predating the public assignment of risk levels, this field will have the value `not_assessed`. In the event of an error in the evaluation, this field will have the value `unknown`. This field is only available with Radar. */
+  risk_level?: Maybe<Scalars['String']>;
+  /** Stripe Radar's evaluation of the riskiness of the payment. Possible values for evaluated payments are between 0 and 100. For non-card payments, card-based payments predating the public assignment of risk scores, or in the event of an error during evaluation, this field will not be present. This field is only available with Radar for Fraud Teams. */
+  risk_score?: Maybe<Scalars['Int']>;
+  rule?: Maybe<Stripe_ChargeOutcomeRuleProperty>;
+  /** A human-readable description of the outcome type and reason, designed for you (the recipient of the payment), not your customer. */
+  seller_message?: Maybe<Scalars['String']>;
+  /** Possible values are `authorized`, `manual_review`, `issuer_declined`, `blocked`, and `invalid`. See [understanding declines](https://stripe.com/docs/declines) and [Radar reviews](https://stripe.com/docs/radar/reviews) for details. */
+  type?: Maybe<Scalars['String']>;
+};
+
+export type Stripe_ChargeOutcomeRuleProperty = WrappedString | Stripe_Rule;
+
+export type Stripe_Rule = {
+  __typename?: 'Stripe_Rule';
+  /** The action taken on the payment. */
+  action?: Maybe<Scalars['String']>;
+  /** Unique identifier for the object. */
+  id?: Maybe<Scalars['String']>;
+  /** The predicate to evaluate the payment against. */
+  predicate?: Maybe<Scalars['String']>;
+};
+
+export type Stripe_ChargePaymentIntentProperty = WrappedString | Stripe_PaymentIntent;
+
+export type Stripe_PaymentMethodDetails = {
+  __typename?: 'Stripe_PaymentMethodDetails';
+  ach_credit_transfer?: Maybe<Stripe_PaymentMethodDetailsAchCreditTransfer>;
+  ach_debit?: Maybe<Stripe_PaymentMethodDetailsAchDebit>;
+  acss_debit?: Maybe<Stripe_PaymentMethodDetailsAcssDebit>;
+  afterpay_clearpay?: Maybe<Stripe_PaymentMethodDetailsAfterpayClearpay>;
+  alipay?: Maybe<Stripe_PaymentFlowsPrivatePaymentMethodsAlipayDetails>;
+  au_becs_debit?: Maybe<Stripe_PaymentMethodDetailsAuBecsDebit>;
+  bacs_debit?: Maybe<Stripe_PaymentMethodDetailsBacsDebit>;
+  bancontact?: Maybe<Stripe_PaymentMethodDetailsBancontact>;
+  boleto?: Maybe<Stripe_PaymentMethodDetailsBoleto>;
+  card?: Maybe<Stripe_PaymentMethodDetailsCard>;
+  card_present?: Maybe<Stripe_PaymentMethodDetailsCardPresent>;
+  eps?: Maybe<Stripe_PaymentMethodDetailsEps>;
+  fpx?: Maybe<Stripe_PaymentMethodDetailsFpx>;
+  giropay?: Maybe<Stripe_PaymentMethodDetailsGiropay>;
+  grabpay?: Maybe<Stripe_PaymentMethodDetailsGrabpay>;
+  ideal?: Maybe<Stripe_PaymentMethodDetailsIdeal>;
+  interac_present?: Maybe<Stripe_PaymentMethodDetailsInteracPresent>;
+  klarna?: Maybe<Stripe_PaymentMethodDetailsKlarna>;
+  multibanco?: Maybe<Stripe_PaymentMethodDetailsMultibanco>;
+  oxxo?: Maybe<Stripe_PaymentMethodDetailsOxxo>;
+  p24?: Maybe<Stripe_PaymentMethodDetailsP24>;
+  sepa_debit?: Maybe<Stripe_PaymentMethodDetailsSepaDebit>;
+  sofort?: Maybe<Stripe_PaymentMethodDetailsSofort>;
+  stripe_account?: Maybe<Stripe_PaymentMethodDetailsStripeAccount>;
+  /**
+   * The type of transaction-specific details of the payment method used in the payment, one of `ach_credit_transfer`, `ach_debit`, `acss_debit`, `alipay`, `au_becs_debit`, `bancontact`, `card`, `card_present`, `eps`, `giropay`, `ideal`, `klarna`, `multibanco`, `p24`, `sepa_debit`, `sofort`, `stripe_account`, or `wechat`.
+   * An additional hash is included on `payment_method_details` with a name matching this value.
+   * It contains information specific to the payment method.
+   */
+  type?: Maybe<Scalars['String']>;
+  wechat?: Maybe<Stripe_PaymentMethodDetailsWechat>;
+  wechat_pay?: Maybe<Stripe_PaymentMethodDetailsWechatPay>;
+};
+
+export type Stripe_PaymentMethodDetailsAchCreditTransfer = {
+  __typename?: 'Stripe_PaymentMethodDetailsAchCreditTransfer';
+  /** Account number to transfer funds to. */
+  account_number?: Maybe<Scalars['String']>;
+  /** Name of the bank associated with the routing number. */
+  bank_name?: Maybe<Scalars['String']>;
+  /** Routing transit number for the bank account to transfer funds to. */
+  routing_number?: Maybe<Scalars['String']>;
+  /** SWIFT code of the bank associated with the routing number. */
+  swift_code?: Maybe<Scalars['String']>;
+};
+
+export type Stripe_PaymentMethodDetailsAchDebit = {
+  __typename?: 'Stripe_PaymentMethodDetailsAchDebit';
+  /** Type of entity that holds the account. This can be either `individual` or `company`. */
+  account_holder_type?: Maybe<Stripe_PaymentMethodDetailsAchDebitAccountHolderTypeProperty>;
+  /** Name of the bank associated with the bank account. */
+  bank_name?: Maybe<Scalars['String']>;
+  /** Two-letter ISO code representing the country the bank account is located in. */
+  country?: Maybe<Scalars['String']>;
+  /** Uniquely identifies this particular bank account. You can use this attribute to check whether two bank accounts are the same. */
+  fingerprint?: Maybe<Scalars['String']>;
+  /** Last four digits of the bank account number. */
+  last4?: Maybe<Scalars['String']>;
+  /** Routing transit number of the bank account. */
+  routing_number?: Maybe<Scalars['String']>;
+};
+
+export enum Stripe_PaymentMethodDetailsAchDebitAccountHolderTypeProperty {
+  Company = 'company',
+  Individual = 'individual'
+}
+
+export type Stripe_PaymentMethodDetailsAcssDebit = {
+  __typename?: 'Stripe_PaymentMethodDetailsAcssDebit';
+  /** Name of the bank associated with the bank account. */
+  bank_name?: Maybe<Scalars['String']>;
+  /** Uniquely identifies this particular bank account. You can use this attribute to check whether two bank accounts are the same. */
+  fingerprint?: Maybe<Scalars['String']>;
+  /** Institution number of the bank account */
+  institution_number?: Maybe<Scalars['String']>;
+  /** Last four digits of the bank account number. */
+  last4?: Maybe<Scalars['String']>;
+  /** ID of the mandate used to make this payment. */
+  mandate?: Maybe<Scalars['String']>;
+  /** Transit number of the bank account. */
+  transit_number?: Maybe<Scalars['String']>;
+};
+
+export type Stripe_PaymentMethodDetailsAfterpayClearpay = {
+  __typename?: 'Stripe_PaymentMethodDetailsAfterpayClearpay';
+  /** Order identifier shown to the merchant in Afterpay’s online portal. */
+  reference?: Maybe<Scalars['String']>;
+};
+
+export type Stripe_PaymentFlowsPrivatePaymentMethodsAlipayDetails = {
+  __typename?: 'Stripe_PaymentFlowsPrivatePaymentMethodsAlipayDetails';
+  /** Uniquely identifies this particular Alipay account. You can use this attribute to check whether two Alipay accounts are the same. */
+  fingerprint?: Maybe<Scalars['String']>;
+  /** Transaction ID of this particular Alipay transaction. */
+  transaction_id?: Maybe<Scalars['String']>;
+};
+
+export type Stripe_PaymentMethodDetailsAuBecsDebit = {
+  __typename?: 'Stripe_PaymentMethodDetailsAuBecsDebit';
+  /** Bank-State-Branch number of the bank account. */
+  bsb_number?: Maybe<Scalars['String']>;
+  /** Uniquely identifies this particular bank account. You can use this attribute to check whether two bank accounts are the same. */
+  fingerprint?: Maybe<Scalars['String']>;
+  /** Last four digits of the bank account number. */
+  last4?: Maybe<Scalars['String']>;
+  /** ID of the mandate used to make this payment. */
+  mandate?: Maybe<Scalars['String']>;
+};
+
+export type Stripe_PaymentMethodDetailsBacsDebit = {
+  __typename?: 'Stripe_PaymentMethodDetailsBacsDebit';
+  /** Uniquely identifies this particular bank account. You can use this attribute to check whether two bank accounts are the same. */
+  fingerprint?: Maybe<Scalars['String']>;
+  /** Last four digits of the bank account number. */
+  last4?: Maybe<Scalars['String']>;
+  /** ID of the mandate used to make this payment. */
+  mandate?: Maybe<Scalars['String']>;
+  /** Sort code of the bank account. (e.g., `10-20-30`) */
+  sort_code?: Maybe<Scalars['String']>;
+};
+
+export type Stripe_PaymentMethodDetailsBancontact = {
+  __typename?: 'Stripe_PaymentMethodDetailsBancontact';
+  /** Bank code of bank associated with the bank account. */
+  bank_code?: Maybe<Scalars['String']>;
+  /** Name of the bank associated with the bank account. */
+  bank_name?: Maybe<Scalars['String']>;
+  /** Bank Identifier Code of the bank associated with the bank account. */
+  bic?: Maybe<Scalars['String']>;
+  generated_sepa_debit?: Maybe<Stripe_PaymentMethodDetailsBancontactGeneratedSepaDebitProperty>;
+  generated_sepa_debit_mandate?: Maybe<Stripe_PaymentMethodDetailsBancontactGeneratedSepaDebitMandateProperty>;
+  /** Last four characters of the IBAN. */
+  iban_last4?: Maybe<Scalars['String']>;
+  /**
+   * Preferred language of the Bancontact authorization page that the customer is redirected to.
+   * Can be one of `en`, `de`, `fr`, or `nl`
+   */
+  preferred_language?: Maybe<Stripe_PaymentMethodDetailsBancontactPreferredLanguageProperty>;
+  /**
+   * Owner's verified full name. Values are verified or provided by Bancontact directly
+   * (if supported) at the time of authorization or settlement. They cannot be set or mutated.
+   */
+  verified_name?: Maybe<Scalars['String']>;
+};
+
+export type Stripe_PaymentMethodDetailsBancontactGeneratedSepaDebitProperty = WrappedString | Stripe_PaymentMethod;
+
+export type Stripe_PaymentMethodDetailsBancontactGeneratedSepaDebitMandateProperty = WrappedString | Stripe_Mandate;
+
+export enum Stripe_PaymentMethodDetailsBancontactPreferredLanguageProperty {
+  De = 'de',
+  En = 'en',
+  Fr = 'fr',
+  Nl = 'nl'
+}
+
+export type Stripe_PaymentMethodDetailsBoleto = {
+  __typename?: 'Stripe_PaymentMethodDetailsBoleto';
+  /** Uniquely identifies this customer tax_id (CNPJ or CPF) */
+  tax_id?: Maybe<Scalars['String']>;
+};
+
+export type Stripe_PaymentMethodDetailsCard = {
+  __typename?: 'Stripe_PaymentMethodDetailsCard';
+  /** Card brand. Can be `amex`, `diners`, `discover`, `jcb`, `mastercard`, `unionpay`, `visa`, or `unknown`. */
+  brand?: Maybe<Scalars['String']>;
+  checks?: Maybe<Stripe_PaymentMethodDetailsCardChecks>;
+  /** Two-letter ISO code representing the country of the card. You could use this attribute to get a sense of the international breakdown of cards you've collected. */
+  country?: Maybe<Scalars['String']>;
+  /** Two-digit number representing the card's expiration month. */
+  exp_month?: Maybe<Scalars['Int']>;
+  /** Four-digit number representing the card's expiration year. */
+  exp_year?: Maybe<Scalars['Int']>;
+  /**
+   * Uniquely identifies this particular card number. You can use this attribute to check whether two customers who’ve signed up with you are using the same card number, for example. For payment methods that tokenize card information (Apple Pay, Google Pay), the tokenized number might be provided instead of the underlying card number.
+   *
+   * *Starting May 1, 2021, card fingerprint in India for Connect will change to allow two fingerprints for the same card --- one for India and one for the rest of the world.*
+   */
+  fingerprint?: Maybe<Scalars['String']>;
+  /** Card funding type. Can be `credit`, `debit`, `prepaid`, or `unknown`. */
+  funding?: Maybe<Scalars['String']>;
+  installments?: Maybe<Stripe_PaymentMethodDetailsCardInstallments>;
+  /** The last four digits of the card. */
+  last4?: Maybe<Scalars['String']>;
+  /** Identifies which network this charge was processed on. Can be `amex`, `cartes_bancaires`, `diners`, `discover`, `interac`, `jcb`, `mastercard`, `unionpay`, `visa`, or `unknown`. */
+  network?: Maybe<Scalars['String']>;
+  three_d_secure?: Maybe<Stripe_ThreeDSecureDetails>;
+  wallet?: Maybe<Stripe_PaymentMethodDetailsCardWallet>;
+};
+
+export type Stripe_PaymentMethodDetailsCardChecks = {
+  __typename?: 'Stripe_PaymentMethodDetailsCardChecks';
+  /** If a address line1 was provided, results of the check, one of `pass`, `fail`, `unavailable`, or `unchecked`. */
+  address_line1_check?: Maybe<Scalars['String']>;
+  /** If a address postal code was provided, results of the check, one of `pass`, `fail`, `unavailable`, or `unchecked`. */
+  address_postal_code_check?: Maybe<Scalars['String']>;
+  /** If a CVC was provided, results of the check, one of `pass`, `fail`, `unavailable`, or `unchecked`. */
+  cvc_check?: Maybe<Scalars['String']>;
+};
+
+export type Stripe_PaymentMethodDetailsCardInstallments = {
+  __typename?: 'Stripe_PaymentMethodDetailsCardInstallments';
+  plan?: Maybe<Stripe_PaymentMethodDetailsCardInstallmentsPlan>;
+};
+
+export type Stripe_PaymentMethodDetailsCardInstallmentsPlan = {
+  __typename?: 'Stripe_PaymentMethodDetailsCardInstallmentsPlan';
+  /** For `fixed_count` installment plans, this is the number of installment payments your customer will make to their credit card. */
+  count?: Maybe<Scalars['Int']>;
+  /**
+   * For `fixed_count` installment plans, this is the interval between installment payments your customer will make to their credit card.
+   * One of `month`.
+   */
+  interval?: Maybe<Stripe_PaymentMethodDetailsCardInstallmentsPlanIntervalProperty>;
+  /** Type of installment plan, one of `fixed_count`. */
+  type?: Maybe<Stripe_PaymentMethodDetailsCardInstallmentsPlanTypeProperty>;
+};
+
+export enum Stripe_PaymentMethodDetailsCardInstallmentsPlanIntervalProperty {
+  Month = 'month'
+}
+
+export enum Stripe_PaymentMethodDetailsCardInstallmentsPlanTypeProperty {
+  FixedCount = 'fixed_count'
+}
+
+export type Stripe_PaymentMethodDetailsCardWallet = {
+  __typename?: 'Stripe_PaymentMethodDetailsCardWallet';
+  amex_express_checkout?: Maybe<Stripe_PaymentMethodDetailsCardWalletAmexExpressCheckout>;
+  apple_pay?: Maybe<Stripe_PaymentMethodDetailsCardWalletApplePay>;
+  /** (For tokenized numbers only.) The last four digits of the device account number. */
+  dynamic_last4?: Maybe<Scalars['String']>;
+  google_pay?: Maybe<Stripe_PaymentMethodDetailsCardWalletGooglePay>;
+  masterpass?: Maybe<Stripe_PaymentMethodDetailsCardWalletMasterpass>;
+  samsung_pay?: Maybe<Stripe_PaymentMethodDetailsCardWalletSamsungPay>;
+  /** The type of the card wallet, one of `amex_express_checkout`, `apple_pay`, `google_pay`, `masterpass`, `samsung_pay`, or `visa_checkout`. An additional hash is included on the Wallet subhash with a name matching this value. It contains additional information specific to the card wallet type. */
+  type?: Maybe<Stripe_PaymentMethodDetailsCardWalletTypeProperty>;
+  visa_checkout?: Maybe<Stripe_PaymentMethodDetailsCardWalletVisaCheckout>;
+};
+
+export type Stripe_PaymentMethodDetailsCardWalletAmexExpressCheckout = {
+  __typename?: 'Stripe_PaymentMethodDetailsCardWalletAmexExpressCheckout';
+  result?: Maybe<Scalars['JSONObject']>;
+};
+
+export type Stripe_PaymentMethodDetailsCardWalletApplePay = {
+  __typename?: 'Stripe_PaymentMethodDetailsCardWalletApplePay';
+  result?: Maybe<Scalars['JSONObject']>;
+};
+
+export type Stripe_PaymentMethodDetailsCardWalletGooglePay = {
+  __typename?: 'Stripe_PaymentMethodDetailsCardWalletGooglePay';
+  result?: Maybe<Scalars['JSONObject']>;
+};
+
+export type Stripe_PaymentMethodDetailsCardWalletMasterpass = {
+  __typename?: 'Stripe_PaymentMethodDetailsCardWalletMasterpass';
+  billing_address?: Maybe<Stripe_Address>;
+  /** Owner's verified email. Values are verified or provided by the wallet directly (if supported) at the time of authorization or settlement. They cannot be set or mutated. */
+  email?: Maybe<Scalars['String']>;
+  /** Owner's verified full name. Values are verified or provided by the wallet directly (if supported) at the time of authorization or settlement. They cannot be set or mutated. */
+  name?: Maybe<Scalars['String']>;
+  shipping_address?: Maybe<Stripe_Address>;
+};
+
+export type Stripe_PaymentMethodDetailsCardWalletSamsungPay = {
+  __typename?: 'Stripe_PaymentMethodDetailsCardWalletSamsungPay';
+  result?: Maybe<Scalars['JSONObject']>;
+};
+
+export enum Stripe_PaymentMethodDetailsCardWalletTypeProperty {
+  AmexExpressCheckout = 'amex_express_checkout',
+  ApplePay = 'apple_pay',
+  GooglePay = 'google_pay',
+  Masterpass = 'masterpass',
+  SamsungPay = 'samsung_pay',
+  VisaCheckout = 'visa_checkout'
+}
+
+export type Stripe_PaymentMethodDetailsCardWalletVisaCheckout = {
+  __typename?: 'Stripe_PaymentMethodDetailsCardWalletVisaCheckout';
+  billing_address?: Maybe<Stripe_Address>;
+  /** Owner's verified email. Values are verified or provided by the wallet directly (if supported) at the time of authorization or settlement. They cannot be set or mutated. */
+  email?: Maybe<Scalars['String']>;
+  /** Owner's verified full name. Values are verified or provided by the wallet directly (if supported) at the time of authorization or settlement. They cannot be set or mutated. */
+  name?: Maybe<Scalars['String']>;
+  shipping_address?: Maybe<Stripe_Address>;
+};
+
+export type Stripe_PaymentMethodDetailsEps = {
+  __typename?: 'Stripe_PaymentMethodDetailsEps';
+  /** The customer's bank. Should be one of `arzte_und_apotheker_bank`, `austrian_anadi_bank_ag`, `bank_austria`, `bankhaus_carl_spangler`, `bankhaus_schelhammer_und_schattera_ag`, `bawag_psk_ag`, `bks_bank_ag`, `brull_kallmus_bank_ag`, `btv_vier_lander_bank`, `capital_bank_grawe_gruppe_ag`, `dolomitenbank`, `easybank_ag`, `erste_bank_und_sparkassen`, `hypo_alpeadriabank_international_ag`, `hypo_noe_lb_fur_niederosterreich_u_wien`, `hypo_oberosterreich_salzburg_steiermark`, `hypo_tirol_bank_ag`, `hypo_vorarlberg_bank_ag`, `hypo_bank_burgenland_aktiengesellschaft`, `marchfelder_bank`, `oberbank_ag`, `raiffeisen_bankengruppe_osterreich`, `schoellerbank_ag`, `sparda_bank_wien`, `volksbank_gruppe`, `volkskreditbank_ag`, or `vr_bank_braunau`. */
+  bank?: Maybe<Stripe_PaymentMethodDetailsEpsBankProperty>;
+  /**
+   * Owner's verified full name. Values are verified or provided by EPS directly
+   * (if supported) at the time of authorization or settlement. They cannot be set or mutated.
+   * EPS rarely provides this information so the attribute is usually empty.
+   */
+  verified_name?: Maybe<Scalars['String']>;
+};
+
+export enum Stripe_PaymentMethodDetailsEpsBankProperty {
+  ArzteUndApothekerBank = 'arzte_und_apotheker_bank',
+  AustrianAnadiBankAg = 'austrian_anadi_bank_ag',
+  BankAustria = 'bank_austria',
+  BankhausCarlSpangler = 'bankhaus_carl_spangler',
+  BankhausSchelhammerUndSchatteraAg = 'bankhaus_schelhammer_und_schattera_ag',
+  BawagPskAg = 'bawag_psk_ag',
+  BksBankAg = 'bks_bank_ag',
+  BrullKallmusBankAg = 'brull_kallmus_bank_ag',
+  BtvVierLanderBank = 'btv_vier_lander_bank',
+  CapitalBankGraweGruppeAg = 'capital_bank_grawe_gruppe_ag',
+  Dolomitenbank = 'dolomitenbank',
+  EasybankAg = 'easybank_ag',
+  ErsteBankUndSparkassen = 'erste_bank_und_sparkassen',
+  HypoAlpeadriabankInternationalAg = 'hypo_alpeadriabank_international_ag',
+  HypoBankBurgenlandAktiengesellschaft = 'hypo_bank_burgenland_aktiengesellschaft',
+  HypoNoeLbFurNiederosterreichUWien = 'hypo_noe_lb_fur_niederosterreich_u_wien',
+  HypoOberosterreichSalzburgSteiermark = 'hypo_oberosterreich_salzburg_steiermark',
+  HypoTirolBankAg = 'hypo_tirol_bank_ag',
+  HypoVorarlbergBankAg = 'hypo_vorarlberg_bank_ag',
+  MarchfelderBank = 'marchfelder_bank',
+  OberbankAg = 'oberbank_ag',
+  RaiffeisenBankengruppeOsterreich = 'raiffeisen_bankengruppe_osterreich',
+  SchoellerbankAg = 'schoellerbank_ag',
+  SpardaBankWien = 'sparda_bank_wien',
+  VolksbankGruppe = 'volksbank_gruppe',
+  VolkskreditbankAg = 'volkskreditbank_ag',
+  VrBankBraunau = 'vr_bank_braunau'
+}
+
+export type Stripe_PaymentMethodDetailsFpx = {
+  __typename?: 'Stripe_PaymentMethodDetailsFpx';
+  /** The customer's bank. Can be one of `affin_bank`, `alliance_bank`, `ambank`, `bank_islam`, `bank_muamalat`, `bank_rakyat`, `bsn`, `cimb`, `hong_leong_bank`, `hsbc`, `kfh`, `maybank2u`, `ocbc`, `public_bank`, `rhb`, `standard_chartered`, `uob`, `deutsche_bank`, `maybank2e`, or `pb_enterprise`. */
+  bank?: Maybe<Stripe_PaymentMethodDetailsFpxBankProperty>;
+  /** Unique transaction id generated by FPX for every request from the merchant */
+  transaction_id?: Maybe<Scalars['String']>;
+};
+
+export enum Stripe_PaymentMethodDetailsFpxBankProperty {
+  AffinBank = 'affin_bank',
+  AllianceBank = 'alliance_bank',
+  Ambank = 'ambank',
+  BankIslam = 'bank_islam',
+  BankMuamalat = 'bank_muamalat',
+  BankRakyat = 'bank_rakyat',
+  Bsn = 'bsn',
+  Cimb = 'cimb',
+  DeutscheBank = 'deutsche_bank',
+  HongLeongBank = 'hong_leong_bank',
+  Hsbc = 'hsbc',
+  Kfh = 'kfh',
+  Maybank2e = 'maybank2e',
+  Maybank2u = 'maybank2u',
+  Ocbc = 'ocbc',
+  PbEnterprise = 'pb_enterprise',
+  PublicBank = 'public_bank',
+  Rhb = 'rhb',
+  StandardChartered = 'standard_chartered',
+  Uob = 'uob'
+}
+
+export type Stripe_PaymentMethodDetailsGiropay = {
+  __typename?: 'Stripe_PaymentMethodDetailsGiropay';
+  /** Bank code of bank associated with the bank account. */
+  bank_code?: Maybe<Scalars['String']>;
+  /** Name of the bank associated with the bank account. */
+  bank_name?: Maybe<Scalars['String']>;
+  /** Bank Identifier Code of the bank associated with the bank account. */
+  bic?: Maybe<Scalars['String']>;
+  /**
+   * Owner's verified full name. Values are verified or provided by Giropay directly
+   * (if supported) at the time of authorization or settlement. They cannot be set or mutated.
+   * Giropay rarely provides this information so the attribute is usually empty.
+   */
+  verified_name?: Maybe<Scalars['String']>;
+};
+
+export type Stripe_PaymentMethodDetailsGrabpay = {
+  __typename?: 'Stripe_PaymentMethodDetailsGrabpay';
+  /** Unique transaction id generated by GrabPay */
+  transaction_id?: Maybe<Scalars['String']>;
+};
+
+export type Stripe_PaymentMethodDetailsIdeal = {
+  __typename?: 'Stripe_PaymentMethodDetailsIdeal';
+  /** The customer's bank. Can be one of `abn_amro`, `asn_bank`, `bunq`, `handelsbanken`, `ing`, `knab`, `moneyou`, `rabobank`, `regiobank`, `revolut`, `sns_bank`, `triodos_bank`, or `van_lanschot`. */
+  bank?: Maybe<Stripe_PaymentMethodDetailsIdealBankProperty>;
+  /** The Bank Identifier Code of the customer's bank. */
+  bic?: Maybe<Stripe_PaymentMethodDetailsIdealBicProperty>;
+  generated_sepa_debit?: Maybe<Stripe_PaymentMethodDetailsIdealGeneratedSepaDebitProperty>;
+  generated_sepa_debit_mandate?: Maybe<Stripe_PaymentMethodDetailsIdealGeneratedSepaDebitMandateProperty>;
+  /** Last four characters of the IBAN. */
+  iban_last4?: Maybe<Scalars['String']>;
+  /**
+   * Owner's verified full name. Values are verified or provided by iDEAL directly
+   * (if supported) at the time of authorization or settlement. They cannot be set or mutated.
+   */
+  verified_name?: Maybe<Scalars['String']>;
+};
+
+export enum Stripe_PaymentMethodDetailsIdealBankProperty {
+  AbnAmro = 'abn_amro',
+  AsnBank = 'asn_bank',
+  Bunq = 'bunq',
+  Handelsbanken = 'handelsbanken',
+  Ing = 'ing',
+  Knab = 'knab',
+  Moneyou = 'moneyou',
+  Rabobank = 'rabobank',
+  Regiobank = 'regiobank',
+  Revolut = 'revolut',
+  SnsBank = 'sns_bank',
+  TriodosBank = 'triodos_bank',
+  VanLanschot = 'van_lanschot'
+}
+
+export enum Stripe_PaymentMethodDetailsIdealBicProperty {
+  Abnanl2A = 'ABNANL2A',
+  Asnbnl21 = 'ASNBNL21',
+  Bunqnl2A = 'BUNQNL2A',
+  Fvlbnl22 = 'FVLBNL22',
+  Handnl2A = 'HANDNL2A',
+  Ingbnl2A = 'INGBNL2A',
+  Knabnl2H = 'KNABNL2H',
+  Moyonl21 = 'MOYONL21',
+  Rabonl2U = 'RABONL2U',
+  Rbrbnl21 = 'RBRBNL21',
+  Revolt21 = 'REVOLT21',
+  Snsbnl2A = 'SNSBNL2A',
+  Trionl2U = 'TRIONL2U'
+}
+
+export type Stripe_PaymentMethodDetailsIdealGeneratedSepaDebitProperty = WrappedString | Stripe_PaymentMethod;
+
+export type Stripe_PaymentMethodDetailsIdealGeneratedSepaDebitMandateProperty = WrappedString | Stripe_Mandate;
+
+export type Stripe_PaymentMethodDetailsInteracPresent = {
+  __typename?: 'Stripe_PaymentMethodDetailsInteracPresent';
+  /** Card brand. Can be `interac`, `mastercard` or `visa`. */
+  brand?: Maybe<Scalars['String']>;
+  /** The cardholder name as read from the card, in [ISO 7813](https://en.wikipedia.org/wiki/ISO/IEC_7813) format. May include alphanumeric characters, special characters and first/last name separator (`/`). */
+  cardholder_name?: Maybe<Scalars['String']>;
+  /** Two-letter ISO code representing the country of the card. You could use this attribute to get a sense of the international breakdown of cards you've collected. */
+  country?: Maybe<Scalars['String']>;
+  /** Authorization response cryptogram. */
+  emv_auth_data?: Maybe<Scalars['String']>;
+  /** Two-digit number representing the card's expiration month. */
+  exp_month?: Maybe<Scalars['Int']>;
+  /** Four-digit number representing the card's expiration year. */
+  exp_year?: Maybe<Scalars['Int']>;
+  /**
+   * Uniquely identifies this particular card number. You can use this attribute to check whether two customers who’ve signed up with you are using the same card number, for example. For payment methods that tokenize card information (Apple Pay, Google Pay), the tokenized number might be provided instead of the underlying card number.
+   *
+   * *Starting May 1, 2021, card fingerprint in India for Connect will change to allow two fingerprints for the same card --- one for India and one for the rest of the world.*
+   */
+  fingerprint?: Maybe<Scalars['String']>;
+  /** Card funding type. Can be `credit`, `debit`, `prepaid`, or `unknown`. */
+  funding?: Maybe<Scalars['String']>;
+  /** ID of a card PaymentMethod generated from the card_present PaymentMethod that may be attached to a Customer for future transactions. Only present if it was possible to generate a card PaymentMethod. */
+  generated_card?: Maybe<Scalars['String']>;
+  /** The last four digits of the card. */
+  last4?: Maybe<Scalars['String']>;
+  /** Identifies which network this charge was processed on. Can be `amex`, `cartes_bancaires`, `diners`, `discover`, `interac`, `jcb`, `mastercard`, `unionpay`, `visa`, or `unknown`. */
+  network?: Maybe<Scalars['String']>;
+  /** EMV tag 5F2D. Preferred languages specified by the integrated circuit chip. */
+  preferred_locales?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** How card details were read in this transaction. */
+  read_method?: Maybe<Stripe_PaymentMethodDetailsInteracPresentReadMethodProperty>;
+  receipt?: Maybe<Stripe_PaymentMethodDetailsInteracPresentReceipt>;
+};
+
+export enum Stripe_PaymentMethodDetailsInteracPresentReadMethodProperty {
+  ContactEmv = 'contact_emv',
+  ContactlessEmv = 'contactless_emv',
+  ContactlessMagstripeMode = 'contactless_magstripe_mode',
+  MagneticStripeFallback = 'magnetic_stripe_fallback',
+  MagneticStripeTrack2 = 'magnetic_stripe_track2'
+}
+
+export type Stripe_PaymentMethodDetailsInteracPresentReceipt = {
+  __typename?: 'Stripe_PaymentMethodDetailsInteracPresentReceipt';
+  /** The type of account being debited or credited */
+  account_type?: Maybe<Stripe_PaymentMethodDetailsInteracPresentReceiptAccountTypeProperty>;
+  /** EMV tag 9F26, cryptogram generated by the integrated circuit chip. */
+  application_cryptogram?: Maybe<Scalars['String']>;
+  /** Mnenomic of the Application Identifier. */
+  application_preferred_name?: Maybe<Scalars['String']>;
+  /** Identifier for this transaction. */
+  authorization_code?: Maybe<Scalars['String']>;
+  /** EMV tag 8A. A code returned by the card issuer. */
+  authorization_response_code?: Maybe<Scalars['String']>;
+  /** How the cardholder verified ownership of the card. */
+  cardholder_verification_method?: Maybe<Scalars['String']>;
+  /** EMV tag 84. Similar to the application identifier stored on the integrated circuit chip. */
+  dedicated_file_name?: Maybe<Scalars['String']>;
+  /** The outcome of a series of EMV functions performed by the card reader. */
+  terminal_verification_results?: Maybe<Scalars['String']>;
+  /** An indication of various EMV functions performed during the transaction. */
+  transaction_status_information?: Maybe<Scalars['String']>;
+};
+
+export enum Stripe_PaymentMethodDetailsInteracPresentReceiptAccountTypeProperty {
+  Checking = 'checking',
+  Savings = 'savings',
+  Unknown = 'unknown'
+}
+
+export type Stripe_PaymentMethodDetailsKlarna = {
+  __typename?: 'Stripe_PaymentMethodDetailsKlarna';
+  result?: Maybe<Scalars['JSONObject']>;
+};
+
+export type Stripe_PaymentMethodDetailsMultibanco = {
+  __typename?: 'Stripe_PaymentMethodDetailsMultibanco';
+  /** Entity number associated with this Multibanco payment. */
+  entity?: Maybe<Scalars['String']>;
+  /** Reference number associated with this Multibanco payment. */
+  reference?: Maybe<Scalars['String']>;
+};
+
+export type Stripe_PaymentMethodDetailsOxxo = {
+  __typename?: 'Stripe_PaymentMethodDetailsOxxo';
+  /** OXXO reference number */
+  number?: Maybe<Scalars['String']>;
+};
+
+export type Stripe_PaymentMethodDetailsP24 = {
+  __typename?: 'Stripe_PaymentMethodDetailsP24';
+  /** The customer's bank. Can be one of `ing`, `citi_handlowy`, `tmobile_usbugi_bankowe`, `plus_bank`, `etransfer_pocztowy24`, `banki_spbdzielcze`, `bank_nowy_bfg_sa`, `getin_bank`, `blik`, `noble_pay`, `ideabank`, `envelobank`, `santander_przelew24`, `nest_przelew`, `mbank_mtransfer`, `inteligo`, `pbac_z_ipko`, `bnp_paribas`, `credit_agricole`, `toyota_bank`, `bank_pekao_sa`, `volkswagen_bank`, `bank_millennium`, `alior_bank`, or `boz`. */
+  bank?: Maybe<Stripe_PaymentMethodDetailsP24BankProperty>;
+  /** Unique reference for this Przelewy24 payment. */
+  reference?: Maybe<Scalars['String']>;
+  /**
+   * Owner's verified full name. Values are verified or provided by Przelewy24 directly
+   * (if supported) at the time of authorization or settlement. They cannot be set or mutated.
+   * Przelewy24 rarely provides this information so the attribute is usually empty.
+   */
+  verified_name?: Maybe<Scalars['String']>;
+};
+
+export enum Stripe_PaymentMethodDetailsP24BankProperty {
+  AliorBank = 'alior_bank',
+  BankMillennium = 'bank_millennium',
+  BankNowyBfgSa = 'bank_nowy_bfg_sa',
+  BankPekaoSa = 'bank_pekao_sa',
+  BankiSpbdzielcze = 'banki_spbdzielcze',
+  Blik = 'blik',
+  BnpParibas = 'bnp_paribas',
+  Boz = 'boz',
+  CitiHandlowy = 'citi_handlowy',
+  CreditAgricole = 'credit_agricole',
+  Envelobank = 'envelobank',
+  EtransferPocztowy24 = 'etransfer_pocztowy24',
+  GetinBank = 'getin_bank',
+  Ideabank = 'ideabank',
+  Ing = 'ing',
+  Inteligo = 'inteligo',
+  MbankMtransfer = 'mbank_mtransfer',
+  NestPrzelew = 'nest_przelew',
+  NoblePay = 'noble_pay',
+  PbacZIpko = 'pbac_z_ipko',
+  PlusBank = 'plus_bank',
+  SantanderPrzelew24 = 'santander_przelew24',
+  TmobileUsbugiBankowe = 'tmobile_usbugi_bankowe',
+  ToyotaBank = 'toyota_bank',
+  VolkswagenBank = 'volkswagen_bank'
+}
+
+export type Stripe_PaymentMethodDetailsSepaDebit = {
+  __typename?: 'Stripe_PaymentMethodDetailsSepaDebit';
+  /** Bank code of bank associated with the bank account. */
+  bank_code?: Maybe<Scalars['String']>;
+  /** Branch code of bank associated with the bank account. */
+  branch_code?: Maybe<Scalars['String']>;
+  /** Two-letter ISO code representing the country the bank account is located in. */
+  country?: Maybe<Scalars['String']>;
+  /** Uniquely identifies this particular bank account. You can use this attribute to check whether two bank accounts are the same. */
+  fingerprint?: Maybe<Scalars['String']>;
+  /** Last four characters of the IBAN. */
+  last4?: Maybe<Scalars['String']>;
+  /** ID of the mandate used to make this payment. */
+  mandate?: Maybe<Scalars['String']>;
+};
+
+export type Stripe_PaymentMethodDetailsSofort = {
+  __typename?: 'Stripe_PaymentMethodDetailsSofort';
+  /** Bank code of bank associated with the bank account. */
+  bank_code?: Maybe<Scalars['String']>;
+  /** Name of the bank associated with the bank account. */
+  bank_name?: Maybe<Scalars['String']>;
+  /** Bank Identifier Code of the bank associated with the bank account. */
+  bic?: Maybe<Scalars['String']>;
+  /** Two-letter ISO code representing the country the bank account is located in. */
+  country?: Maybe<Scalars['String']>;
+  generated_sepa_debit?: Maybe<Stripe_PaymentMethodDetailsSofortGeneratedSepaDebitProperty>;
+  generated_sepa_debit_mandate?: Maybe<Stripe_PaymentMethodDetailsSofortGeneratedSepaDebitMandateProperty>;
+  /** Last four characters of the IBAN. */
+  iban_last4?: Maybe<Scalars['String']>;
+  /**
+   * Preferred language of the SOFORT authorization page that the customer is redirected to.
+   * Can be one of `de`, `en`, `es`, `fr`, `it`, `nl`, or `pl`
+   */
+  preferred_language?: Maybe<Stripe_PaymentMethodDetailsSofortPreferredLanguageProperty>;
+  /**
+   * Owner's verified full name. Values are verified or provided by SOFORT directly
+   * (if supported) at the time of authorization or settlement. They cannot be set or mutated.
+   */
+  verified_name?: Maybe<Scalars['String']>;
+};
+
+export type Stripe_PaymentMethodDetailsSofortGeneratedSepaDebitProperty = WrappedString | Stripe_PaymentMethod;
+
+export type Stripe_PaymentMethodDetailsSofortGeneratedSepaDebitMandateProperty = WrappedString | Stripe_Mandate;
+
+export enum Stripe_PaymentMethodDetailsSofortPreferredLanguageProperty {
+  De = 'de',
+  En = 'en',
+  Es = 'es',
+  Fr = 'fr',
+  It = 'it',
+  Nl = 'nl',
+  Pl = 'pl'
+}
+
+export type Stripe_PaymentMethodDetailsStripeAccount = {
+  __typename?: 'Stripe_PaymentMethodDetailsStripeAccount';
+  result?: Maybe<Scalars['JSONObject']>;
+};
+
+export type Stripe_PaymentMethodDetailsWechat = {
+  __typename?: 'Stripe_PaymentMethodDetailsWechat';
+  result?: Maybe<Scalars['JSONObject']>;
+};
+
+export type Stripe_PaymentMethodDetailsWechatPay = {
+  __typename?: 'Stripe_PaymentMethodDetailsWechatPay';
+  /** Uniquely identifies this particular WeChat Pay account. You can use this attribute to check whether two WeChat accounts are the same. */
+  fingerprint?: Maybe<Scalars['String']>;
+  /** Transaction ID of this particular WeChat Pay transaction. */
+  transaction_id?: Maybe<Scalars['String']>;
+};
+
+/** A list of refunds that have been applied to the charge. */
+export type Stripe_ChargeRefundsProperty = {
+  __typename?: 'Stripe_ChargeRefundsProperty';
+  /** Details about each object. */
+  data: Array<Stripe_Refund>;
+  /** True if this list has another page of items after this one that can be fetched. */
+  has_more: Scalars['Boolean'];
+  /** String representing the object's type. Objects of the same type share the same value. Always has the value `list`. */
+  object: Stripe_ChargeRefundsObjectProperty;
+  /** The URL where this list can be accessed. */
+  url: Scalars['String'];
+};
+
+export enum Stripe_ChargeRefundsObjectProperty {
+  List = 'list'
+}
+
+export type Stripe_ChargeReviewProperty = WrappedString | Stripe_Review;
+
+export type Stripe_Review = {
+  __typename?: 'Stripe_Review';
+  /** The ZIP or postal code of the card used, if applicable. */
+  billing_zip?: Maybe<Scalars['String']>;
+  charge?: Maybe<Stripe_ReviewChargeProperty>;
+  /** The reason the review was closed, or null if it has not yet been closed. One of `approved`, `refunded`, `refunded_as_fraud`, or `disputed`. */
+  closed_reason?: Maybe<Stripe_ReviewClosedReasonProperty>;
+  /** Time at which the object was created. Measured in seconds since the Unix epoch. */
+  created?: Maybe<Scalars['Int']>;
+  /** Unique identifier for the object. */
+  id?: Maybe<Scalars['String']>;
+  /** The IP address where the payment originated. */
+  ip_address?: Maybe<Scalars['String']>;
+  ip_address_location?: Maybe<Stripe_RadarReviewResourceLocation>;
+  /** Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode. */
+  livemode?: Maybe<Scalars['Boolean']>;
+  /** String representing the object's type. Objects of the same type share the same value. */
+  object?: Maybe<Stripe_ReviewObjectProperty>;
+  /** If `true`, the review needs action. */
+  open?: Maybe<Scalars['Boolean']>;
+  /** The reason the review was opened. One of `rule` or `manual`. */
+  opened_reason?: Maybe<Stripe_ReviewOpenedReasonProperty>;
+  payment_intent?: Maybe<Stripe_ReviewPaymentIntentProperty>;
+  /** The reason the review is currently open or closed. One of `rule`, `manual`, `approved`, `refunded`, `refunded_as_fraud`, or `disputed`. */
+  reason?: Maybe<Scalars['String']>;
+  session?: Maybe<Stripe_RadarReviewResourceSession>;
+};
+
+export type Stripe_ReviewChargeProperty = WrappedString | Stripe_Charge;
+
+export enum Stripe_ReviewClosedReasonProperty {
+  Approved = 'approved',
+  Disputed = 'disputed',
+  Refunded = 'refunded',
+  RefundedAsFraud = 'refunded_as_fraud'
+}
+
+export type Stripe_RadarReviewResourceLocation = {
+  __typename?: 'Stripe_RadarReviewResourceLocation';
+  /** The city where the payment originated. */
+  city?: Maybe<Scalars['String']>;
+  /** Two-letter ISO code representing the country where the payment originated. */
+  country?: Maybe<Scalars['String']>;
+  /** The geographic latitude where the payment originated. */
+  latitude?: Maybe<Scalars['Float']>;
+  /** The geographic longitude where the payment originated. */
+  longitude?: Maybe<Scalars['Float']>;
+  /** The state/county/province/region where the payment originated. */
+  region?: Maybe<Scalars['String']>;
+};
+
+export enum Stripe_ReviewObjectProperty {
+  Review = 'review'
+}
+
+export enum Stripe_ReviewOpenedReasonProperty {
+  Manual = 'manual',
+  Rule = 'rule'
+}
+
+export type Stripe_ReviewPaymentIntentProperty = WrappedString | Stripe_PaymentIntent;
+
+export type Stripe_RadarReviewResourceSession = {
+  __typename?: 'Stripe_RadarReviewResourceSession';
+  /** The browser used in this browser session (e.g., `Chrome`). */
+  browser?: Maybe<Scalars['String']>;
+  /** Information about the device used for the browser session (e.g., `Samsung SM-G930T`). */
+  device?: Maybe<Scalars['String']>;
+  /** The platform for the browser session (e.g., `Macintosh`). */
+  platform?: Maybe<Scalars['String']>;
+  /** The version for the browser session (e.g., `61.0.3163.100`). */
+  version?: Maybe<Scalars['String']>;
+};
+
+export type Stripe_ChargeSourceTransferProperty = WrappedString | Stripe_Transfer;
+
+export type Stripe_ChargeTransferProperty = WrappedString | Stripe_Transfer;
+
+export type Stripe_ChargeTransferData = {
+  __typename?: 'Stripe_ChargeTransferData';
+  /** The amount transferred to the destination account, if specified. By default, the entire charge amount is transferred to the destination account. */
+  amount?: Maybe<Scalars['Int']>;
+  destination?: Maybe<Stripe_ChargeTransferDataDestinationProperty>;
+};
+
+export type Stripe_ChargeTransferDataDestinationProperty = WrappedString | Stripe_Account;
+
+export enum Stripe_PaymentIntentChargesObjectProperty {
+  List = 'list'
+}
+
+export enum Stripe_PaymentIntentConfirmationMethodProperty {
+  Automatic = 'automatic',
+  Manual = 'manual'
+}
+
+export type Stripe_PaymentIntentCustomerProperty = WrappedString | Stripe_Customer | Stripe_DeletedCustomer;
+
+export type Stripe_PaymentIntentInvoiceProperty = WrappedString | Stripe_Invoice;
+
+export type Stripe_PaymentIntentNextAction = {
+  __typename?: 'Stripe_PaymentIntentNextAction';
+  alipay_handle_redirect?: Maybe<Stripe_PaymentIntentNextActionAlipayHandleRedirect>;
+  boleto_display_details?: Maybe<Stripe_PaymentIntentNextActionBoleto>;
+  oxxo_display_details?: Maybe<Stripe_PaymentIntentNextActionDisplayOxxoDetails>;
+  redirect_to_url?: Maybe<Stripe_PaymentIntentNextActionRedirectToUrl>;
+  /** Type of the next action to perform, one of `redirect_to_url`, `use_stripe_sdk`, `alipay_handle_redirect`, or `oxxo_display_details`. */
+  type?: Maybe<Scalars['String']>;
+  /** When confirming a PaymentIntent with Stripe.js, Stripe.js depends on the contents of this dictionary to invoke authentication flows. The shape of the contents is subject to change and is only intended to be used by Stripe.js. */
+  use_stripe_sdk?: Maybe<Scalars['JSONObject']>;
+  verify_with_microdeposits?: Maybe<Stripe_PaymentIntentNextActionVerifyWithMicrodeposits>;
+  wechat_pay_display_qr_code?: Maybe<Stripe_PaymentIntentNextActionWechatPayDisplayQrCode>;
+  wechat_pay_redirect_to_android_app?: Maybe<Stripe_PaymentIntentNextActionWechatPayRedirectToAndroidApp>;
+  wechat_pay_redirect_to_ios_app?: Maybe<Stripe_PaymentIntentNextActionWechatPayRedirectToIosApp>;
+};
+
+export type Stripe_PaymentIntentNextActionAlipayHandleRedirect = {
+  __typename?: 'Stripe_PaymentIntentNextActionAlipayHandleRedirect';
+  /** The native data to be used with Alipay SDK you must redirect your customer to in order to authenticate the payment in an Android App. */
+  native_data?: Maybe<Scalars['String']>;
+  /** The native URL you must redirect your customer to in order to authenticate the payment in an iOS App. */
+  native_url?: Maybe<Scalars['String']>;
+  /** If the customer does not exit their browser while authenticating, they will be redirected to this specified URL after completion. */
+  return_url?: Maybe<Scalars['String']>;
+  /** The URL you must redirect your customer to in order to authenticate the payment. */
+  url?: Maybe<Scalars['String']>;
+};
+
+export type Stripe_PaymentIntentNextActionBoleto = {
+  __typename?: 'Stripe_PaymentIntentNextActionBoleto';
+  /** The timestamp after which the boleto expires. */
+  expires_at?: Maybe<Scalars['Int']>;
+  /** The URL to the hosted boleto voucher page, which allows customers to view the boleto voucher. */
+  hosted_voucher_url?: Maybe<Scalars['String']>;
+  /** The boleto number. */
+  number?: Maybe<Scalars['String']>;
+  /** The URL to the downloadable boleto voucher PDF. */
+  pdf?: Maybe<Scalars['String']>;
+};
+
+export type Stripe_PaymentIntentNextActionDisplayOxxoDetails = {
+  __typename?: 'Stripe_PaymentIntentNextActionDisplayOxxoDetails';
+  /** The timestamp after which the OXXO voucher expires. */
+  expires_after?: Maybe<Scalars['Int']>;
+  /** The URL for the hosted OXXO voucher page, which allows customers to view and print an OXXO voucher. */
+  hosted_voucher_url?: Maybe<Scalars['String']>;
+  /** OXXO reference number. */
+  number?: Maybe<Scalars['String']>;
+};
+
+export type Stripe_PaymentIntentNextActionRedirectToUrl = {
+  __typename?: 'Stripe_PaymentIntentNextActionRedirectToUrl';
+  /** If the customer does not exit their browser while authenticating, they will be redirected to this specified URL after completion. */
+  return_url?: Maybe<Scalars['String']>;
+  /** The URL you must redirect your customer to in order to authenticate the payment. */
+  url?: Maybe<Scalars['String']>;
+};
+
+export type Stripe_PaymentIntentNextActionVerifyWithMicrodeposits = {
+  __typename?: 'Stripe_PaymentIntentNextActionVerifyWithMicrodeposits';
+  /** The timestamp when the microdeposits are expected to land. */
+  arrival_date?: Maybe<Scalars['Int']>;
+  /** The URL for the hosted verification page, which allows customers to verify their bank account. */
+  hosted_verification_url?: Maybe<Scalars['String']>;
+};
+
+export type Stripe_PaymentIntentNextActionWechatPayDisplayQrCode = {
+  __typename?: 'Stripe_PaymentIntentNextActionWechatPayDisplayQrCode';
+  /** The data being used to generate QR code */
+  data?: Maybe<Scalars['String']>;
+  /** The base64 image data for a pre-generated QR code */
+  image_data_url?: Maybe<Scalars['String']>;
+};
+
+export type Stripe_PaymentIntentNextActionWechatPayRedirectToAndroidApp = {
+  __typename?: 'Stripe_PaymentIntentNextActionWechatPayRedirectToAndroidApp';
+  /** app_id is the APP ID registered on WeChat open platform */
+  app_id?: Maybe<Scalars['String']>;
+  /** nonce_str is a random string */
+  nonce_str?: Maybe<Scalars['String']>;
+  /** package is static value */
+  package?: Maybe<Scalars['String']>;
+  /** an unique merchant ID assigned by Wechat Pay */
+  partner_id?: Maybe<Scalars['String']>;
+  /** an unique trading ID assigned by Wechat Pay */
+  prepay_id?: Maybe<Scalars['String']>;
+  /** A signature */
+  sign?: Maybe<Scalars['String']>;
+  /** Specifies the current time in epoch format */
+  timestamp?: Maybe<Scalars['String']>;
+};
+
+export type Stripe_PaymentIntentNextActionWechatPayRedirectToIosApp = {
+  __typename?: 'Stripe_PaymentIntentNextActionWechatPayRedirectToIosApp';
+  /** An universal link that redirect to Wechat Pay APP */
+  native_url?: Maybe<Scalars['String']>;
+};
+
+export enum Stripe_PaymentIntentObjectProperty {
+  PaymentIntent = 'payment_intent'
+}
+
+export type Stripe_PaymentIntentOnBehalfOfProperty = WrappedString | Stripe_Account;
+
+export type Stripe_PaymentIntentPaymentMethodProperty = WrappedString | Stripe_PaymentMethod;
+
+export type Stripe_PaymentIntentPaymentMethodOptions = {
+  __typename?: 'Stripe_PaymentIntentPaymentMethodOptions';
+  acss_debit?: Maybe<Stripe_PaymentIntentPaymentMethodOptionsAcssDebit>;
+  afterpay_clearpay?: Maybe<Stripe_PaymentMethodOptionsAfterpayClearpay>;
+  alipay?: Maybe<Stripe_PaymentMethodOptionsAlipay>;
+  bancontact?: Maybe<Stripe_PaymentMethodOptionsBancontact>;
+  boleto?: Maybe<Stripe_PaymentMethodOptionsBoleto>;
+  card?: Maybe<Stripe_PaymentIntentPaymentMethodOptionsCard>;
+  card_present?: Maybe<Stripe_PaymentMethodOptionsCardPresent>;
+  ideal?: Maybe<Stripe_PaymentMethodOptionsIdeal>;
+  oxxo?: Maybe<Stripe_PaymentMethodOptionsOxxo>;
+  p24?: Maybe<Stripe_PaymentMethodOptionsP24>;
+  sepa_debit?: Maybe<Stripe_PaymentIntentPaymentMethodOptionsSepaDebit>;
+  sofort?: Maybe<Stripe_PaymentMethodOptionsSofort>;
+  wechat_pay?: Maybe<Stripe_PaymentMethodOptionsWechatPay>;
+};
+
+export type Stripe_PaymentIntentPaymentMethodOptionsAcssDebit = {
+  __typename?: 'Stripe_PaymentIntentPaymentMethodOptionsAcssDebit';
+  mandate_options?: Maybe<Stripe_PaymentIntentPaymentMethodOptionsMandateOptionsAcssDebit>;
+  /** Bank account verification method. */
+  verification_method?: Maybe<Stripe_PaymentIntentPaymentMethodOptionsAcssDebitVerificationMethodProperty>;
+};
+
+export type Stripe_PaymentIntentPaymentMethodOptionsMandateOptionsAcssDebit = {
+  __typename?: 'Stripe_PaymentIntentPaymentMethodOptionsMandateOptionsAcssDebit';
+  /** A URL for custom mandate text */
+  custom_mandate_url?: Maybe<Scalars['String']>;
+  /** Description of the interval. Only required if 'payment_schedule' parmeter is 'interval' or 'combined'. */
+  interval_description?: Maybe<Scalars['String']>;
+  /** Payment schedule for the mandate. */
+  payment_schedule?: Maybe<Stripe_PaymentIntentPaymentMethodOptionsMandateOptionsAcssDebitPaymentScheduleProperty>;
+  /** Transaction type of the mandate. */
+  transaction_type?: Maybe<Stripe_PaymentIntentPaymentMethodOptionsMandateOptionsAcssDebitTransactionTypeProperty>;
+};
+
+export enum Stripe_PaymentIntentPaymentMethodOptionsMandateOptionsAcssDebitPaymentScheduleProperty {
+  Combined = 'combined',
+  Interval = 'interval',
+  Sporadic = 'sporadic'
+}
+
+export enum Stripe_PaymentIntentPaymentMethodOptionsMandateOptionsAcssDebitTransactionTypeProperty {
+  Business = 'business',
+  Personal = 'personal'
+}
+
+export enum Stripe_PaymentIntentPaymentMethodOptionsAcssDebitVerificationMethodProperty {
+  Automatic = 'automatic',
+  Instant = 'instant',
+  Microdeposits = 'microdeposits'
+}
+
+export type Stripe_PaymentMethodOptionsAfterpayClearpay = {
+  __typename?: 'Stripe_PaymentMethodOptionsAfterpayClearpay';
+  /**
+   * Order identifier shown to the merchant in Afterpay’s online portal. We recommend using a value that helps you answer any questions a customer might have about
+   * the payment. The identifier is limited to 128 characters and may contain only letters, digits, underscores, backslashes and dashes.
+   */
+  reference?: Maybe<Scalars['String']>;
+};
+
+export type Stripe_PaymentMethodOptionsAlipay = {
+  __typename?: 'Stripe_PaymentMethodOptionsAlipay';
+  result?: Maybe<Scalars['JSONObject']>;
+};
+
+export type Stripe_PaymentMethodOptionsBancontact = {
+  __typename?: 'Stripe_PaymentMethodOptionsBancontact';
+  /** Preferred language of the Bancontact authorization page that the customer is redirected to. */
+  preferred_language?: Maybe<Stripe_PaymentMethodOptionsBancontactPreferredLanguageProperty>;
+};
+
+export enum Stripe_PaymentMethodOptionsBancontactPreferredLanguageProperty {
+  De = 'de',
+  En = 'en',
+  Fr = 'fr',
+  Nl = 'nl'
+}
+
+export type Stripe_PaymentMethodOptionsBoleto = {
+  __typename?: 'Stripe_PaymentMethodOptionsBoleto';
+  /** The number of calendar days before a Boleto voucher expires. For example, if you create a Boleto voucher on Monday and you set expires_after_days to 2, the Boleto voucher will expire on Wednesday at 23:59 America/Sao_Paulo time. */
+  expires_after_days?: Maybe<Scalars['Int']>;
+};
+
+export type Stripe_PaymentIntentPaymentMethodOptionsCard = {
+  __typename?: 'Stripe_PaymentIntentPaymentMethodOptionsCard';
+  installments?: Maybe<Stripe_PaymentMethodOptionsCardInstallments>;
+  /** Selected network to process this payment intent on. Depends on the available networks of the card attached to the payment intent. Can be only set confirm-time. */
+  network?: Maybe<Stripe_PaymentIntentPaymentMethodOptionsCardNetworkProperty>;
+  /** We strongly recommend that you rely on our SCA Engine to automatically prompt your customers for authentication based on risk level and [other requirements](https://stripe.com/docs/strong-customer-authentication). However, if you wish to request 3D Secure based on logic from your own fraud engine, provide this option. Permitted values include: `automatic` or `any`. If not provided, defaults to `automatic`. Read our guide on [manually requesting 3D Secure](https://stripe.com/docs/payments/3d-secure#manual-three-ds) for more information on how this configuration interacts with Radar and our SCA Engine. */
+  request_three_d_secure?: Maybe<Stripe_PaymentIntentPaymentMethodOptionsCardRequestThreeDSecureProperty>;
+};
+
+export type Stripe_PaymentMethodOptionsCardInstallments = {
+  __typename?: 'Stripe_PaymentMethodOptionsCardInstallments';
+  /** Installment plans that may be selected for this PaymentIntent. */
+  available_plans?: Maybe<Array<Maybe<Stripe_PaymentMethodDetailsCardInstallmentsPlan>>>;
+  /** Whether Installments are enabled for this PaymentIntent. */
+  enabled?: Maybe<Scalars['Boolean']>;
+  plan?: Maybe<Stripe_PaymentMethodDetailsCardInstallmentsPlan>;
+};
+
+export enum Stripe_PaymentIntentPaymentMethodOptionsCardNetworkProperty {
+  Amex = 'amex',
+  CartesBancaires = 'cartes_bancaires',
+  Diners = 'diners',
+  Discover = 'discover',
+  Interac = 'interac',
+  Jcb = 'jcb',
+  Mastercard = 'mastercard',
+  Unionpay = 'unionpay',
+  Unknown = 'unknown',
+  Visa = 'visa'
+}
+
+export enum Stripe_PaymentIntentPaymentMethodOptionsCardRequestThreeDSecureProperty {
+  Any = 'any',
+  Automatic = 'automatic',
+  ChallengeOnly = 'challenge_only'
+}
+
+export type Stripe_PaymentMethodOptionsCardPresent = {
+  __typename?: 'Stripe_PaymentMethodOptionsCardPresent';
+  result?: Maybe<Scalars['JSONObject']>;
+};
+
+export type Stripe_PaymentMethodOptionsIdeal = {
+  __typename?: 'Stripe_PaymentMethodOptionsIdeal';
+  result?: Maybe<Scalars['JSONObject']>;
+};
+
+export type Stripe_PaymentMethodOptionsOxxo = {
+  __typename?: 'Stripe_PaymentMethodOptionsOxxo';
+  /** The number of calendar days before an OXXO invoice expires. For example, if you create an OXXO invoice on Monday and you set expires_after_days to 2, the OXXO invoice will expire on Wednesday at 23:59 America/Mexico_City time. */
+  expires_after_days?: Maybe<Scalars['Int']>;
+};
+
+export type Stripe_PaymentMethodOptionsP24 = {
+  __typename?: 'Stripe_PaymentMethodOptionsP24';
+  result?: Maybe<Scalars['JSONObject']>;
+};
+
+export type Stripe_PaymentIntentPaymentMethodOptionsSepaDebit = {
+  __typename?: 'Stripe_PaymentIntentPaymentMethodOptionsSepaDebit';
+  mandate_options?: Maybe<Stripe_PaymentIntentPaymentMethodOptionsMandateOptionsSepaDebit>;
+};
+
+export type Stripe_PaymentIntentPaymentMethodOptionsMandateOptionsSepaDebit = {
+  __typename?: 'Stripe_PaymentIntentPaymentMethodOptionsMandateOptionsSepaDebit';
+  result?: Maybe<Scalars['JSONObject']>;
+};
+
+export type Stripe_PaymentMethodOptionsSofort = {
+  __typename?: 'Stripe_PaymentMethodOptionsSofort';
+  /** Preferred language of the SOFORT authorization page that the customer is redirected to. */
+  preferred_language?: Maybe<Stripe_PaymentMethodOptionsSofortPreferredLanguageProperty>;
+};
+
+export enum Stripe_PaymentMethodOptionsSofortPreferredLanguageProperty {
+  De = 'de',
+  En = 'en',
+  Es = 'es',
+  Fr = 'fr',
+  It = 'it',
+  Nl = 'nl',
+  Pl = 'pl'
+}
+
+export type Stripe_PaymentMethodOptionsWechatPay = {
+  __typename?: 'Stripe_PaymentMethodOptionsWechatPay';
+  /** The app ID registered with WeChat Pay. Only required when client is ios or android. */
+  app_id?: Maybe<Scalars['String']>;
+  /** The client type that the end customer will pay from */
+  client?: Maybe<Stripe_PaymentMethodOptionsWechatPayClientProperty>;
+};
+
+export enum Stripe_PaymentMethodOptionsWechatPayClientProperty {
+  Android = 'android',
+  Ios = 'ios',
+  Web = 'web'
+}
+
+export type Stripe_PaymentIntentReviewProperty = WrappedString | Stripe_Review;
+
+export enum Stripe_PaymentIntentSetupFutureUsageProperty {
+  OffSession = 'off_session',
+  OnSession = 'on_session'
+}
+
+export enum Stripe_PaymentIntentStatusProperty {
+  Canceled = 'canceled',
+  Processing = 'processing',
+  RequiresAction = 'requires_action',
+  RequiresCapture = 'requires_capture',
+  RequiresConfirmation = 'requires_confirmation',
+  RequiresPaymentMethod = 'requires_payment_method',
+  Succeeded = 'succeeded'
+}
+
+export type Stripe_TransferData = {
+  __typename?: 'Stripe_TransferData';
+  /** Amount intended to be collected by this PaymentIntent. A positive integer representing how much to charge in the [smallest currency unit](https://stripe.com/docs/currencies#zero-decimal) (e.g., 100 cents to charge $1.00 or 100 to charge ¥100, a zero-decimal currency). The minimum amount is $0.50 US or [equivalent in charge currency](https://stripe.com/docs/currencies#minimum-and-maximum-charge-amounts). The amount value supports up to eight digits (e.g., a value of 99999999 for a USD charge of $999,999.99). */
+  amount?: Maybe<Scalars['Int']>;
+  destination?: Maybe<Stripe_TransferDataDestinationProperty>;
+};
+
+export type Stripe_TransferDataDestinationProperty = WrappedString | Stripe_Account;
+
+export type Stripe_ApiErrorsSourceProperty = Stripe_BankAccount | Stripe_Card | Stripe_Source;
+
+export enum Stripe_ApiErrorsTypeProperty {
+  ApiError = 'api_error',
+  CardError = 'card_error',
+  IdempotencyError = 'idempotency_error',
+  InvalidRequestError = 'invalid_request_error'
+}
+
+export type Stripe_SetupAttemptSetupIntentProperty = WrappedString | Stripe_SetupIntent;
+
+export type Stripe_Networks = {
+  __typename?: 'Stripe_Networks';
+  /** All available networks for the card. */
+  available?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** The preferred network for the card. */
+  preferred?: Maybe<Scalars['String']>;
+};
+
+export type Stripe_ThreeDSecureUsage = {
+  __typename?: 'Stripe_ThreeDSecureUsage';
+  /** Whether 3D Secure is supported on this card. */
+  supported?: Maybe<Scalars['Boolean']>;
+};
+
+export type Stripe_PaymentMethodCardWallet = {
+  __typename?: 'Stripe_PaymentMethodCardWallet';
+  amex_express_checkout?: Maybe<Stripe_PaymentMethodCardWalletAmexExpressCheckout>;
+  apple_pay?: Maybe<Stripe_PaymentMethodCardWalletApplePay>;
+  /** (For tokenized numbers only.) The last four digits of the device account number. */
+  dynamic_last4?: Maybe<Scalars['String']>;
+  google_pay?: Maybe<Stripe_PaymentMethodCardWalletGooglePay>;
+  masterpass?: Maybe<Stripe_PaymentMethodCardWalletMasterpass>;
+  samsung_pay?: Maybe<Stripe_PaymentMethodCardWalletSamsungPay>;
+  /** The type of the card wallet, one of `amex_express_checkout`, `apple_pay`, `google_pay`, `masterpass`, `samsung_pay`, or `visa_checkout`. An additional hash is included on the Wallet subhash with a name matching this value. It contains additional information specific to the card wallet type. */
+  type?: Maybe<Stripe_PaymentMethodCardWalletTypeProperty>;
+  visa_checkout?: Maybe<Stripe_PaymentMethodCardWalletVisaCheckout>;
+};
+
+export type Stripe_PaymentMethodCardWalletAmexExpressCheckout = {
+  __typename?: 'Stripe_PaymentMethodCardWalletAmexExpressCheckout';
+  result?: Maybe<Scalars['JSONObject']>;
+};
+
+export type Stripe_PaymentMethodCardWalletApplePay = {
+  __typename?: 'Stripe_PaymentMethodCardWalletApplePay';
+  result?: Maybe<Scalars['JSONObject']>;
+};
+
+export type Stripe_PaymentMethodCardWalletGooglePay = {
+  __typename?: 'Stripe_PaymentMethodCardWalletGooglePay';
+  result?: Maybe<Scalars['JSONObject']>;
+};
+
+export type Stripe_PaymentMethodCardWalletMasterpass = {
+  __typename?: 'Stripe_PaymentMethodCardWalletMasterpass';
+  billing_address?: Maybe<Stripe_Address>;
+  /** Owner's verified email. Values are verified or provided by the wallet directly (if supported) at the time of authorization or settlement. They cannot be set or mutated. */
+  email?: Maybe<Scalars['String']>;
+  /** Owner's verified full name. Values are verified or provided by the wallet directly (if supported) at the time of authorization or settlement. They cannot be set or mutated. */
+  name?: Maybe<Scalars['String']>;
+  shipping_address?: Maybe<Stripe_Address>;
+};
+
+export type Stripe_PaymentMethodCardWalletSamsungPay = {
+  __typename?: 'Stripe_PaymentMethodCardWalletSamsungPay';
+  result?: Maybe<Scalars['JSONObject']>;
+};
+
+export enum Stripe_PaymentMethodCardWalletTypeProperty {
+  AmexExpressCheckout = 'amex_express_checkout',
+  ApplePay = 'apple_pay',
+  GooglePay = 'google_pay',
+  Masterpass = 'masterpass',
+  SamsungPay = 'samsung_pay',
+  VisaCheckout = 'visa_checkout'
+}
+
+export type Stripe_PaymentMethodCardWalletVisaCheckout = {
+  __typename?: 'Stripe_PaymentMethodCardWalletVisaCheckout';
+  billing_address?: Maybe<Stripe_Address>;
+  /** Owner's verified email. Values are verified or provided by the wallet directly (if supported) at the time of authorization or settlement. They cannot be set or mutated. */
+  email?: Maybe<Scalars['String']>;
+  /** Owner's verified full name. Values are verified or provided by the wallet directly (if supported) at the time of authorization or settlement. They cannot be set or mutated. */
+  name?: Maybe<Scalars['String']>;
+  shipping_address?: Maybe<Stripe_Address>;
+};
+
+export type Stripe_PaymentMethodCardPresent = {
+  __typename?: 'Stripe_PaymentMethodCardPresent';
+  result?: Maybe<Scalars['JSONObject']>;
+};
+
+export type Stripe_PaymentMethodCustomerProperty = WrappedString | Stripe_Customer;
+
+export type Stripe_PaymentMethodEps = {
+  __typename?: 'Stripe_PaymentMethodEps';
+  /** The customer's bank. Should be one of `arzte_und_apotheker_bank`, `austrian_anadi_bank_ag`, `bank_austria`, `bankhaus_carl_spangler`, `bankhaus_schelhammer_und_schattera_ag`, `bawag_psk_ag`, `bks_bank_ag`, `brull_kallmus_bank_ag`, `btv_vier_lander_bank`, `capital_bank_grawe_gruppe_ag`, `dolomitenbank`, `easybank_ag`, `erste_bank_und_sparkassen`, `hypo_alpeadriabank_international_ag`, `hypo_noe_lb_fur_niederosterreich_u_wien`, `hypo_oberosterreich_salzburg_steiermark`, `hypo_tirol_bank_ag`, `hypo_vorarlberg_bank_ag`, `hypo_bank_burgenland_aktiengesellschaft`, `marchfelder_bank`, `oberbank_ag`, `raiffeisen_bankengruppe_osterreich`, `schoellerbank_ag`, `sparda_bank_wien`, `volksbank_gruppe`, `volkskreditbank_ag`, or `vr_bank_braunau`. */
+  bank?: Maybe<Stripe_PaymentMethodEpsBankProperty>;
+};
+
+export enum Stripe_PaymentMethodEpsBankProperty {
+  ArzteUndApothekerBank = 'arzte_und_apotheker_bank',
+  AustrianAnadiBankAg = 'austrian_anadi_bank_ag',
+  BankAustria = 'bank_austria',
+  BankhausCarlSpangler = 'bankhaus_carl_spangler',
+  BankhausSchelhammerUndSchatteraAg = 'bankhaus_schelhammer_und_schattera_ag',
+  BawagPskAg = 'bawag_psk_ag',
+  BksBankAg = 'bks_bank_ag',
+  BrullKallmusBankAg = 'brull_kallmus_bank_ag',
+  BtvVierLanderBank = 'btv_vier_lander_bank',
+  CapitalBankGraweGruppeAg = 'capital_bank_grawe_gruppe_ag',
+  Dolomitenbank = 'dolomitenbank',
+  EasybankAg = 'easybank_ag',
+  ErsteBankUndSparkassen = 'erste_bank_und_sparkassen',
+  HypoAlpeadriabankInternationalAg = 'hypo_alpeadriabank_international_ag',
+  HypoBankBurgenlandAktiengesellschaft = 'hypo_bank_burgenland_aktiengesellschaft',
+  HypoNoeLbFurNiederosterreichUWien = 'hypo_noe_lb_fur_niederosterreich_u_wien',
+  HypoOberosterreichSalzburgSteiermark = 'hypo_oberosterreich_salzburg_steiermark',
+  HypoTirolBankAg = 'hypo_tirol_bank_ag',
+  HypoVorarlbergBankAg = 'hypo_vorarlberg_bank_ag',
+  MarchfelderBank = 'marchfelder_bank',
+  OberbankAg = 'oberbank_ag',
+  RaiffeisenBankengruppeOsterreich = 'raiffeisen_bankengruppe_osterreich',
+  SchoellerbankAg = 'schoellerbank_ag',
+  SpardaBankWien = 'sparda_bank_wien',
+  VolksbankGruppe = 'volksbank_gruppe',
+  VolkskreditbankAg = 'volkskreditbank_ag',
+  VrBankBraunau = 'vr_bank_braunau'
+}
+
+export type Stripe_PaymentMethodFpx = {
+  __typename?: 'Stripe_PaymentMethodFpx';
+  /** The customer's bank, if provided. Can be one of `affin_bank`, `alliance_bank`, `ambank`, `bank_islam`, `bank_muamalat`, `bank_rakyat`, `bsn`, `cimb`, `hong_leong_bank`, `hsbc`, `kfh`, `maybank2u`, `ocbc`, `public_bank`, `rhb`, `standard_chartered`, `uob`, `deutsche_bank`, `maybank2e`, or `pb_enterprise`. */
+  bank?: Maybe<Stripe_PaymentMethodFpxBankProperty>;
+};
+
+export enum Stripe_PaymentMethodFpxBankProperty {
+  AffinBank = 'affin_bank',
+  AllianceBank = 'alliance_bank',
+  Ambank = 'ambank',
+  BankIslam = 'bank_islam',
+  BankMuamalat = 'bank_muamalat',
+  BankRakyat = 'bank_rakyat',
+  Bsn = 'bsn',
+  Cimb = 'cimb',
+  DeutscheBank = 'deutsche_bank',
+  HongLeongBank = 'hong_leong_bank',
+  Hsbc = 'hsbc',
+  Kfh = 'kfh',
+  Maybank2e = 'maybank2e',
+  Maybank2u = 'maybank2u',
+  Ocbc = 'ocbc',
+  PbEnterprise = 'pb_enterprise',
+  PublicBank = 'public_bank',
+  Rhb = 'rhb',
+  StandardChartered = 'standard_chartered',
+  Uob = 'uob'
+}
+
+export type Stripe_PaymentMethodGiropay = {
+  __typename?: 'Stripe_PaymentMethodGiropay';
+  result?: Maybe<Scalars['JSONObject']>;
+};
+
+export type Stripe_PaymentMethodGrabpay = {
+  __typename?: 'Stripe_PaymentMethodGrabpay';
+  result?: Maybe<Scalars['JSONObject']>;
+};
+
+export type Stripe_PaymentMethodIdeal = {
+  __typename?: 'Stripe_PaymentMethodIdeal';
+  /** The customer's bank, if provided. Can be one of `abn_amro`, `asn_bank`, `bunq`, `handelsbanken`, `ing`, `knab`, `moneyou`, `rabobank`, `regiobank`, `revolut`, `sns_bank`, `triodos_bank`, or `van_lanschot`. */
+  bank?: Maybe<Stripe_PaymentMethodIdealBankProperty>;
+  /** The Bank Identifier Code of the customer's bank, if the bank was provided. */
+  bic?: Maybe<Stripe_PaymentMethodIdealBicProperty>;
+};
+
+export enum Stripe_PaymentMethodIdealBankProperty {
+  AbnAmro = 'abn_amro',
+  AsnBank = 'asn_bank',
+  Bunq = 'bunq',
+  Handelsbanken = 'handelsbanken',
+  Ing = 'ing',
+  Knab = 'knab',
+  Moneyou = 'moneyou',
+  Rabobank = 'rabobank',
+  Regiobank = 'regiobank',
+  Revolut = 'revolut',
+  SnsBank = 'sns_bank',
+  TriodosBank = 'triodos_bank',
+  VanLanschot = 'van_lanschot'
+}
+
+export enum Stripe_PaymentMethodIdealBicProperty {
+  Abnanl2A = 'ABNANL2A',
+  Asnbnl21 = 'ASNBNL21',
+  Bunqnl2A = 'BUNQNL2A',
+  Fvlbnl22 = 'FVLBNL22',
+  Handnl2A = 'HANDNL2A',
+  Ingbnl2A = 'INGBNL2A',
+  Knabnl2H = 'KNABNL2H',
+  Moyonl21 = 'MOYONL21',
+  Rabonl2U = 'RABONL2U',
+  Rbrbnl21 = 'RBRBNL21',
+  Revolt21 = 'REVOLT21',
+  Snsbnl2A = 'SNSBNL2A',
+  Trionl2U = 'TRIONL2U'
+}
+
+export type Stripe_PaymentMethodInteracPresent = {
+  __typename?: 'Stripe_PaymentMethodInteracPresent';
+  result?: Maybe<Scalars['JSONObject']>;
+};
+
+export enum Stripe_PaymentMethodObjectProperty {
+  PaymentMethod = 'payment_method'
+}
+
+export type Stripe_PaymentMethodOxxo = {
+  __typename?: 'Stripe_PaymentMethodOxxo';
+  result?: Maybe<Scalars['JSONObject']>;
+};
+
+export type Stripe_PaymentMethodP24 = {
+  __typename?: 'Stripe_PaymentMethodP24';
+  /** The customer's bank, if provided. */
+  bank?: Maybe<Stripe_PaymentMethodP24BankProperty>;
+};
+
+export enum Stripe_PaymentMethodP24BankProperty {
+  AliorBank = 'alior_bank',
+  BankMillennium = 'bank_millennium',
+  BankNowyBfgSa = 'bank_nowy_bfg_sa',
+  BankPekaoSa = 'bank_pekao_sa',
+  BankiSpbdzielcze = 'banki_spbdzielcze',
+  Blik = 'blik',
+  BnpParibas = 'bnp_paribas',
+  Boz = 'boz',
+  CitiHandlowy = 'citi_handlowy',
+  CreditAgricole = 'credit_agricole',
+  Envelobank = 'envelobank',
+  EtransferPocztowy24 = 'etransfer_pocztowy24',
+  GetinBank = 'getin_bank',
+  Ideabank = 'ideabank',
+  Ing = 'ing',
+  Inteligo = 'inteligo',
+  MbankMtransfer = 'mbank_mtransfer',
+  NestPrzelew = 'nest_przelew',
+  NoblePay = 'noble_pay',
+  PbacZIpko = 'pbac_z_ipko',
+  PlusBank = 'plus_bank',
+  SantanderPrzelew24 = 'santander_przelew24',
+  TmobileUsbugiBankowe = 'tmobile_usbugi_bankowe',
+  ToyotaBank = 'toyota_bank',
+  VolkswagenBank = 'volkswagen_bank'
+}
+
+export type Stripe_PaymentMethodSepaDebit = {
+  __typename?: 'Stripe_PaymentMethodSepaDebit';
+  /** Bank code of bank associated with the bank account. */
+  bank_code?: Maybe<Scalars['String']>;
+  /** Branch code of bank associated with the bank account. */
+  branch_code?: Maybe<Scalars['String']>;
+  /** Two-letter ISO code representing the country the bank account is located in. */
+  country?: Maybe<Scalars['String']>;
+  /** Uniquely identifies this particular bank account. You can use this attribute to check whether two bank accounts are the same. */
+  fingerprint?: Maybe<Scalars['String']>;
+  generated_from?: Maybe<Stripe_SepaDebitGeneratedFrom>;
+  /** Last four characters of the IBAN. */
+  last4?: Maybe<Scalars['String']>;
+};
+
+export type Stripe_SepaDebitGeneratedFrom = {
+  __typename?: 'Stripe_SepaDebitGeneratedFrom';
+  charge?: Maybe<Stripe_SepaDebitGeneratedFromChargeProperty>;
+  setup_attempt?: Maybe<Stripe_SepaDebitGeneratedFromSetupAttemptProperty>;
+};
+
+export type Stripe_SepaDebitGeneratedFromChargeProperty = WrappedString | Stripe_Charge;
+
+export type Stripe_SepaDebitGeneratedFromSetupAttemptProperty = WrappedString | Stripe_SetupAttempt;
+
+export type Stripe_PaymentMethodSofort = {
+  __typename?: 'Stripe_PaymentMethodSofort';
+  /** Two-letter ISO code representing the country the bank account is located in. */
+  country?: Maybe<Scalars['String']>;
+};
+
+export enum Stripe_PaymentMethodTypeProperty {
+  AcssDebit = 'acss_debit',
+  AfterpayClearpay = 'afterpay_clearpay',
+  Alipay = 'alipay',
+  AuBecsDebit = 'au_becs_debit',
+  BacsDebit = 'bacs_debit',
+  Bancontact = 'bancontact',
+  Boleto = 'boleto',
+  Card = 'card',
+  CardPresent = 'card_present',
+  Eps = 'eps',
+  Fpx = 'fpx',
+  Giropay = 'giropay',
+  Grabpay = 'grabpay',
+  Ideal = 'ideal',
+  InteracPresent = 'interac_present',
+  Oxxo = 'oxxo',
+  P24 = 'p24',
+  SepaDebit = 'sepa_debit',
+  Sofort = 'sofort',
+  WechatPay = 'wechat_pay'
+}
+
+export type Stripe_PaymentMethodWechatPay = {
+  __typename?: 'Stripe_PaymentMethodWechatPay';
+  result?: Maybe<Scalars['JSONObject']>;
+};
+
+export enum Stripe_CustomerObjectProperty {
+  Customer = 'customer'
+}
+
+/** The customer's payment sources, if any. */
+export type Stripe_CustomerSourcesProperty = {
+  __typename?: 'Stripe_CustomerSourcesProperty';
+  /** Details about each object. */
+  data: Array<Stripe_CustomerSourcesDataProperty>;
+  /** True if this list has another page of items after this one that can be fetched. */
+  has_more: Scalars['Boolean'];
+  /** String representing the object's type. Objects of the same type share the same value. Always has the value `list`. */
+  object: Stripe_CustomerSourcesObjectProperty;
+  /** The URL where this list can be accessed. */
+  url: Scalars['String'];
+};
+
+export type Stripe_CustomerSourcesDataProperty = Stripe_AlipayAccount | Stripe_BankAccount | Stripe_BitcoinReceiver | Stripe_Card | Stripe_Source;
+
+export enum Stripe_CustomerSourcesObjectProperty {
+  List = 'list'
+}
+
+/** The customer's current subscriptions, if any. */
+export type Stripe_CustomerSubscriptionsProperty = {
+  __typename?: 'Stripe_CustomerSubscriptionsProperty';
+  /** Details about each object. */
+  data: Array<Stripe_Subscription>;
+  /** True if this list has another page of items after this one that can be fetched. */
+  has_more: Scalars['Boolean'];
+  /** String representing the object's type. Objects of the same type share the same value. Always has the value `list`. */
+  object: Stripe_CustomerSubscriptionsObjectProperty;
+  /** The URL where this list can be accessed. */
+  url: Scalars['String'];
+};
+
+export enum Stripe_CustomerSubscriptionsObjectProperty {
+  List = 'list'
+}
+
+export type Stripe_CustomerTax = {
+  __typename?: 'Stripe_CustomerTax';
+  /** Surfaces if automatic tax computation is possible given the current customer location information. */
+  automatic_tax?: Maybe<Stripe_CustomerTaxAutomaticTaxProperty>;
+  /** A recent IP address of the customer used for tax reporting and tax location inference. */
+  ip_address?: Maybe<Scalars['String']>;
+  location?: Maybe<Stripe_CustomerTaxLocation>;
+};
+
+export enum Stripe_CustomerTaxAutomaticTaxProperty {
+  Failed = 'failed',
+  NotCollecting = 'not_collecting',
+  Supported = 'supported',
+  UnrecognizedLocation = 'unrecognized_location'
+}
+
+export type Stripe_CustomerTaxLocation = {
+  __typename?: 'Stripe_CustomerTaxLocation';
+  /** The customer's country as identified by Stripe Tax. */
+  country?: Maybe<Scalars['String']>;
+  /** The data source used to infer the customer's location. */
+  source?: Maybe<Stripe_CustomerTaxLocationSourceProperty>;
+  /** The customer's state, county, province, or region as identified by Stripe Tax. */
+  state?: Maybe<Scalars['String']>;
+};
+
+export enum Stripe_CustomerTaxLocationSourceProperty {
+  BillingAddress = 'billing_address',
+  IpAddress = 'ip_address',
+  PaymentMethod = 'payment_method',
+  ShippingDestination = 'shipping_destination'
+}
+
+export enum Stripe_CustomerTaxExemptProperty {
+  Exempt = 'exempt',
+  None = 'none',
+  Reverse = 'reverse'
+}
+
+/** The customer's tax IDs. */
+export type Stripe_CustomerTaxIdsProperty = {
+  __typename?: 'Stripe_CustomerTaxIdsProperty';
+  /** Details about each object. */
+  data: Array<Stripe_TaxId>;
+  /** True if this list has another page of items after this one that can be fetched. */
+  has_more: Scalars['Boolean'];
+  /** String representing the object's type. Objects of the same type share the same value. Always has the value `list`. */
+  object: Stripe_CustomerTaxIdsObjectProperty;
+  /** The URL where this list can be accessed. */
+  url: Scalars['String'];
+};
+
+export enum Stripe_CustomerTaxIdsObjectProperty {
+  List = 'list'
+}
+
+export type Stripe_ListProductsResponse = {
+  __typename?: 'Stripe_ListProductsResponse';
+  data?: Maybe<Array<Maybe<Stripe_Product>>>;
+  /** True if this list has another page of items after this one that can be fetched. */
+  has_more?: Maybe<Scalars['Boolean']>;
+  /** String representing the object's type. Objects of the same type share the same value. Always has the value `list`. */
+  object?: Maybe<Stripe_ListProductsResponseObjectProperty>;
+  /** The URL where this list can be accessed. */
+  url?: Maybe<Scalars['String']>;
+};
+
+export enum Stripe_ListProductsResponseObjectProperty {
+  List = 'list'
+}
+
+export type ProfilePaginatedList = {
+  __typename?: 'ProfilePaginatedList';
+  items: Array<Profile>;
+  total: Scalars['Int'];
+};
+
+export type TsWhereProfileInput = {
+  id?: InputMaybe<TsWhereStringInput>;
+  name?: InputMaybe<TsWhereStringInput>;
+  email?: InputMaybe<TsWhereStringInput>;
+  bio?: InputMaybe<TsWhereStringInput>;
+  avatar?: InputMaybe<TsWhereAssetRelationshipInput>;
+  stripeCustomerId?: InputMaybe<TsWhereStringInput>;
+  _shapeId?: InputMaybe<TsWhereIdInput>;
+  _id?: InputMaybe<TsWhereIdInput>;
+  _version?: InputMaybe<TsWhereIntegerInput>;
+  _shapeName?: InputMaybe<TsWhereStringInput>;
+  _createdAt?: InputMaybe<TsWhereDateInput>;
+  _updatedAt?: InputMaybe<TsWhereDateInput>;
+  _schemaVersion?: InputMaybe<TsWhereNumberInput>;
+  _status?: InputMaybe<TsWhereWorkflowInput>;
+  _contentTypeId?: InputMaybe<TsWhereIdInput>;
+  _contentTypeName?: InputMaybe<TsWhereStringInput>;
+  AND?: InputMaybe<Array<InputMaybe<TsWhereProfileInput>>>;
+  OR?: InputMaybe<Array<InputMaybe<TsWhereProfileInput>>>;
+  NOT?: InputMaybe<TsWhereProfileInput>;
+};
+
+/** Asset search results */
+export type AssetSearchResults = {
+  __typename?: 'AssetSearchResults';
+  results: Array<Asset>;
+  total: Scalars['Int'];
+};
+
+/** TsStaticSite search results */
+export type TsStaticSiteSearchResults = {
+  __typename?: 'TsStaticSiteSearchResults';
+  results: Array<TsStaticSite>;
+  total: Scalars['Int'];
+};
+
+/** Profile search results */
+export type ProfileSearchResults = {
+  __typename?: 'ProfileSearchResults';
+  results: Array<Profile>;
+  total: Scalars['Int'];
+};
+
+/** TSSearchable search results */
+export type TsSearchableSearchResults = {
+  __typename?: 'TSSearchableSearchResults';
+  results: Array<TsSearchable>;
+  total: Scalars['Int'];
+};
+
+/** This query allow you to pass context to your queries */
+export type WithContext = {
+  __typename?: 'WithContext';
+  taxonomySuggest?: Maybe<TsSuggestionPaginatedList>;
+  /** List Versions for a piece of content */
+  getContentVersion?: Maybe<TsVersionResponse>;
+  /** List Versions for a piece of content */
+  getContentVersionList?: Maybe<TsVersionsPaginatedList>;
+  /** Get a Asset by ID */
+  getAsset?: Maybe<Asset>;
+  /** Returns a list Asset in natural order. */
+  getAssetList?: Maybe<AssetPaginatedList>;
+  /** Get a TsStaticSite by ID */
+  getTsStaticSite?: Maybe<TsStaticSite>;
+  /** Returns a list TsStaticSite in natural order. */
+  getTsStaticSiteList?: Maybe<TsStaticSitePaginatedList>;
+  /** Fetch Stripe products from the API Index. */
+  getIndexedProductList?: Maybe<Stripe_ProductPaginatedList>;
+  /** Get my profile */
+  getMyProfile?: Maybe<Profile>;
+  /** Get my subscriptions */
+  getMySubscriptions?: Maybe<Array<Maybe<Stripe_Subscription>>>;
+  /** Get my invoices */
+  getMyInvoices?: Maybe<Array<Maybe<Stripe_Invoice>>>;
+  /** Get my payments */
+  getMyPayments?: Maybe<Array<Maybe<Stripe_PaymentIntent>>>;
+  /** Get Stripe products. */
+  getStripeProducts?: Maybe<Stripe_ListProductsResponse>;
+  /** Get a profile by ID */
+  getProfile?: Maybe<Profile>;
+  /** Returns a list of profiles in natural order. */
+  getProfileList?: Maybe<ProfilePaginatedList>;
+  /** <p>Returns a list of your products. The products are returned sorted by creation date, with the most recently created products appearing first.</p> */
+  Stripe_listProducts?: Maybe<Stripe_ListProductsResponse>;
+  /** <p>Retrieves the details of an existing product. Supply the unique product ID from either a product creation request or the product list, and Stripe will return the corresponding product information.</p> */
+  Stripe_getProduct?: Maybe<Stripe_Product>;
+  searchAssetIndex?: Maybe<AssetSearchResults>;
+  searchTsStaticSiteIndex?: Maybe<TsStaticSiteSearchResults>;
+  searchProfileIndex?: Maybe<ProfileSearchResults>;
+  search?: Maybe<TsSearchableSearchResults>;
+};
+
+
+/** This query allow you to pass context to your queries */
+export type WithContextTaxonomySuggestArgs = {
+  shapeNames?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  shapeIds?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  contentTypeNames?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  contentTypeIds?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  terms?: InputMaybe<Scalars['String']>;
+  locale?: InputMaybe<Scalars['String']>;
+  enableLocaleFallback?: InputMaybe<Scalars['Boolean']>;
+  from?: InputMaybe<Scalars['Int']>;
+  size?: InputMaybe<Scalars['Int']>;
+  filter?: InputMaybe<Scalars['JSON']>;
+  sort?: InputMaybe<Array<InputMaybe<TsSearchSort>>>;
+};
+
+
+/** This query allow you to pass context to your queries */
+export type WithContextGetContentVersionArgs = {
+  id: Scalars['ID'];
+  version: Scalars['Int'];
+  locale?: InputMaybe<Scalars['String']>;
+  enableLocaleFallback?: InputMaybe<Scalars['Boolean']>;
+};
+
+
+/** This query allow you to pass context to your queries */
+export type WithContextGetContentVersionListArgs = {
+  id: Scalars['ID'];
+  from?: InputMaybe<Scalars['Int']>;
+  size?: InputMaybe<Scalars['Int']>;
+};
+
+
+/** This query allow you to pass context to your queries */
+export type WithContextGetAssetArgs = {
+  _id: Scalars['ID'];
+  locale?: InputMaybe<Scalars['String']>;
+  enableLocaleFallback?: InputMaybe<Scalars['Boolean']>;
+};
+
+
+/** This query allow you to pass context to your queries */
+export type WithContextGetAssetListArgs = {
+  terms?: InputMaybe<Scalars['String']>;
+  from?: InputMaybe<Scalars['Int']>;
+  size?: InputMaybe<Scalars['Int']>;
+  filter?: InputMaybe<Scalars['JSONObject']>;
+  sort?: InputMaybe<Array<InputMaybe<TsSearchSortInput>>>;
+  locale?: InputMaybe<Scalars['String']>;
+  enableLocaleFallback?: InputMaybe<Scalars['Boolean']>;
+  onlyEnabled?: InputMaybe<Scalars['Boolean']>;
+  where?: InputMaybe<TsWhereAssetInput>;
+};
+
+
+/** This query allow you to pass context to your queries */
+export type WithContextGetTsStaticSiteArgs = {
+  _id: Scalars['ID'];
+  locale?: InputMaybe<Scalars['String']>;
+  enableLocaleFallback?: InputMaybe<Scalars['Boolean']>;
+};
+
+
+/** This query allow you to pass context to your queries */
+export type WithContextGetTsStaticSiteListArgs = {
+  terms?: InputMaybe<Scalars['String']>;
+  from?: InputMaybe<Scalars['Int']>;
+  size?: InputMaybe<Scalars['Int']>;
+  filter?: InputMaybe<Scalars['JSONObject']>;
+  sort?: InputMaybe<Array<InputMaybe<TsSearchSortInput>>>;
+  locale?: InputMaybe<Scalars['String']>;
+  enableLocaleFallback?: InputMaybe<Scalars['Boolean']>;
+  onlyEnabled?: InputMaybe<Scalars['Boolean']>;
+  where?: InputMaybe<TsWhereTsStaticSiteInput>;
+};
+
+
+/** This query allow you to pass context to your queries */
+export type WithContextGetIndexedProductListArgs = {
+  terms?: InputMaybe<Scalars['String']>;
+  from?: InputMaybe<Scalars['Int']>;
+  size?: InputMaybe<Scalars['Int']>;
+  filter?: InputMaybe<Scalars['JSONObject']>;
+  sort?: InputMaybe<Array<InputMaybe<TsSearchSortInput>>>;
+  locale?: InputMaybe<Scalars['String']>;
+  enableLocaleFallback?: InputMaybe<Scalars['Boolean']>;
+  onlyEnabled?: InputMaybe<Scalars['Boolean']>;
+  where?: InputMaybe<TsWhereStripeProductInput>;
+};
+
+
+/** This query allow you to pass context to your queries */
+export type WithContextGetMySubscriptionsArgs = {
+  expand?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+};
+
+
+/** This query allow you to pass context to your queries */
+export type WithContextGetMyInvoicesArgs = {
+  expand?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  status?: InputMaybe<Scalars['String']>;
+  limit?: InputMaybe<Scalars['Float']>;
+  created?: InputMaybe<Scalars['JSON']>;
+  startingAfter?: InputMaybe<Scalars['String']>;
+};
+
+
+/** This query allow you to pass context to your queries */
+export type WithContextGetMyPaymentsArgs = {
+  expand?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  limit?: InputMaybe<Scalars['Float']>;
+  created?: InputMaybe<Scalars['JSON']>;
+  startingAfter?: InputMaybe<Scalars['String']>;
+  endingBefore?: InputMaybe<Scalars['String']>;
+};
+
+
+/** This query allow you to pass context to your queries */
+export type WithContextGetProfileArgs = {
+  _id: Scalars['ID'];
+  locale?: InputMaybe<Scalars['String']>;
+  enableLocaleFallback?: InputMaybe<Scalars['Boolean']>;
+};
+
+
+/** This query allow you to pass context to your queries */
+export type WithContextGetProfileListArgs = {
+  terms?: InputMaybe<Scalars['String']>;
+  from?: InputMaybe<Scalars['Int']>;
+  size?: InputMaybe<Scalars['Int']>;
+  filter?: InputMaybe<Scalars['JSONObject']>;
+  sort?: InputMaybe<Array<InputMaybe<TsSearchSortInput>>>;
+  locale?: InputMaybe<Scalars['String']>;
+  enableLocaleFallback?: InputMaybe<Scalars['Boolean']>;
+  onlyEnabled?: InputMaybe<Scalars['Boolean']>;
+  where?: InputMaybe<TsWhereProfileInput>;
+};
+
+
+/** This query allow you to pass context to your queries */
+export type WithContextStripe_ListProductsArgs = {
+  active?: InputMaybe<Scalars['Boolean']>;
+  created?: InputMaybe<Scalars['JSON']>;
+  ending_before?: InputMaybe<Scalars['String']>;
+  expand?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  ids?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  limit?: InputMaybe<Scalars['Int']>;
+  shippable?: InputMaybe<Scalars['Boolean']>;
+  starting_after?: InputMaybe<Scalars['String']>;
+  url?: InputMaybe<Scalars['String']>;
+};
+
+
+/** This query allow you to pass context to your queries */
+export type WithContextStripe_GetProductArgs = {
+  expand?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  id: Scalars['String'];
+};
+
+
+/** This query allow you to pass context to your queries */
+export type WithContextSearchAssetIndexArgs = {
+  terms?: InputMaybe<Scalars['String']>;
+  from?: InputMaybe<Scalars['Int']>;
+  size?: InputMaybe<Scalars['Int']>;
+  filter?: InputMaybe<Scalars['JSONObject']>;
+  sort?: InputMaybe<Array<InputMaybe<TsSearchSortInput>>>;
+  locale?: InputMaybe<Scalars['String']>;
+  enableLocaleFallback?: InputMaybe<Scalars['Boolean']>;
+  where?: InputMaybe<TsWhereAssetInput>;
+};
+
+
+/** This query allow you to pass context to your queries */
+export type WithContextSearchTsStaticSiteIndexArgs = {
+  terms?: InputMaybe<Scalars['String']>;
+  from?: InputMaybe<Scalars['Int']>;
+  size?: InputMaybe<Scalars['Int']>;
+  filter?: InputMaybe<Scalars['JSONObject']>;
+  sort?: InputMaybe<Array<InputMaybe<TsSearchSortInput>>>;
+  locale?: InputMaybe<Scalars['String']>;
+  enableLocaleFallback?: InputMaybe<Scalars['Boolean']>;
+  where?: InputMaybe<TsWhereTsStaticSiteInput>;
+};
+
+
+/** This query allow you to pass context to your queries */
+export type WithContextSearchProfileIndexArgs = {
+  terms?: InputMaybe<Scalars['String']>;
+  from?: InputMaybe<Scalars['Int']>;
+  size?: InputMaybe<Scalars['Int']>;
+  filter?: InputMaybe<Scalars['JSONObject']>;
+  sort?: InputMaybe<Array<InputMaybe<TsSearchSortInput>>>;
+  locale?: InputMaybe<Scalars['String']>;
+  enableLocaleFallback?: InputMaybe<Scalars['Boolean']>;
+  where?: InputMaybe<TsWhereProfileInput>;
+};
+
+
+/** This query allow you to pass context to your queries */
+export type WithContextSearchArgs = {
+  terms?: InputMaybe<Scalars['String']>;
+  from?: InputMaybe<Scalars['Int']>;
+  size?: InputMaybe<Scalars['Int']>;
+  filter?: InputMaybe<Scalars['JSONObject']>;
+  sort?: InputMaybe<Array<InputMaybe<TsSearchSortInput>>>;
+  locale?: InputMaybe<Scalars['String']>;
+  enableLocaleFallback?: InputMaybe<Scalars['Boolean']>;
+  shapeNames?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  shapeIds?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  contentTypeNames?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  contentTypeIds?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  where?: InputMaybe<TsWhereInput>;
+};
+
+export type Mutation = {
+  __typename?: 'Mutation';
+  /** Initiate upload process for asset(s) */
+  uploadAssets?: Maybe<Array<Maybe<Upload>>>;
+  /** Replace an asset file */
+  replaceAsset?: Maybe<Upload>;
+  /** Update Asset */
+  updateAsset?: Maybe<UpdateAssetResult>;
+  /** Create Asset */
+  createAsset?: Maybe<CreateAssetResult>;
+  /** Duplicate Asset */
+  duplicateAsset?: Maybe<DuplicateAssetResult>;
+  /** Delete Asset */
+  deleteAsset?: Maybe<DeleteAssetResult>;
+  /** Update TsStaticSite */
+  updateTsStaticSite?: Maybe<UpdateTsStaticSiteResult>;
+  /** Create TsStaticSite */
+  createTsStaticSite?: Maybe<CreateTsStaticSiteResult>;
+  /** Duplicate TsStaticSite */
+  duplicateTsStaticSite?: Maybe<DuplicateTsStaticSiteResult>;
+  /** Delete TsStaticSite */
+  deleteTsStaticSite?: Maybe<DeleteTsStaticSiteResult>;
+  /** Upsert my profile. */
+  upsertMyProfile?: Maybe<Profile>;
+  /** Upsert my Stripe customer. */
+  upsertMyCustomer?: Maybe<Stripe_Customer>;
+  /** Delete a Stripe subscription */
+  deleteMySubscription?: Maybe<Stripe_Subscription>;
+  /** Create a Stripe checkout session. */
+  createMyCheckoutSession?: Maybe<Stripe_CheckoutSession>;
+  /** Update Profile */
+  updateProfile?: Maybe<UpdateProfileResult>;
+  /** Create Profile */
+  createProfile?: Maybe<CreateProfileResult>;
+  /** Duplicate Profile */
+  duplicateProfile?: Maybe<DuplicateProfileResult>;
+  /** Delete Profile */
+  deleteProfile?: Maybe<DeleteProfileResult>;
+};
+
+
+export type MutationUploadAssetsArgs = {
+  projectId?: InputMaybe<Scalars['ID']>;
+  files: Array<InputMaybe<TsFile>>;
+};
+
+
+export type MutationReplaceAssetArgs = {
+  projectId?: InputMaybe<Scalars['ID']>;
+  _id: Scalars['ID'];
+  _version: Scalars['Int'];
+  file: TsFile;
+};
+
+
+export type MutationUpdateAssetArgs = {
+  input: UpdateAssetInput;
+  clientMutationId?: InputMaybe<Scalars['String']>;
+  structure?: InputMaybe<Array<InputMaybe<ContentStructureInput>>>;
+  locale?: InputMaybe<Scalars['String']>;
+  enableLocaleFallback?: InputMaybe<Scalars['Boolean']>;
+};
+
+
+export type MutationCreateAssetArgs = {
+  input: CreateAssetInput;
+  clientMutationId?: InputMaybe<Scalars['String']>;
+};
+
+
+export type MutationDuplicateAssetArgs = {
+  input: DuplicateAssetInput;
+  clientMutationId?: InputMaybe<Scalars['String']>;
+  locale?: InputMaybe<Scalars['String']>;
+  enableLocaleFallback?: InputMaybe<Scalars['Boolean']>;
+};
+
+
+export type MutationDeleteAssetArgs = {
+  input: DeleteAssetInput;
+  clientMutationId?: InputMaybe<Scalars['String']>;
+};
+
+
+export type MutationUpdateTsStaticSiteArgs = {
+  input: UpdateTsStaticSiteInput;
+  clientMutationId?: InputMaybe<Scalars['String']>;
+  structure?: InputMaybe<Array<InputMaybe<ContentStructureInput>>>;
+  locale?: InputMaybe<Scalars['String']>;
+  enableLocaleFallback?: InputMaybe<Scalars['Boolean']>;
+};
+
+
+export type MutationCreateTsStaticSiteArgs = {
+  input: CreateTsStaticSiteInput;
+  clientMutationId?: InputMaybe<Scalars['String']>;
+};
+
+
+export type MutationDuplicateTsStaticSiteArgs = {
+  input: DuplicateTsStaticSiteInput;
+  clientMutationId?: InputMaybe<Scalars['String']>;
+  locale?: InputMaybe<Scalars['String']>;
+  enableLocaleFallback?: InputMaybe<Scalars['Boolean']>;
+};
+
+
+export type MutationDeleteTsStaticSiteArgs = {
+  input: DeleteTsStaticSiteInput;
+  clientMutationId?: InputMaybe<Scalars['String']>;
+};
+
+
+export type MutationUpsertMyProfileArgs = {
+  name?: InputMaybe<Scalars['String']>;
+  bio?: InputMaybe<Scalars['String']>;
+  avatarId?: InputMaybe<Scalars['String']>;
+};
+
+
+export type MutationUpsertMyCustomerArgs = {
+  name?: InputMaybe<Scalars['String']>;
+  description?: InputMaybe<Scalars['String']>;
+  address?: InputMaybe<Stripe_CustomerAddressPropertyInput>;
+};
+
+
+export type MutationDeleteMySubscriptionArgs = {
+  subscriptionId: Scalars['String'];
+};
+
+
+export type MutationCreateMyCheckoutSessionArgs = {
+  redirectUrl: Scalars['String'];
+  mode?: InputMaybe<Scalars['String']>;
+  lineItems: Array<Stripe_CheckoutSessionLineItemsPropertyInput>;
+};
+
+
+export type MutationUpdateProfileArgs = {
+  input: UpdateProfileInput;
+  clientMutationId?: InputMaybe<Scalars['String']>;
+  structure?: InputMaybe<Array<InputMaybe<ContentStructureInput>>>;
+  locale?: InputMaybe<Scalars['String']>;
+  enableLocaleFallback?: InputMaybe<Scalars['Boolean']>;
+};
+
+
+export type MutationCreateProfileArgs = {
+  input: CreateProfileInput;
+  clientMutationId?: InputMaybe<Scalars['String']>;
+};
+
+
+export type MutationDuplicateProfileArgs = {
+  input: DuplicateProfileInput;
+  clientMutationId?: InputMaybe<Scalars['String']>;
+  locale?: InputMaybe<Scalars['String']>;
+  enableLocaleFallback?: InputMaybe<Scalars['Boolean']>;
+};
+
+
+export type MutationDeleteProfileArgs = {
+  input: DeleteProfileInput;
+  clientMutationId?: InputMaybe<Scalars['String']>;
+};
+
+/** A project file stored on s3 */
+export type Upload = {
+  __typename?: 'Upload';
+  uploadUrl?: Maybe<Scalars['ID']>;
+  asset?: Maybe<Asset>;
+};
+
+export type TsFile = {
+  name: Scalars['String'];
+  type: Scalars['String'];
+};
+
+export type UpdateAssetResult = {
+  __typename?: 'UpdateAssetResult';
+  clientMutationId?: Maybe<Scalars['String']>;
+  result?: Maybe<Asset>;
+};
+
+/** update Asset input */
+export type UpdateAssetInput = {
+  _id: Scalars['ID'];
+  title?: InputMaybe<Scalars['String']>;
+  description?: InputMaybe<Scalars['String']>;
+  filename?: InputMaybe<Scalars['String']>;
+  caption?: InputMaybe<Scalars['JSON']>;
+  credit?: InputMaybe<Scalars['JSON']>;
+  path?: InputMaybe<Scalars['String']>;
+  mimeType?: InputMaybe<Scalars['String']>;
+  sourceUrl?: InputMaybe<Scalars['String']>;
+  uploadStatus?: InputMaybe<Scalars['String']>;
+  _shapeId?: InputMaybe<Scalars['String']>;
+  _version?: InputMaybe<Scalars['Int']>;
+  _shapeName?: InputMaybe<Scalars['String']>;
+  _createdAt?: InputMaybe<Scalars['String']>;
+  _createdBy?: InputMaybe<Scalars['String']>;
+  _updatedAt?: InputMaybe<Scalars['String']>;
+  _updatedBy?: InputMaybe<Scalars['String']>;
+  _schemaVersion?: InputMaybe<Scalars['Float']>;
+  _enabled?: InputMaybe<Scalars['Boolean']>;
+  _enabledAt?: InputMaybe<Scalars['String']>;
+  _status?: InputMaybe<DefaultWorkflow>;
+  _contentTypeId?: InputMaybe<Scalars['String']>;
+  _contentTypeName?: InputMaybe<Scalars['String']>;
+  s3Key?: InputMaybe<Scalars['String']>;
+};
+
+/** Describes a structural update to an array of data. */
+export type ContentStructureInput = {
+  /** A deep path to the array being updated (e.g. a.b[1].c). */
+  path: Scalars['String'];
+  /** An array where the indices represent the to index, and the values represent the from index.For example to transform ["a","b","c","d"] into ["c","a"], this value would be [2,0]. */
+  structure?: InputMaybe<Array<InputMaybe<Scalars['Int']>>>;
+};
+
+export type CreateAssetResult = {
+  __typename?: 'CreateAssetResult';
+  clientMutationId?: Maybe<Scalars['String']>;
+  result?: Maybe<Asset>;
+};
+
+/** create Asset input */
+export type CreateAssetInput = {
+  title?: InputMaybe<Scalars['String']>;
+  description?: InputMaybe<Scalars['String']>;
+  filename: Scalars['String'];
+  caption?: InputMaybe<Scalars['JSON']>;
+  credit?: InputMaybe<Scalars['JSON']>;
+  path: Scalars['String'];
+  mimeType?: InputMaybe<Scalars['String']>;
+  sourceUrl?: InputMaybe<Scalars['String']>;
+  uploadStatus?: InputMaybe<Scalars['String']>;
+  _shapeId?: InputMaybe<Scalars['String']>;
+  _id?: InputMaybe<Scalars['ID']>;
+  _version?: InputMaybe<Scalars['Int']>;
+  _shapeName?: InputMaybe<Scalars['String']>;
+  _createdAt?: InputMaybe<Scalars['String']>;
+  _createdBy?: InputMaybe<Scalars['String']>;
+  _updatedAt?: InputMaybe<Scalars['String']>;
+  _updatedBy?: InputMaybe<Scalars['String']>;
+  _schemaVersion?: InputMaybe<Scalars['Float']>;
+  _enabled?: InputMaybe<Scalars['Boolean']>;
+  _enabledAt?: InputMaybe<Scalars['String']>;
+  _status?: InputMaybe<DefaultWorkflow>;
+  _contentTypeId?: InputMaybe<Scalars['String']>;
+  _contentTypeName?: InputMaybe<Scalars['String']>;
+  s3Key?: InputMaybe<Scalars['String']>;
+};
+
+export type DuplicateAssetResult = {
+  __typename?: 'DuplicateAssetResult';
+  clientMutationId?: Maybe<Scalars['String']>;
+  result?: Maybe<Asset>;
+};
+
+/** duplicate Asset input */
+export type DuplicateAssetInput = {
+  _id: Scalars['ID'];
+  title?: InputMaybe<Scalars['String']>;
+  description?: InputMaybe<Scalars['String']>;
+  filename?: InputMaybe<Scalars['String']>;
+  caption?: InputMaybe<Scalars['JSON']>;
+  credit?: InputMaybe<Scalars['JSON']>;
+  path?: InputMaybe<Scalars['String']>;
+  mimeType?: InputMaybe<Scalars['String']>;
+  sourceUrl?: InputMaybe<Scalars['String']>;
+  uploadStatus?: InputMaybe<Scalars['String']>;
+  _shapeId?: InputMaybe<Scalars['String']>;
+  _version?: InputMaybe<Scalars['Int']>;
+  _shapeName?: InputMaybe<Scalars['String']>;
+  _createdAt?: InputMaybe<Scalars['String']>;
+  _createdBy?: InputMaybe<Scalars['String']>;
+  _updatedAt?: InputMaybe<Scalars['String']>;
+  _updatedBy?: InputMaybe<Scalars['String']>;
+  _schemaVersion?: InputMaybe<Scalars['Float']>;
+  _enabled?: InputMaybe<Scalars['Boolean']>;
+  _enabledAt?: InputMaybe<Scalars['String']>;
+  _status?: InputMaybe<DefaultWorkflow>;
+  _contentTypeId?: InputMaybe<Scalars['String']>;
+  _contentTypeName?: InputMaybe<Scalars['String']>;
+  s3Key?: InputMaybe<Scalars['String']>;
+};
+
+export type DeleteAssetResult = {
+  __typename?: 'DeleteAssetResult';
+  clientMutationId?: Maybe<Scalars['String']>;
+  result?: Maybe<Scalars['Boolean']>;
+};
+
+/** delete Asset input */
+export type DeleteAssetInput = {
+  _id: Scalars['ID'];
+};
+
+export type UpdateTsStaticSiteResult = {
+  __typename?: 'UpdateTsStaticSiteResult';
+  clientMutationId?: Maybe<Scalars['String']>;
+  result?: Maybe<TsStaticSite>;
+};
+
+/** update TsStaticSite input */
+export type UpdateTsStaticSiteInput = {
+  _id: Scalars['ID'];
+  title?: InputMaybe<Scalars['String']>;
+  baseUrl?: InputMaybe<Scalars['String']>;
+  provider?: InputMaybe<Scalars['String']>;
+  idKey?: InputMaybe<Scalars['String']>;
+  secretKey?: InputMaybe<Scalars['String']>;
+  destination?: InputMaybe<Scalars['String']>;
+  privateAcl?: InputMaybe<Scalars['Boolean']>;
+  environmentVariables?: InputMaybe<Array<InputMaybe<TsStaticSiteEnvironmentVariablesInput>>>;
+  triggers?: InputMaybe<Array<InputMaybe<TsStaticSiteTriggersInput>>>;
+  templateHash?: InputMaybe<Scalars['String']>;
+  _shapeId?: InputMaybe<Scalars['String']>;
+  _version?: InputMaybe<Scalars['Int']>;
+  _shapeName?: InputMaybe<Scalars['String']>;
+  _createdAt?: InputMaybe<Scalars['String']>;
+  _createdBy?: InputMaybe<Scalars['String']>;
+  _updatedAt?: InputMaybe<Scalars['String']>;
+  _updatedBy?: InputMaybe<Scalars['String']>;
+  _schemaVersion?: InputMaybe<Scalars['Float']>;
+  _enabled?: InputMaybe<Scalars['Boolean']>;
+  _enabledAt?: InputMaybe<Scalars['String']>;
+  _status?: InputMaybe<DefaultWorkflow>;
+  _contentTypeId?: InputMaybe<Scalars['String']>;
+  _contentTypeName?: InputMaybe<Scalars['String']>;
+};
+
+export type TsStaticSiteEnvironmentVariablesInput = {
+  name?: InputMaybe<Scalars['String']>;
+  value?: InputMaybe<Scalars['String']>;
+};
+
+export type TsStaticSiteTriggersInput = {
+  contentTypeId?: InputMaybe<Scalars['String']>;
+  status?: InputMaybe<Scalars['String']>;
+};
+
+export type CreateTsStaticSiteResult = {
+  __typename?: 'CreateTsStaticSiteResult';
+  clientMutationId?: Maybe<Scalars['String']>;
+  result?: Maybe<TsStaticSite>;
+};
+
+/** create TsStaticSite input */
+export type CreateTsStaticSiteInput = {
+  title: Scalars['String'];
+  baseUrl?: InputMaybe<Scalars['String']>;
+  provider?: Scalars['String'];
+  idKey?: InputMaybe<Scalars['String']>;
+  secretKey?: InputMaybe<Scalars['String']>;
+  destination: Scalars['String'];
+  privateAcl?: InputMaybe<Scalars['Boolean']>;
+  environmentVariables?: InputMaybe<Array<InputMaybe<TsStaticSiteEnvironmentVariablesInput>>>;
+  triggers?: InputMaybe<Array<InputMaybe<TsStaticSiteTriggersInput>>>;
+  templateHash?: InputMaybe<Scalars['String']>;
+  _shapeId?: InputMaybe<Scalars['String']>;
+  _id?: InputMaybe<Scalars['ID']>;
+  _version?: InputMaybe<Scalars['Int']>;
+  _shapeName?: InputMaybe<Scalars['String']>;
+  _createdAt?: InputMaybe<Scalars['String']>;
+  _createdBy?: InputMaybe<Scalars['String']>;
+  _updatedAt?: InputMaybe<Scalars['String']>;
+  _updatedBy?: InputMaybe<Scalars['String']>;
+  _schemaVersion?: InputMaybe<Scalars['Float']>;
+  _enabled?: InputMaybe<Scalars['Boolean']>;
+  _enabledAt?: InputMaybe<Scalars['String']>;
+  _status?: InputMaybe<DefaultWorkflow>;
+  _contentTypeId?: InputMaybe<Scalars['String']>;
+  _contentTypeName?: InputMaybe<Scalars['String']>;
+};
+
+export type DuplicateTsStaticSiteResult = {
+  __typename?: 'DuplicateTsStaticSiteResult';
+  clientMutationId?: Maybe<Scalars['String']>;
+  result?: Maybe<TsStaticSite>;
+};
+
+/** duplicate TsStaticSite input */
+export type DuplicateTsStaticSiteInput = {
+  _id: Scalars['ID'];
+  title?: InputMaybe<Scalars['String']>;
+  baseUrl?: InputMaybe<Scalars['String']>;
+  provider?: InputMaybe<Scalars['String']>;
+  idKey?: InputMaybe<Scalars['String']>;
+  secretKey?: InputMaybe<Scalars['String']>;
+  destination?: InputMaybe<Scalars['String']>;
+  privateAcl?: InputMaybe<Scalars['Boolean']>;
+  environmentVariables?: InputMaybe<Array<InputMaybe<TsStaticSiteEnvironmentVariablesInput>>>;
+  triggers?: InputMaybe<Array<InputMaybe<TsStaticSiteTriggersInput>>>;
+  templateHash?: InputMaybe<Scalars['String']>;
+  _shapeId?: InputMaybe<Scalars['String']>;
+  _version?: InputMaybe<Scalars['Int']>;
+  _shapeName?: InputMaybe<Scalars['String']>;
+  _createdAt?: InputMaybe<Scalars['String']>;
+  _createdBy?: InputMaybe<Scalars['String']>;
+  _updatedAt?: InputMaybe<Scalars['String']>;
+  _updatedBy?: InputMaybe<Scalars['String']>;
+  _schemaVersion?: InputMaybe<Scalars['Float']>;
+  _enabled?: InputMaybe<Scalars['Boolean']>;
+  _enabledAt?: InputMaybe<Scalars['String']>;
+  _status?: InputMaybe<DefaultWorkflow>;
+  _contentTypeId?: InputMaybe<Scalars['String']>;
+  _contentTypeName?: InputMaybe<Scalars['String']>;
+};
+
+export type DeleteTsStaticSiteResult = {
+  __typename?: 'DeleteTsStaticSiteResult';
+  clientMutationId?: Maybe<Scalars['String']>;
+  result?: Maybe<Scalars['Boolean']>;
+};
+
+/** delete TsStaticSite input */
+export type DeleteTsStaticSiteInput = {
+  _id: Scalars['ID'];
+};
+
+export type Stripe_CustomerAddressPropertyInput = {
+  line1?: InputMaybe<Scalars['String']>;
+  line2?: InputMaybe<Scalars['String']>;
+  city?: InputMaybe<Scalars['String']>;
+  country?: InputMaybe<Scalars['String']>;
+  postal_code?: InputMaybe<Scalars['String']>;
+  state?: InputMaybe<Scalars['String']>;
+};
+
+export type Stripe_CheckoutSession = {
+  __typename?: 'Stripe_CheckoutSession';
+  /** Enables user redeemable promotion codes. */
+  allow_promotion_codes?: Maybe<Scalars['Boolean']>;
+  /** Total of all items before discounts or taxes are applied. */
+  amount_subtotal?: Maybe<Scalars['Int']>;
+  /** Total of all items after discounts and taxes are applied. */
+  amount_total?: Maybe<Scalars['Int']>;
+  automatic_tax?: Maybe<Stripe_PaymentPagesCheckoutSessionAutomaticTax>;
+  /** Describes whether Checkout should collect the customer's billing address. */
+  billing_address_collection?: Maybe<Stripe_CheckoutSessionBillingAddressCollectionProperty>;
+  /** The URL the customer will be directed to if they decide to cancel payment and return to your website. */
+  cancel_url?: Maybe<Scalars['String']>;
+  /**
+   * A unique string to reference the Checkout Session. This can be a
+   * customer ID, a cart ID, or similar, and can be used to reconcile the
+   * Session with your internal systems.
+   */
+  client_reference_id?: Maybe<Scalars['String']>;
+  /** Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies). */
+  currency?: Maybe<Scalars['String']>;
+  customer?: Maybe<Stripe_CheckoutSessionCustomerProperty>;
+  customer_details?: Maybe<Stripe_PaymentPagesCheckoutSessionCustomerDetails>;
+  /**
+   * If provided, this value will be used when the Customer object is created.
+   * If not provided, customers will be asked to enter their email address.
+   * Use this parameter to prefill customer data if you already have an email
+   * on file. To access information about the customer once the payment flow is
+   * complete, use the `customer` attribute.
+   */
+  customer_email?: Maybe<Scalars['String']>;
+  /**
+   * Unique identifier for the object. Used to pass to `redirectToCheckout`
+   * in Stripe.js.
+   */
+  id?: Maybe<Scalars['String']>;
+  /** The line items purchased by the customer. */
+  line_items?: Maybe<Stripe_CheckoutSessionLineItemsProperty>;
+  /** Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode. */
+  livemode?: Maybe<Scalars['Boolean']>;
+  /** The IETF language tag of the locale Checkout is displayed in. If blank or `auto`, the browser's locale is used. */
+  locale?: Maybe<Stripe_CheckoutSessionLocaleProperty>;
+  /** Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. */
+  metadata?: Maybe<Scalars['JSONObject']>;
+  /** The mode of the Checkout Session. */
+  mode?: Maybe<Stripe_CheckoutSessionModeProperty>;
+  /** String representing the object's type. Objects of the same type share the same value. */
+  object?: Maybe<Stripe_CheckoutSessionObjectProperty>;
+  payment_intent?: Maybe<Stripe_CheckoutSessionPaymentIntentProperty>;
+  payment_method_options?: Maybe<Stripe_CheckoutSessionPaymentMethodOptions>;
+  /**
+   * A list of the types of payment methods (e.g. card) this Checkout
+   * Session is allowed to accept.
+   */
+  payment_method_types?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /**
+   * The payment status of the Checkout Session, one of `paid`, `unpaid`, or `no_payment_required`.
+   * You can use this value to decide when to fulfill your customer's order.
+   */
+  payment_status?: Maybe<Stripe_CheckoutSessionPaymentStatusProperty>;
+  setup_intent?: Maybe<Stripe_CheckoutSessionSetupIntentProperty>;
+  shipping?: Maybe<Stripe_Shipping>;
+  shipping_address_collection?: Maybe<Stripe_PaymentPagesPaymentPageResourcesShippingAddressCollection>;
+  /**
+   * Describes the type of transaction being performed by Checkout in order to customize
+   * relevant text on the page, such as the submit button. `submit_type` can only be
+   * specified on Checkout Sessions in `payment` mode, but not Checkout Sessions
+   * in `subscription` or `setup` mode.
+   */
+  submit_type?: Maybe<Stripe_CheckoutSessionSubmitTypeProperty>;
+  subscription?: Maybe<Stripe_CheckoutSessionSubscriptionProperty>;
+  /**
+   * The URL the customer will be directed to after the payment or
+   * subscription creation is successful.
+   */
+  success_url?: Maybe<Scalars['String']>;
+  tax_id_collection?: Maybe<Stripe_PaymentPagesCheckoutSessionTaxIdCollection>;
+  total_details?: Maybe<Stripe_PaymentPagesCheckoutSessionTotalDetails>;
+  /** The URL to the Checkout Session. */
+  url?: Maybe<Scalars['String']>;
+};
+
+export type Stripe_PaymentPagesCheckoutSessionAutomaticTax = {
+  __typename?: 'Stripe_PaymentPagesCheckoutSessionAutomaticTax';
+  /** Indicates whether automatic tax is enabled for the session */
+  enabled?: Maybe<Scalars['Boolean']>;
+  /** The status of the most recent automated tax calculation for this session. */
+  status?: Maybe<Stripe_PaymentPagesCheckoutSessionAutomaticTaxStatusProperty>;
+};
+
+export enum Stripe_PaymentPagesCheckoutSessionAutomaticTaxStatusProperty {
+  Complete = 'complete',
+  Failed = 'failed',
+  RequiresLocationInputs = 'requires_location_inputs'
+}
+
+export enum Stripe_CheckoutSessionBillingAddressCollectionProperty {
+  Auto = 'auto',
+  Required = 'required'
+}
+
+export type Stripe_CheckoutSessionCustomerProperty = WrappedString | Stripe_Customer | Stripe_DeletedCustomer;
+
+export type Stripe_PaymentPagesCheckoutSessionCustomerDetails = {
+  __typename?: 'Stripe_PaymentPagesCheckoutSessionCustomerDetails';
+  /** The customer’s email at time of checkout. */
+  email?: Maybe<Scalars['String']>;
+  /** The customer’s tax exempt status at time of checkout. */
+  tax_exempt?: Maybe<Stripe_PaymentPagesCheckoutSessionCustomerDetailsTaxExemptProperty>;
+  /** The customer’s tax IDs at time of checkout. */
+  tax_ids?: Maybe<Array<Maybe<Stripe_PaymentPagesCheckoutSessionTaxId>>>;
+};
+
+export enum Stripe_PaymentPagesCheckoutSessionCustomerDetailsTaxExemptProperty {
+  Exempt = 'exempt',
+  None = 'none',
+  Reverse = 'reverse'
+}
+
+export type Stripe_PaymentPagesCheckoutSessionTaxId = {
+  __typename?: 'Stripe_PaymentPagesCheckoutSessionTaxId';
+  /** The type of the tax ID, one of `eu_vat`, `br_cnpj`, `br_cpf`, `gb_vat`, `nz_gst`, `au_abn`, `in_gst`, `no_vat`, `za_vat`, `ch_vat`, `mx_rfc`, `sg_uen`, `ru_inn`, `ru_kpp`, `ca_bn`, `hk_br`, `es_cif`, `tw_vat`, `th_vat`, `jp_cn`, `jp_rn`, `li_uid`, `my_itn`, `us_ein`, `kr_brn`, `ca_qst`, `ca_gst_hst`, `ca_pst_bc`, `ca_pst_mb`, `ca_pst_sk`, `my_sst`, `sg_gst`, `ae_trn`, `cl_tin`, `sa_vat`, `id_npwp`, `my_frp`, `il_vat`, or `unknown` */
+  type?: Maybe<Stripe_PaymentPagesCheckoutSessionTaxIdTypeProperty>;
+  /** The value of the tax ID. */
+  value?: Maybe<Scalars['String']>;
+};
+
+export enum Stripe_PaymentPagesCheckoutSessionTaxIdTypeProperty {
+  AeTrn = 'ae_trn',
+  AuAbn = 'au_abn',
+  BrCnpj = 'br_cnpj',
+  BrCpf = 'br_cpf',
+  CaBn = 'ca_bn',
+  CaGstHst = 'ca_gst_hst',
+  CaPstBc = 'ca_pst_bc',
+  CaPstMb = 'ca_pst_mb',
+  CaPstSk = 'ca_pst_sk',
+  CaQst = 'ca_qst',
+  ChVat = 'ch_vat',
+  ClTin = 'cl_tin',
+  EsCif = 'es_cif',
+  EuVat = 'eu_vat',
+  GbVat = 'gb_vat',
+  HkBr = 'hk_br',
+  IdNpwp = 'id_npwp',
+  IlVat = 'il_vat',
+  InGst = 'in_gst',
+  JpCn = 'jp_cn',
+  JpRn = 'jp_rn',
+  KrBrn = 'kr_brn',
+  LiUid = 'li_uid',
+  MxRfc = 'mx_rfc',
+  MyFrp = 'my_frp',
+  MyItn = 'my_itn',
+  MySst = 'my_sst',
+  NoVat = 'no_vat',
+  NzGst = 'nz_gst',
+  RuInn = 'ru_inn',
+  RuKpp = 'ru_kpp',
+  SaVat = 'sa_vat',
+  SgGst = 'sg_gst',
+  SgUen = 'sg_uen',
+  ThVat = 'th_vat',
+  TwVat = 'tw_vat',
+  Unknown = 'unknown',
+  UsEin = 'us_ein',
+  ZaVat = 'za_vat'
+}
+
+/** The line items purchased by the customer. */
+export type Stripe_CheckoutSessionLineItemsProperty = {
+  __typename?: 'Stripe_CheckoutSessionLineItemsProperty';
+  /** Details about each object. */
+  data: Array<Stripe_Item>;
+  /** True if this list has another page of items after this one that can be fetched. */
+  has_more: Scalars['Boolean'];
+  /** String representing the object's type. Objects of the same type share the same value. Always has the value `list`. */
+  object: Stripe_CheckoutSessionLineItemsObjectProperty;
+  /** The URL where this list can be accessed. */
+  url: Scalars['String'];
+};
+
+export enum Stripe_CheckoutSessionLineItemsObjectProperty {
+  List = 'list'
+}
+
+export enum Stripe_CheckoutSessionLocaleProperty {
+  Auto = 'auto',
+  Bg = 'bg',
+  Cs = 'cs',
+  Da = 'da',
+  De = 'de',
+  El = 'el',
+  En = 'en',
+  EnDashgb = 'enDASHGB',
+  Es = 'es',
+  EsDash419 = 'esDASH419',
+  Et = 'et',
+  Fi = 'fi',
+  Fr = 'fr',
+  FrDashca = 'frDASHCA',
+  Hr = 'hr',
+  Hu = 'hu',
+  Id = 'id',
+  It = 'it',
+  Ja = 'ja',
+  Ko = 'ko',
+  Lt = 'lt',
+  Lv = 'lv',
+  Ms = 'ms',
+  Mt = 'mt',
+  Nb = 'nb',
+  Nl = 'nl',
+  Pl = 'pl',
+  Pt = 'pt',
+  PtDashbr = 'ptDASHBR',
+  Ro = 'ro',
+  Ru = 'ru',
+  Sk = 'sk',
+  Sl = 'sl',
+  Sv = 'sv',
+  Th = 'th',
+  Tr = 'tr',
+  Vi = 'vi',
+  Zh = 'zh',
+  ZhDashhk = 'zhDASHHK',
+  ZhDashtw = 'zhDASHTW'
+}
+
+export enum Stripe_CheckoutSessionModeProperty {
+  Payment = 'payment',
+  Setup = 'setup',
+  Subscription = 'subscription'
+}
+
+export enum Stripe_CheckoutSessionObjectProperty {
+  CheckoutDoTsession = 'checkoutDOTsession'
+}
+
+export type Stripe_CheckoutSessionPaymentIntentProperty = WrappedString | Stripe_PaymentIntent;
+
+export type Stripe_CheckoutSessionPaymentMethodOptions = {
+  __typename?: 'Stripe_CheckoutSessionPaymentMethodOptions';
+  acss_debit?: Maybe<Stripe_CheckoutAcssDebitPaymentMethodOptions>;
+  boleto?: Maybe<Stripe_PaymentMethodOptionsBoleto>;
+  oxxo?: Maybe<Stripe_PaymentMethodOptionsOxxo>;
+};
+
+export type Stripe_CheckoutAcssDebitPaymentMethodOptions = {
+  __typename?: 'Stripe_CheckoutAcssDebitPaymentMethodOptions';
+  /** Currency supported by the bank account. Returned when the Session is in `setup` mode. */
+  currency?: Maybe<Stripe_CheckoutAcssDebitPaymentMethodOptionsCurrencyProperty>;
+  mandate_options?: Maybe<Stripe_CheckoutAcssDebitMandateOptions>;
+  /** Bank account verification method. */
+  verification_method?: Maybe<Stripe_CheckoutAcssDebitPaymentMethodOptionsVerificationMethodProperty>;
+};
+
+export enum Stripe_CheckoutAcssDebitPaymentMethodOptionsCurrencyProperty {
+  Cad = 'cad',
+  Usd = 'usd'
+}
+
+export type Stripe_CheckoutAcssDebitMandateOptions = {
+  __typename?: 'Stripe_CheckoutAcssDebitMandateOptions';
+  /** A URL for custom mandate text */
+  custom_mandate_url?: Maybe<Scalars['String']>;
+  /** Description of the interval. Only required if 'payment_schedule' parmeter is 'interval' or 'combined'. */
+  interval_description?: Maybe<Scalars['String']>;
+  /** Payment schedule for the mandate. */
+  payment_schedule?: Maybe<Stripe_CheckoutAcssDebitMandateOptionsPaymentScheduleProperty>;
+  /** Transaction type of the mandate. */
+  transaction_type?: Maybe<Stripe_CheckoutAcssDebitMandateOptionsTransactionTypeProperty>;
+};
+
+export enum Stripe_CheckoutAcssDebitMandateOptionsPaymentScheduleProperty {
+  Combined = 'combined',
+  Interval = 'interval',
+  Sporadic = 'sporadic'
+}
+
+export enum Stripe_CheckoutAcssDebitMandateOptionsTransactionTypeProperty {
+  Business = 'business',
+  Personal = 'personal'
+}
+
+export enum Stripe_CheckoutAcssDebitPaymentMethodOptionsVerificationMethodProperty {
+  Automatic = 'automatic',
+  Instant = 'instant',
+  Microdeposits = 'microdeposits'
+}
+
+export enum Stripe_CheckoutSessionPaymentStatusProperty {
+  NoPaymentRequired = 'no_payment_required',
+  Paid = 'paid',
+  Unpaid = 'unpaid'
+}
+
+export type Stripe_CheckoutSessionSetupIntentProperty = WrappedString | Stripe_SetupIntent;
+
+export type Stripe_PaymentPagesPaymentPageResourcesShippingAddressCollection = {
+  __typename?: 'Stripe_PaymentPagesPaymentPageResourcesShippingAddressCollection';
+  /**
+   * An array of two-letter ISO country codes representing which countries Checkout should provide as options for
+   * shipping locations. Unsupported country codes: `AS, CX, CC, CU, HM, IR, KP, MH, FM, NF, MP, PW, SD, SY, UM, VI`.
+   */
+  allowed_countries?: Maybe<Array<Maybe<Stripe_PaymentPagesPaymentPageResourcesShippingAddressCollectionAllowedCountriesProperty>>>;
+};
+
+export enum Stripe_PaymentPagesPaymentPageResourcesShippingAddressCollectionAllowedCountriesProperty {
+  Ac = 'AC',
+  Ad = 'AD',
+  Ae = 'AE',
+  Af = 'AF',
+  Ag = 'AG',
+  Ai = 'AI',
+  Al = 'AL',
+  Am = 'AM',
+  Ao = 'AO',
+  Aq = 'AQ',
+  Ar = 'AR',
+  At = 'AT',
+  Au = 'AU',
+  Aw = 'AW',
+  Ax = 'AX',
+  Az = 'AZ',
+  Ba = 'BA',
+  Bb = 'BB',
+  Bd = 'BD',
+  Be = 'BE',
+  Bf = 'BF',
+  Bg = 'BG',
+  Bh = 'BH',
+  Bi = 'BI',
+  Bj = 'BJ',
+  Bl = 'BL',
+  Bm = 'BM',
+  Bn = 'BN',
+  Bo = 'BO',
+  Bq = 'BQ',
+  Br = 'BR',
+  Bs = 'BS',
+  Bt = 'BT',
+  Bv = 'BV',
+  Bw = 'BW',
+  By = 'BY',
+  Bz = 'BZ',
+  Ca = 'CA',
+  Cd = 'CD',
+  Cf = 'CF',
+  Cg = 'CG',
+  Ch = 'CH',
+  Ci = 'CI',
+  Ck = 'CK',
+  Cl = 'CL',
+  Cm = 'CM',
+  Cn = 'CN',
+  Co = 'CO',
+  Cr = 'CR',
+  Cv = 'CV',
+  Cw = 'CW',
+  Cy = 'CY',
+  Cz = 'CZ',
+  De = 'DE',
+  Dj = 'DJ',
+  Dk = 'DK',
+  Dm = 'DM',
+  Do = 'DO',
+  Dz = 'DZ',
+  Ec = 'EC',
+  Ee = 'EE',
+  Eg = 'EG',
+  Eh = 'EH',
+  Er = 'ER',
+  Es = 'ES',
+  Et = 'ET',
+  Fi = 'FI',
+  Fj = 'FJ',
+  Fk = 'FK',
+  Fo = 'FO',
+  Fr = 'FR',
+  Ga = 'GA',
+  Gb = 'GB',
+  Gd = 'GD',
+  Ge = 'GE',
+  Gf = 'GF',
+  Gg = 'GG',
+  Gh = 'GH',
+  Gi = 'GI',
+  Gl = 'GL',
+  Gm = 'GM',
+  Gn = 'GN',
+  Gp = 'GP',
+  Gq = 'GQ',
+  Gr = 'GR',
+  Gs = 'GS',
+  Gt = 'GT',
+  Gu = 'GU',
+  Gw = 'GW',
+  Gy = 'GY',
+  Hk = 'HK',
+  Hn = 'HN',
+  Hr = 'HR',
+  Ht = 'HT',
+  Hu = 'HU',
+  Id = 'ID',
+  Ie = 'IE',
+  Il = 'IL',
+  Im = 'IM',
+  In = 'IN',
+  Io = 'IO',
+  Iq = 'IQ',
+  Is = 'IS',
+  It = 'IT',
+  Je = 'JE',
+  Jm = 'JM',
+  Jo = 'JO',
+  Jp = 'JP',
+  Ke = 'KE',
+  Kg = 'KG',
+  Kh = 'KH',
+  Ki = 'KI',
+  Km = 'KM',
+  Kn = 'KN',
+  Kr = 'KR',
+  Kw = 'KW',
+  Ky = 'KY',
+  Kz = 'KZ',
+  La = 'LA',
+  Lb = 'LB',
+  Lc = 'LC',
+  Li = 'LI',
+  Lk = 'LK',
+  Lr = 'LR',
+  Ls = 'LS',
+  Lt = 'LT',
+  Lu = 'LU',
+  Lv = 'LV',
+  Ly = 'LY',
+  Ma = 'MA',
+  Mc = 'MC',
+  Md = 'MD',
+  Me = 'ME',
+  Mf = 'MF',
+  Mg = 'MG',
+  Mk = 'MK',
+  Ml = 'ML',
+  Mm = 'MM',
+  Mn = 'MN',
+  Mo = 'MO',
+  Mq = 'MQ',
+  Mr = 'MR',
+  Ms = 'MS',
+  Mt = 'MT',
+  Mu = 'MU',
+  Mv = 'MV',
+  Mw = 'MW',
+  Mx = 'MX',
+  My = 'MY',
+  Mz = 'MZ',
+  Na = 'NA',
+  Nc = 'NC',
+  Ne = 'NE',
+  Ng = 'NG',
+  Ni = 'NI',
+  Nl = 'NL',
+  No = 'NO',
+  Np = 'NP',
+  Nr = 'NR',
+  Nu = 'NU',
+  Nz = 'NZ',
+  Om = 'OM',
+  Pa = 'PA',
+  Pe = 'PE',
+  Pf = 'PF',
+  Pg = 'PG',
+  Ph = 'PH',
+  Pk = 'PK',
+  Pl = 'PL',
+  Pm = 'PM',
+  Pn = 'PN',
+  Pr = 'PR',
+  Ps = 'PS',
+  Pt = 'PT',
+  Py = 'PY',
+  Qa = 'QA',
+  Re = 'RE',
+  Ro = 'RO',
+  Rs = 'RS',
+  Ru = 'RU',
+  Rw = 'RW',
+  Sa = 'SA',
+  Sb = 'SB',
+  Sc = 'SC',
+  Se = 'SE',
+  Sg = 'SG',
+  Sh = 'SH',
+  Si = 'SI',
+  Sj = 'SJ',
+  Sk = 'SK',
+  Sl = 'SL',
+  Sm = 'SM',
+  Sn = 'SN',
+  So = 'SO',
+  Sr = 'SR',
+  Ss = 'SS',
+  St = 'ST',
+  Sv = 'SV',
+  Sx = 'SX',
+  Sz = 'SZ',
+  Ta = 'TA',
+  Tc = 'TC',
+  Td = 'TD',
+  Tf = 'TF',
+  Tg = 'TG',
+  Th = 'TH',
+  Tj = 'TJ',
+  Tk = 'TK',
+  Tl = 'TL',
+  Tm = 'TM',
+  Tn = 'TN',
+  To = 'TO',
+  Tr = 'TR',
+  Tt = 'TT',
+  Tv = 'TV',
+  Tw = 'TW',
+  Tz = 'TZ',
+  Ua = 'UA',
+  Ug = 'UG',
+  Us = 'US',
+  Uy = 'UY',
+  Uz = 'UZ',
+  Va = 'VA',
+  Vc = 'VC',
+  Ve = 'VE',
+  Vg = 'VG',
+  Vn = 'VN',
+  Vu = 'VU',
+  Wf = 'WF',
+  Ws = 'WS',
+  Xk = 'XK',
+  Ye = 'YE',
+  Yt = 'YT',
+  Za = 'ZA',
+  Zm = 'ZM',
+  Zw = 'ZW',
+  Zz = 'ZZ'
+}
+
+export enum Stripe_CheckoutSessionSubmitTypeProperty {
+  Auto = 'auto',
+  Book = 'book',
+  Donate = 'donate',
+  Pay = 'pay'
+}
+
+export type Stripe_CheckoutSessionSubscriptionProperty = WrappedString | Stripe_Subscription;
+
+export type Stripe_PaymentPagesCheckoutSessionTaxIdCollection = {
+  __typename?: 'Stripe_PaymentPagesCheckoutSessionTaxIdCollection';
+  /** Indicates whether tax ID collection is enabled for the session */
+  enabled?: Maybe<Scalars['Boolean']>;
+};
+
+export type Stripe_PaymentPagesCheckoutSessionTotalDetails = {
+  __typename?: 'Stripe_PaymentPagesCheckoutSessionTotalDetails';
+  /** This is the sum of all the line item discounts. */
+  amount_discount?: Maybe<Scalars['Int']>;
+  /** This is the sum of all the line item shipping amounts. */
+  amount_shipping?: Maybe<Scalars['Int']>;
+  /** This is the sum of all the line item tax amounts. */
+  amount_tax?: Maybe<Scalars['Int']>;
+  breakdown?: Maybe<Stripe_PaymentPagesCheckoutSessionTotalDetailsResourceBreakdown>;
+};
+
+export type Stripe_PaymentPagesCheckoutSessionTotalDetailsResourceBreakdown = {
+  __typename?: 'Stripe_PaymentPagesCheckoutSessionTotalDetailsResourceBreakdown';
+  /** The aggregated line item discounts. */
+  discounts?: Maybe<Array<Maybe<Stripe_LineItemsDiscountAmount>>>;
+  /** The aggregated line item tax amounts by rate. */
+  taxes?: Maybe<Array<Maybe<Stripe_LineItemsTaxAmount>>>;
+};
+
+export type Stripe_CheckoutSessionLineItemsPropertyInput = {
+  price?: InputMaybe<Scalars['String']>;
+  quantity?: InputMaybe<Scalars['Int']>;
+};
+
+export type UpdateProfileResult = {
+  __typename?: 'UpdateProfileResult';
+  clientMutationId?: Maybe<Scalars['String']>;
+  result?: Maybe<Profile>;
+};
+
+/** update Profile input */
+export type UpdateProfileInput = {
+  _id: Scalars['ID'];
+  id?: InputMaybe<Scalars['String']>;
+  name?: InputMaybe<Scalars['String']>;
+  email?: InputMaybe<Scalars['String']>;
+  bio?: InputMaybe<Scalars['String']>;
+  avatar?: InputMaybe<TsRelationshipInput>;
+  stripeCustomerId?: InputMaybe<Scalars['String']>;
+  _shapeId?: InputMaybe<Scalars['String']>;
+  _version?: InputMaybe<Scalars['Int']>;
+  _shapeName?: InputMaybe<Scalars['String']>;
+  _createdAt?: InputMaybe<Scalars['String']>;
+  _createdBy?: InputMaybe<Scalars['String']>;
+  _updatedAt?: InputMaybe<Scalars['String']>;
+  _updatedBy?: InputMaybe<Scalars['String']>;
+  _schemaVersion?: InputMaybe<Scalars['Float']>;
+  _enabled?: InputMaybe<Scalars['Boolean']>;
+  _enabledAt?: InputMaybe<Scalars['String']>;
+  _status?: InputMaybe<DefaultWorkflow>;
+  _contentTypeId?: InputMaybe<Scalars['String']>;
+  _contentTypeName?: InputMaybe<Scalars['String']>;
+};
+
+export type TsRelationshipInput = {
+  shapeId?: InputMaybe<Scalars['String']>;
+  shapeName?: InputMaybe<Scalars['String']>;
+  contentTypeId?: InputMaybe<Scalars['String']>;
+  id: Scalars['String'];
+};
+
+export type CreateProfileResult = {
+  __typename?: 'CreateProfileResult';
+  clientMutationId?: Maybe<Scalars['String']>;
+  result?: Maybe<Profile>;
+};
+
+/** create Profile input */
+export type CreateProfileInput = {
+  id?: InputMaybe<Scalars['String']>;
+  name?: InputMaybe<Scalars['String']>;
+  email?: InputMaybe<Scalars['String']>;
+  bio?: InputMaybe<Scalars['String']>;
+  avatar?: InputMaybe<TsRelationshipInput>;
+  stripeCustomerId?: InputMaybe<Scalars['String']>;
+  _shapeId?: InputMaybe<Scalars['String']>;
+  _id?: InputMaybe<Scalars['ID']>;
+  _version?: InputMaybe<Scalars['Int']>;
+  _shapeName?: InputMaybe<Scalars['String']>;
+  _createdAt?: InputMaybe<Scalars['String']>;
+  _createdBy?: InputMaybe<Scalars['String']>;
+  _updatedAt?: InputMaybe<Scalars['String']>;
+  _updatedBy?: InputMaybe<Scalars['String']>;
+  _schemaVersion?: InputMaybe<Scalars['Float']>;
+  _enabled?: InputMaybe<Scalars['Boolean']>;
+  _enabledAt?: InputMaybe<Scalars['String']>;
+  _status?: InputMaybe<DefaultWorkflow>;
+  _contentTypeId?: InputMaybe<Scalars['String']>;
+  _contentTypeName?: InputMaybe<Scalars['String']>;
+};
+
+export type DuplicateProfileResult = {
+  __typename?: 'DuplicateProfileResult';
+  clientMutationId?: Maybe<Scalars['String']>;
+  result?: Maybe<Profile>;
+};
+
+/** duplicate Profile input */
+export type DuplicateProfileInput = {
+  _id: Scalars['ID'];
+  id?: InputMaybe<Scalars['String']>;
+  name?: InputMaybe<Scalars['String']>;
+  email?: InputMaybe<Scalars['String']>;
+  bio?: InputMaybe<Scalars['String']>;
+  avatar?: InputMaybe<TsRelationshipInput>;
+  stripeCustomerId?: InputMaybe<Scalars['String']>;
+  _shapeId?: InputMaybe<Scalars['String']>;
+  _version?: InputMaybe<Scalars['Int']>;
+  _shapeName?: InputMaybe<Scalars['String']>;
+  _createdAt?: InputMaybe<Scalars['String']>;
+  _createdBy?: InputMaybe<Scalars['String']>;
+  _updatedAt?: InputMaybe<Scalars['String']>;
+  _updatedBy?: InputMaybe<Scalars['String']>;
+  _schemaVersion?: InputMaybe<Scalars['Float']>;
+  _enabled?: InputMaybe<Scalars['Boolean']>;
+  _enabledAt?: InputMaybe<Scalars['String']>;
+  _status?: InputMaybe<DefaultWorkflow>;
+  _contentTypeId?: InputMaybe<Scalars['String']>;
+  _contentTypeName?: InputMaybe<Scalars['String']>;
+};
+
+export type DeleteProfileResult = {
+  __typename?: 'DeleteProfileResult';
+  clientMutationId?: Maybe<Scalars['String']>;
+  result?: Maybe<Scalars['Boolean']>;
+};
+
+/** delete Profile input */
+export type DeleteProfileInput = {
+  _id: Scalars['ID'];
+};

--- a/lib/utils/types.ts
+++ b/lib/utils/types.ts
@@ -1,0 +1,6 @@
+export function getSingle<T>(param?: T | T[]): T | undefined {
+  if (Array.isArray(param)) {
+    return param[0];
+  }
+  return param;
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,14 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@ampproject/remapping": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.1.2.tgz",
+      "integrity": "sha512-hoyByceqwKirw7w3Z7gnIIZC3Wx3J484Y3L/cMpXFbr7d9ZQj2mODrirNzcJa+SM3UlpWXYvKV4RlRpFXlWgXg==",
+      "requires": {
+        "@jridgewell/trace-mapping": "^0.3.0"
+      }
+    },
     "@apollo/client": {
       "version": "3.5.8",
       "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.5.8.tgz",
@@ -53,6 +61,160 @@
         "@babel/highlight": "^7.10.4"
       }
     },
+    "@babel/compat-data": {
+      "version": "7.17.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.17.7.tgz",
+      "integrity": "sha512-p8pdE6j0a29TNGebNm7NzYZWB3xVZJBZ7XGs42uAKzQo8VQ3F0By/cQCtUEABwIqw5zo6WA4NbmxsfzADzMKnQ=="
+    },
+    "@babel/core": {
+      "version": "7.17.8",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.17.8.tgz",
+      "integrity": "sha512-OdQDV/7cRBtJHLSOBqqbYNkOcydOgnX59TZx4puf41fzcVtN3e/4yqY8lMQsK+5X2lJtAdmA+6OHqsj1hBJ4IQ==",
+      "requires": {
+        "@ampproject/remapping": "^2.1.0",
+        "@babel/code-frame": "^7.16.7",
+        "@babel/generator": "^7.17.7",
+        "@babel/helper-compilation-targets": "^7.17.7",
+        "@babel/helper-module-transforms": "^7.17.7",
+        "@babel/helpers": "^7.17.8",
+        "@babel/parser": "^7.17.8",
+        "@babel/template": "^7.16.7",
+        "@babel/traverse": "^7.17.3",
+        "@babel/types": "^7.17.0",
+        "convert-source-map": "^1.7.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.1.2",
+        "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.16.7",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.7.tgz",
+          "integrity": "sha512-iAXqUn8IIeBTNd72xsFlgaXHkMBMt6y4HJp1tIaK465CWLT/fG1aqB7ykr95gHHmlBdGbFeWWfyB4NJJ0nmeIg==",
+          "requires": {
+            "@babel/highlight": "^7.16.7"
+          }
+        },
+        "@babel/helper-validator-identifier": {
+          "version": "7.16.7",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz",
+          "integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw=="
+        },
+        "@babel/highlight": {
+          "version": "7.16.10",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.10.tgz",
+          "integrity": "sha512-5FnTQLSLswEj6IkgVw5KusNUUFY9ZGqe/TRFnP/BKYHYgfh7tc+C7mwiy95/yNP7Dh9x580Vv8r7u7ZfTBFxdw==",
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.16.7",
+            "chalk": "^2.0.0",
+            "js-tokens": "^4.0.0"
+          }
+        },
+        "json5": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
+          "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA=="
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+        }
+      }
+    },
+    "@babel/generator": {
+      "version": "7.17.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.17.7.tgz",
+      "integrity": "sha512-oLcVCTeIFadUoArDTwpluncplrYBmTCCZZgXCbgNGvOBBiSDDK3eWO4b/+eOTli5tKv1lg+a5/NAXg+nTcei1w==",
+      "requires": {
+        "@babel/types": "^7.17.0",
+        "jsesc": "^2.5.1",
+        "source-map": "^0.5.0"
+      }
+    },
+    "@babel/helper-annotate-as-pure": {
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.16.7.tgz",
+      "integrity": "sha512-s6t2w/IPQVTAET1HitoowRGXooX8mCgtuP5195wD/QJPV6wYjpujCGF7JuMODVX2ZAJOf1GT6DT9MHEZvLOFSw==",
+      "requires": {
+        "@babel/types": "^7.16.7"
+      }
+    },
+    "@babel/helper-compilation-targets": {
+      "version": "7.17.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.17.7.tgz",
+      "integrity": "sha512-UFzlz2jjd8kroj0hmCFV5zr+tQPi1dpC2cRsDV/3IEW8bJfCPrPpmcSN6ZS8RqIq4LXcmpipCQFPddyFA5Yc7w==",
+      "requires": {
+        "@babel/compat-data": "^7.17.7",
+        "@babel/helper-validator-option": "^7.16.7",
+        "browserslist": "^4.17.5",
+        "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+        }
+      }
+    },
+    "@babel/helper-create-class-features-plugin": {
+      "version": "7.17.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.17.6.tgz",
+      "integrity": "sha512-SogLLSxXm2OkBbSsHZMM4tUi8fUzjs63AT/d0YQIzr6GSd8Hxsbk2KYDX0k0DweAzGMj/YWeiCsorIdtdcW8Eg==",
+      "requires": {
+        "@babel/helper-annotate-as-pure": "^7.16.7",
+        "@babel/helper-environment-visitor": "^7.16.7",
+        "@babel/helper-function-name": "^7.16.7",
+        "@babel/helper-member-expression-to-functions": "^7.16.7",
+        "@babel/helper-optimise-call-expression": "^7.16.7",
+        "@babel/helper-replace-supers": "^7.16.7",
+        "@babel/helper-split-export-declaration": "^7.16.7"
+      }
+    },
+    "@babel/helper-environment-visitor": {
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.16.7.tgz",
+      "integrity": "sha512-SLLb0AAn6PkUeAfKJCCOl9e1R53pQlGAfc4y4XuMRZfqeMYLE0dM1LMhqbGAlGQY0lfw5/ohoYWAe9V1yibRag==",
+      "requires": {
+        "@babel/types": "^7.16.7"
+      }
+    },
+    "@babel/helper-function-name": {
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.16.7.tgz",
+      "integrity": "sha512-QfDfEnIUyyBSR3HtrtGECuZ6DAyCkYFp7GHl75vFtTnn6pjKeK0T1DB5lLkFvBea8MdaiUABx3osbgLyInoejA==",
+      "requires": {
+        "@babel/helper-get-function-arity": "^7.16.7",
+        "@babel/template": "^7.16.7",
+        "@babel/types": "^7.16.7"
+      }
+    },
+    "@babel/helper-get-function-arity": {
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.16.7.tgz",
+      "integrity": "sha512-flc+RLSOBXzNzVhcLu6ujeHUrD6tANAOU5ojrRx/as+tbzf8+stUCj7+IfRRoAbEZqj/ahXEMsjhOhgeZsrnTw==",
+      "requires": {
+        "@babel/types": "^7.16.7"
+      }
+    },
+    "@babel/helper-hoist-variables": {
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.16.7.tgz",
+      "integrity": "sha512-m04d/0Op34H5v7pbZw6pSKP7weA6lsMvfiIAMeIvkY/R4xQtBSMFEigu9QTZ2qB/9l22vsxtM8a+Q8CzD255fg==",
+      "requires": {
+        "@babel/types": "^7.16.7"
+      }
+    },
+    "@babel/helper-member-expression-to-functions": {
+      "version": "7.17.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.17.7.tgz",
+      "integrity": "sha512-thxXgnQ8qQ11W2wVUObIqDL4p148VMxkt5T/qpN5k2fboRyzFGFmKsTGViquyM5QHKUy48OZoca8kw4ajaDPyw==",
+      "requires": {
+        "@babel/types": "^7.17.0"
+      }
+    },
     "@babel/helper-module-imports": {
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.16.0.tgz",
@@ -72,15 +234,104 @@
         }
       }
     },
+    "@babel/helper-module-transforms": {
+      "version": "7.17.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.17.7.tgz",
+      "integrity": "sha512-VmZD99F3gNTYB7fJRDTi+u6l/zxY0BE6OIxPSU7a50s6ZUQkHwSDmV92FfM+oCG0pZRVojGYhkR8I0OGeCVREw==",
+      "requires": {
+        "@babel/helper-environment-visitor": "^7.16.7",
+        "@babel/helper-module-imports": "^7.16.7",
+        "@babel/helper-simple-access": "^7.17.7",
+        "@babel/helper-split-export-declaration": "^7.16.7",
+        "@babel/helper-validator-identifier": "^7.16.7",
+        "@babel/template": "^7.16.7",
+        "@babel/traverse": "^7.17.3",
+        "@babel/types": "^7.17.0"
+      },
+      "dependencies": {
+        "@babel/helper-module-imports": {
+          "version": "7.16.7",
+          "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.16.7.tgz",
+          "integrity": "sha512-LVtS6TqjJHFc+nYeITRo6VLXve70xmq7wPhWTqDJusJEgGmkAACWwMiTNrvfoQo6hEhFwAIixNkvB0jPXDL8Wg==",
+          "requires": {
+            "@babel/types": "^7.16.7"
+          }
+        },
+        "@babel/helper-validator-identifier": {
+          "version": "7.16.7",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz",
+          "integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw=="
+        }
+      }
+    },
+    "@babel/helper-optimise-call-expression": {
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.16.7.tgz",
+      "integrity": "sha512-EtgBhg7rd/JcnpZFXpBy0ze1YRfdm7BnBX4uKMBd3ixa3RGAE002JZB66FJyNH7g0F38U05pXmA5P8cBh7z+1w==",
+      "requires": {
+        "@babel/types": "^7.16.7"
+      }
+    },
     "@babel/helper-plugin-utils": {
       "version": "7.14.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.14.5.tgz",
       "integrity": "sha512-/37qQCE3K0vvZKwoK4XU/irIJQdIfCJuhU5eKnNxpFDsOkgFaUAwbv+RYw6eYgsC0E4hS7r5KqGULUogqui0fQ=="
     },
+    "@babel/helper-replace-supers": {
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.16.7.tgz",
+      "integrity": "sha512-y9vsWilTNaVnVh6xiJfABzsNpgDPKev9HnAgz6Gb1p6UUwf9NepdlsV7VXGCftJM+jqD5f7JIEubcpLjZj5dBw==",
+      "requires": {
+        "@babel/helper-environment-visitor": "^7.16.7",
+        "@babel/helper-member-expression-to-functions": "^7.16.7",
+        "@babel/helper-optimise-call-expression": "^7.16.7",
+        "@babel/traverse": "^7.16.7",
+        "@babel/types": "^7.16.7"
+      }
+    },
+    "@babel/helper-simple-access": {
+      "version": "7.17.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.17.7.tgz",
+      "integrity": "sha512-txyMCGroZ96i+Pxr3Je3lzEJjqwaRC9buMUgtomcrLe5Nd0+fk1h0LLA+ixUF5OW7AhHuQ7Es1WcQJZmZsz2XA==",
+      "requires": {
+        "@babel/types": "^7.17.0"
+      }
+    },
+    "@babel/helper-skip-transparent-expression-wrappers": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.16.0.tgz",
+      "integrity": "sha512-+il1gTy0oHwUsBQZyJvukbB4vPMdcYBrFHa0Uc4AizLxbq6BOYC51Rv4tWocX9BLBDLZ4kc6qUFpQ6HRgL+3zw==",
+      "requires": {
+        "@babel/types": "^7.16.0"
+      }
+    },
+    "@babel/helper-split-export-declaration": {
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.16.7.tgz",
+      "integrity": "sha512-xbWoy/PFoxSWazIToT9Sif+jJTlrMcndIsaOKvTA6u7QEo7ilkRZpjew18/W3c7nm8fXdUDXh02VXTbZ0pGDNw==",
+      "requires": {
+        "@babel/types": "^7.16.7"
+      }
+    },
     "@babel/helper-validator-identifier": {
       "version": "7.15.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
       "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w=="
+    },
+    "@babel/helper-validator-option": {
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.16.7.tgz",
+      "integrity": "sha512-TRtenOuRUVo9oIQGPC5G9DgK4743cdxvtOw0weQNpZXaS16SCBi5MNjZF8vba3ETURjZpTbVn7Vvcf2eAwFozQ=="
+    },
+    "@babel/helpers": {
+      "version": "7.17.8",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.17.8.tgz",
+      "integrity": "sha512-QcL86FGxpfSJwGtAvv4iG93UL6bmqBdmoVY0CMCU2g+oD2ezQse3PT5Pa+jiD6LJndBQi0EDlpzOWNlLuhz5gw==",
+      "requires": {
+        "@babel/template": "^7.16.7",
+        "@babel/traverse": "^7.17.3",
+        "@babel/types": "^7.17.0"
+      }
     },
     "@babel/highlight": {
       "version": "7.16.0",
@@ -92,12 +343,423 @@
         "js-tokens": "^4.0.0"
       }
     },
+    "@babel/parser": {
+      "version": "7.17.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.8.tgz",
+      "integrity": "sha512-BoHhDJrJXqcg+ZL16Xv39H9n+AqJ4pcDrQBGZN+wHxIysrLZ3/ECwCBUch/1zUNhnsXULcONU3Ei5Hmkfk6kiQ=="
+    },
+    "@babel/plugin-proposal-class-properties": {
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.16.7.tgz",
+      "integrity": "sha512-IobU0Xme31ewjYOShSIqd/ZGM/r/cuOz2z0MDbNrhF5FW+ZVgi0f2lyeoj9KFPDOAqsYxmLWZte1WOwlvY9aww==",
+      "requires": {
+        "@babel/helper-create-class-features-plugin": "^7.16.7",
+        "@babel/helper-plugin-utils": "^7.16.7"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.16.7",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.16.7.tgz",
+          "integrity": "sha512-Qg3Nk7ZxpgMrsox6HreY1ZNKdBq7K72tDSliA6dCl5f007jR4ne8iD5UzuNnCJH2xBf2BEEVGr+/OL6Gdp7RxA=="
+        }
+      }
+    },
+    "@babel/plugin-proposal-object-rest-spread": {
+      "version": "7.17.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.17.3.tgz",
+      "integrity": "sha512-yuL5iQA/TbZn+RGAfxQXfi7CNLmKi1f8zInn4IgobuCWcAb7i+zj4TYzQ9l8cEzVyJ89PDGuqxK1xZpUDISesw==",
+      "requires": {
+        "@babel/compat-data": "^7.17.0",
+        "@babel/helper-compilation-targets": "^7.16.7",
+        "@babel/helper-plugin-utils": "^7.16.7",
+        "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+        "@babel/plugin-transform-parameters": "^7.16.7"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.16.7",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.16.7.tgz",
+          "integrity": "sha512-Qg3Nk7ZxpgMrsox6HreY1ZNKdBq7K72tDSliA6dCl5f007jR4ne8iD5UzuNnCJH2xBf2BEEVGr+/OL6Gdp7RxA=="
+        }
+      }
+    },
+    "@babel/plugin-syntax-class-properties": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.13.tgz",
+      "integrity": "sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.12.13"
+      }
+    },
+    "@babel/plugin-syntax-flow": {
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.16.7.tgz",
+      "integrity": "sha512-UDo3YGQO0jH6ytzVwgSLv9i/CzMcUjbKenL67dTrAZPPv6GFAtDhe6jqnvmoKzC/7htNTohhos+onPtDMqJwaQ==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.16.7"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.16.7",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.16.7.tgz",
+          "integrity": "sha512-Qg3Nk7ZxpgMrsox6HreY1ZNKdBq7K72tDSliA6dCl5f007jR4ne8iD5UzuNnCJH2xBf2BEEVGr+/OL6Gdp7RxA=="
+        }
+      }
+    },
     "@babel/plugin-syntax-jsx": {
       "version": "7.14.5",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.14.5.tgz",
       "integrity": "sha512-ohuFIsOMXJnbOMRfX7/w7LocdR6R7whhuRD4ax8IipLcLPlZGJKkBxgHp++U4N/vKyU16/YDQr2f5seajD3jIw==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-syntax-object-rest-spread": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
+      "integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-transform-arrow-functions": {
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.16.7.tgz",
+      "integrity": "sha512-9ffkFFMbvzTvv+7dTp/66xvZAWASuPD5Tl9LK3Z9vhOmANo6j94rik+5YMBt4CwHVMWLWpMsriIc2zsa3WW3xQ==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.16.7"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.16.7",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.16.7.tgz",
+          "integrity": "sha512-Qg3Nk7ZxpgMrsox6HreY1ZNKdBq7K72tDSliA6dCl5f007jR4ne8iD5UzuNnCJH2xBf2BEEVGr+/OL6Gdp7RxA=="
+        }
+      }
+    },
+    "@babel/plugin-transform-block-scoped-functions": {
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.16.7.tgz",
+      "integrity": "sha512-JUuzlzmF40Z9cXyytcbZEZKckgrQzChbQJw/5PuEHYeqzCsvebDx0K0jWnIIVcmmDOAVctCgnYs0pMcrYj2zJg==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.16.7"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.16.7",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.16.7.tgz",
+          "integrity": "sha512-Qg3Nk7ZxpgMrsox6HreY1ZNKdBq7K72tDSliA6dCl5f007jR4ne8iD5UzuNnCJH2xBf2BEEVGr+/OL6Gdp7RxA=="
+        }
+      }
+    },
+    "@babel/plugin-transform-block-scoping": {
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.16.7.tgz",
+      "integrity": "sha512-ObZev2nxVAYA4bhyusELdo9hb3H+A56bxH3FZMbEImZFiEDYVHXQSJ1hQKFlDnlt8G9bBrCZ5ZpURZUrV4G5qQ==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.16.7"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.16.7",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.16.7.tgz",
+          "integrity": "sha512-Qg3Nk7ZxpgMrsox6HreY1ZNKdBq7K72tDSliA6dCl5f007jR4ne8iD5UzuNnCJH2xBf2BEEVGr+/OL6Gdp7RxA=="
+        }
+      }
+    },
+    "@babel/plugin-transform-classes": {
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.16.7.tgz",
+      "integrity": "sha512-WY7og38SFAGYRe64BrjKf8OrE6ulEHtr5jEYaZMwox9KebgqPi67Zqz8K53EKk1fFEJgm96r32rkKZ3qA2nCWQ==",
+      "requires": {
+        "@babel/helper-annotate-as-pure": "^7.16.7",
+        "@babel/helper-environment-visitor": "^7.16.7",
+        "@babel/helper-function-name": "^7.16.7",
+        "@babel/helper-optimise-call-expression": "^7.16.7",
+        "@babel/helper-plugin-utils": "^7.16.7",
+        "@babel/helper-replace-supers": "^7.16.7",
+        "@babel/helper-split-export-declaration": "^7.16.7",
+        "globals": "^11.1.0"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.16.7",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.16.7.tgz",
+          "integrity": "sha512-Qg3Nk7ZxpgMrsox6HreY1ZNKdBq7K72tDSliA6dCl5f007jR4ne8iD5UzuNnCJH2xBf2BEEVGr+/OL6Gdp7RxA=="
+        },
+        "globals": {
+          "version": "11.12.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+          "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
+        }
+      }
+    },
+    "@babel/plugin-transform-computed-properties": {
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.16.7.tgz",
+      "integrity": "sha512-gN72G9bcmenVILj//sv1zLNaPyYcOzUho2lIJBMh/iakJ9ygCo/hEF9cpGb61SCMEDxbbyBoVQxrt+bWKu5KGw==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.16.7"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.16.7",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.16.7.tgz",
+          "integrity": "sha512-Qg3Nk7ZxpgMrsox6HreY1ZNKdBq7K72tDSliA6dCl5f007jR4ne8iD5UzuNnCJH2xBf2BEEVGr+/OL6Gdp7RxA=="
+        }
+      }
+    },
+    "@babel/plugin-transform-destructuring": {
+      "version": "7.17.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.17.7.tgz",
+      "integrity": "sha512-XVh0r5yq9sLR4vZ6eVZe8FKfIcSgaTBxVBRSYokRj2qksf6QerYnTxz9/GTuKTH/n/HwLP7t6gtlybHetJ/6hQ==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.16.7"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.16.7",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.16.7.tgz",
+          "integrity": "sha512-Qg3Nk7ZxpgMrsox6HreY1ZNKdBq7K72tDSliA6dCl5f007jR4ne8iD5UzuNnCJH2xBf2BEEVGr+/OL6Gdp7RxA=="
+        }
+      }
+    },
+    "@babel/plugin-transform-flow-strip-types": {
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.16.7.tgz",
+      "integrity": "sha512-mzmCq3cNsDpZZu9FADYYyfZJIOrSONmHcop2XEKPdBNMa4PDC4eEvcOvzZaCNcjKu72v0XQlA5y1g58aLRXdYg==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.16.7",
+        "@babel/plugin-syntax-flow": "^7.16.7"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.16.7",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.16.7.tgz",
+          "integrity": "sha512-Qg3Nk7ZxpgMrsox6HreY1ZNKdBq7K72tDSliA6dCl5f007jR4ne8iD5UzuNnCJH2xBf2BEEVGr+/OL6Gdp7RxA=="
+        }
+      }
+    },
+    "@babel/plugin-transform-for-of": {
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.16.7.tgz",
+      "integrity": "sha512-/QZm9W92Ptpw7sjI9Nx1mbcsWz33+l8kuMIQnDwgQBG5s3fAfQvkRjQ7NqXhtNcKOnPkdICmUHyCaWW06HCsqg==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.16.7"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.16.7",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.16.7.tgz",
+          "integrity": "sha512-Qg3Nk7ZxpgMrsox6HreY1ZNKdBq7K72tDSliA6dCl5f007jR4ne8iD5UzuNnCJH2xBf2BEEVGr+/OL6Gdp7RxA=="
+        }
+      }
+    },
+    "@babel/plugin-transform-function-name": {
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.16.7.tgz",
+      "integrity": "sha512-SU/C68YVwTRxqWj5kgsbKINakGag0KTgq9f2iZEXdStoAbOzLHEBRYzImmA6yFo8YZhJVflvXmIHUO7GWHmxxA==",
+      "requires": {
+        "@babel/helper-compilation-targets": "^7.16.7",
+        "@babel/helper-function-name": "^7.16.7",
+        "@babel/helper-plugin-utils": "^7.16.7"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.16.7",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.16.7.tgz",
+          "integrity": "sha512-Qg3Nk7ZxpgMrsox6HreY1ZNKdBq7K72tDSliA6dCl5f007jR4ne8iD5UzuNnCJH2xBf2BEEVGr+/OL6Gdp7RxA=="
+        }
+      }
+    },
+    "@babel/plugin-transform-literals": {
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.16.7.tgz",
+      "integrity": "sha512-6tH8RTpTWI0s2sV6uq3e/C9wPo4PTqqZps4uF0kzQ9/xPLFQtipynvmT1g/dOfEJ+0EQsHhkQ/zyRId8J2b8zQ==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.16.7"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.16.7",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.16.7.tgz",
+          "integrity": "sha512-Qg3Nk7ZxpgMrsox6HreY1ZNKdBq7K72tDSliA6dCl5f007jR4ne8iD5UzuNnCJH2xBf2BEEVGr+/OL6Gdp7RxA=="
+        }
+      }
+    },
+    "@babel/plugin-transform-member-expression-literals": {
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.16.7.tgz",
+      "integrity": "sha512-mBruRMbktKQwbxaJof32LT9KLy2f3gH+27a5XSuXo6h7R3vqltl0PgZ80C8ZMKw98Bf8bqt6BEVi3svOh2PzMw==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.16.7"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.16.7",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.16.7.tgz",
+          "integrity": "sha512-Qg3Nk7ZxpgMrsox6HreY1ZNKdBq7K72tDSliA6dCl5f007jR4ne8iD5UzuNnCJH2xBf2BEEVGr+/OL6Gdp7RxA=="
+        }
+      }
+    },
+    "@babel/plugin-transform-modules-commonjs": {
+      "version": "7.17.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.17.7.tgz",
+      "integrity": "sha512-ITPmR2V7MqioMJyrxUo2onHNC3e+MvfFiFIR0RP21d3PtlVb6sfzoxNKiphSZUOM9hEIdzCcZe83ieX3yoqjUA==",
+      "requires": {
+        "@babel/helper-module-transforms": "^7.17.7",
+        "@babel/helper-plugin-utils": "^7.16.7",
+        "@babel/helper-simple-access": "^7.17.7",
+        "babel-plugin-dynamic-import-node": "^2.3.3"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.16.7",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.16.7.tgz",
+          "integrity": "sha512-Qg3Nk7ZxpgMrsox6HreY1ZNKdBq7K72tDSliA6dCl5f007jR4ne8iD5UzuNnCJH2xBf2BEEVGr+/OL6Gdp7RxA=="
+        }
+      }
+    },
+    "@babel/plugin-transform-object-super": {
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.16.7.tgz",
+      "integrity": "sha512-14J1feiQVWaGvRxj2WjyMuXS2jsBkgB3MdSN5HuC2G5nRspa5RK9COcs82Pwy5BuGcjb+fYaUj94mYcOj7rCvw==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.16.7",
+        "@babel/helper-replace-supers": "^7.16.7"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.16.7",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.16.7.tgz",
+          "integrity": "sha512-Qg3Nk7ZxpgMrsox6HreY1ZNKdBq7K72tDSliA6dCl5f007jR4ne8iD5UzuNnCJH2xBf2BEEVGr+/OL6Gdp7RxA=="
+        }
+      }
+    },
+    "@babel/plugin-transform-parameters": {
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.16.7.tgz",
+      "integrity": "sha512-AT3MufQ7zZEhU2hwOA11axBnExW0Lszu4RL/tAlUJBuNoRak+wehQW8h6KcXOcgjY42fHtDxswuMhMjFEuv/aw==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.16.7"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.16.7",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.16.7.tgz",
+          "integrity": "sha512-Qg3Nk7ZxpgMrsox6HreY1ZNKdBq7K72tDSliA6dCl5f007jR4ne8iD5UzuNnCJH2xBf2BEEVGr+/OL6Gdp7RxA=="
+        }
+      }
+    },
+    "@babel/plugin-transform-property-literals": {
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.16.7.tgz",
+      "integrity": "sha512-z4FGr9NMGdoIl1RqavCqGG+ZuYjfZ/hkCIeuH6Do7tXmSm0ls11nYVSJqFEUOSJbDab5wC6lRE/w6YjVcr6Hqw==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.16.7"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.16.7",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.16.7.tgz",
+          "integrity": "sha512-Qg3Nk7ZxpgMrsox6HreY1ZNKdBq7K72tDSliA6dCl5f007jR4ne8iD5UzuNnCJH2xBf2BEEVGr+/OL6Gdp7RxA=="
+        }
+      }
+    },
+    "@babel/plugin-transform-react-display-name": {
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.16.7.tgz",
+      "integrity": "sha512-qgIg8BcZgd0G/Cz916D5+9kqX0c7nPZyXaP8R2tLNN5tkyIZdG5fEwBrxwplzSnjC1jvQmyMNVwUCZPcbGY7Pg==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.16.7"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.16.7",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.16.7.tgz",
+          "integrity": "sha512-Qg3Nk7ZxpgMrsox6HreY1ZNKdBq7K72tDSliA6dCl5f007jR4ne8iD5UzuNnCJH2xBf2BEEVGr+/OL6Gdp7RxA=="
+        }
+      }
+    },
+    "@babel/plugin-transform-react-jsx": {
+      "version": "7.17.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.17.3.tgz",
+      "integrity": "sha512-9tjBm4O07f7mzKSIlEmPdiE6ub7kfIe6Cd+w+oQebpATfTQMAgW+YOuWxogbKVTulA+MEO7byMeIUtQ1z+z+ZQ==",
+      "requires": {
+        "@babel/helper-annotate-as-pure": "^7.16.7",
+        "@babel/helper-module-imports": "^7.16.7",
+        "@babel/helper-plugin-utils": "^7.16.7",
+        "@babel/plugin-syntax-jsx": "^7.16.7",
+        "@babel/types": "^7.17.0"
+      },
+      "dependencies": {
+        "@babel/helper-module-imports": {
+          "version": "7.16.7",
+          "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.16.7.tgz",
+          "integrity": "sha512-LVtS6TqjJHFc+nYeITRo6VLXve70xmq7wPhWTqDJusJEgGmkAACWwMiTNrvfoQo6hEhFwAIixNkvB0jPXDL8Wg==",
+          "requires": {
+            "@babel/types": "^7.16.7"
+          }
+        },
+        "@babel/helper-plugin-utils": {
+          "version": "7.16.7",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.16.7.tgz",
+          "integrity": "sha512-Qg3Nk7ZxpgMrsox6HreY1ZNKdBq7K72tDSliA6dCl5f007jR4ne8iD5UzuNnCJH2xBf2BEEVGr+/OL6Gdp7RxA=="
+        },
+        "@babel/plugin-syntax-jsx": {
+          "version": "7.16.7",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.16.7.tgz",
+          "integrity": "sha512-Esxmk7YjA8QysKeT3VhTXvF6y77f/a91SIs4pWb4H2eWGQkCKFgQaG6hdoEVZtGsrAcb2K5BW66XsOErD4WU3Q==",
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.16.7"
+          }
+        }
+      }
+    },
+    "@babel/plugin-transform-shorthand-properties": {
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.16.7.tgz",
+      "integrity": "sha512-hah2+FEnoRoATdIb05IOXf+4GzXYTq75TVhIn1PewihbpyrNWUt2JbudKQOETWw6QpLe+AIUpJ5MVLYTQbeeUg==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.16.7"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.16.7",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.16.7.tgz",
+          "integrity": "sha512-Qg3Nk7ZxpgMrsox6HreY1ZNKdBq7K72tDSliA6dCl5f007jR4ne8iD5UzuNnCJH2xBf2BEEVGr+/OL6Gdp7RxA=="
+        }
+      }
+    },
+    "@babel/plugin-transform-spread": {
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.16.7.tgz",
+      "integrity": "sha512-+pjJpgAngb53L0iaA5gU/1MLXJIfXcYepLgXB3esVRf4fqmj8f2cxM3/FKaHsZms08hFQJkFccEWuIpm429TXg==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.16.7",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.16.0"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.16.7",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.16.7.tgz",
+          "integrity": "sha512-Qg3Nk7ZxpgMrsox6HreY1ZNKdBq7K72tDSliA6dCl5f007jR4ne8iD5UzuNnCJH2xBf2BEEVGr+/OL6Gdp7RxA=="
+        }
+      }
+    },
+    "@babel/plugin-transform-template-literals": {
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.16.7.tgz",
+      "integrity": "sha512-VwbkDDUeenlIjmfNeDX/V0aWrQH2QiVyJtwymVQSzItFDTpxfyJh3EVaQiS0rIN/CqbLGr0VcGmuwyTdZtdIsA==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.16.7"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.16.7",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.16.7.tgz",
+          "integrity": "sha512-Qg3Nk7ZxpgMrsox6HreY1ZNKdBq7K72tDSliA6dCl5f007jR4ne8iD5UzuNnCJH2xBf2BEEVGr+/OL6Gdp7RxA=="
+        }
       }
     },
     "@babel/runtime": {
@@ -116,6 +778,104 @@
       "requires": {
         "core-js-pure": "^3.20.2",
         "regenerator-runtime": "^0.13.4"
+      }
+    },
+    "@babel/template": {
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.16.7.tgz",
+      "integrity": "sha512-I8j/x8kHUrbYRTUxXrrMbfCa7jxkE7tZre39x3kjr9hvI82cK1FfqLygotcWN5kdPGWcLdWMHpSBavse5tWw3w==",
+      "requires": {
+        "@babel/code-frame": "^7.16.7",
+        "@babel/parser": "^7.16.7",
+        "@babel/types": "^7.16.7"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.16.7",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.7.tgz",
+          "integrity": "sha512-iAXqUn8IIeBTNd72xsFlgaXHkMBMt6y4HJp1tIaK465CWLT/fG1aqB7ykr95gHHmlBdGbFeWWfyB4NJJ0nmeIg==",
+          "requires": {
+            "@babel/highlight": "^7.16.7"
+          }
+        },
+        "@babel/helper-validator-identifier": {
+          "version": "7.16.7",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz",
+          "integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw=="
+        },
+        "@babel/highlight": {
+          "version": "7.16.10",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.10.tgz",
+          "integrity": "sha512-5FnTQLSLswEj6IkgVw5KusNUUFY9ZGqe/TRFnP/BKYHYgfh7tc+C7mwiy95/yNP7Dh9x580Vv8r7u7ZfTBFxdw==",
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.16.7",
+            "chalk": "^2.0.0",
+            "js-tokens": "^4.0.0"
+          }
+        }
+      }
+    },
+    "@babel/traverse": {
+      "version": "7.17.3",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.17.3.tgz",
+      "integrity": "sha512-5irClVky7TxRWIRtxlh2WPUUOLhcPN06AGgaQSB8AEwuyEBgJVuJ5imdHm5zxk8w0QS5T+tDfnDxAlhWjpb7cw==",
+      "requires": {
+        "@babel/code-frame": "^7.16.7",
+        "@babel/generator": "^7.17.3",
+        "@babel/helper-environment-visitor": "^7.16.7",
+        "@babel/helper-function-name": "^7.16.7",
+        "@babel/helper-hoist-variables": "^7.16.7",
+        "@babel/helper-split-export-declaration": "^7.16.7",
+        "@babel/parser": "^7.17.3",
+        "@babel/types": "^7.17.0",
+        "debug": "^4.1.0",
+        "globals": "^11.1.0"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.16.7",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.7.tgz",
+          "integrity": "sha512-iAXqUn8IIeBTNd72xsFlgaXHkMBMt6y4HJp1tIaK465CWLT/fG1aqB7ykr95gHHmlBdGbFeWWfyB4NJJ0nmeIg==",
+          "requires": {
+            "@babel/highlight": "^7.16.7"
+          }
+        },
+        "@babel/helper-validator-identifier": {
+          "version": "7.16.7",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz",
+          "integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw=="
+        },
+        "@babel/highlight": {
+          "version": "7.16.10",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.10.tgz",
+          "integrity": "sha512-5FnTQLSLswEj6IkgVw5KusNUUFY9ZGqe/TRFnP/BKYHYgfh7tc+C7mwiy95/yNP7Dh9x580Vv8r7u7ZfTBFxdw==",
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.16.7",
+            "chalk": "^2.0.0",
+            "js-tokens": "^4.0.0"
+          }
+        },
+        "globals": {
+          "version": "11.12.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+          "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
+        }
+      }
+    },
+    "@babel/types": {
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.17.0.tgz",
+      "integrity": "sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==",
+      "requires": {
+        "@babel/helper-validator-identifier": "^7.16.7",
+        "to-fast-properties": "^2.0.0"
+      },
+      "dependencies": {
+        "@babel/helper-validator-identifier": {
+          "version": "7.16.7",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz",
+          "integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw=="
+        }
       }
     },
     "@emotion/babel-plugin": {
@@ -269,6 +1029,165 @@
         }
       }
     },
+    "@graphql-codegen/core": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/core/-/core-2.5.1.tgz",
+      "integrity": "sha512-alctBVl2hMnBXDLwkgmnFPrZVIiBDsWJSmxJcM4GKg1PB23+xuov35GE47YAyAhQItE1B1fbYnbb1PtGiDZ4LA==",
+      "requires": {
+        "@graphql-codegen/plugin-helpers": "^2.4.1",
+        "@graphql-tools/schema": "^8.1.2",
+        "@graphql-tools/utils": "^8.1.1",
+        "tslib": "~2.3.0"
+      }
+    },
+    "@graphql-codegen/plugin-helpers": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/plugin-helpers/-/plugin-helpers-2.4.2.tgz",
+      "integrity": "sha512-LJNvwAPv/sKtI3RnRDm+nPD+JeOfOuSOS4FFIpQCMUCyMnFcchV/CPTTv7tT12fLUpEg6XjuFfDBvOwndti30Q==",
+      "requires": {
+        "@graphql-tools/utils": "^8.5.2",
+        "change-case-all": "1.0.14",
+        "common-tags": "1.8.2",
+        "import-from": "4.0.0",
+        "lodash": "~4.17.0",
+        "tslib": "~2.3.0"
+      }
+    },
+    "@graphql-codegen/schema-ast": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/schema-ast/-/schema-ast-2.4.1.tgz",
+      "integrity": "sha512-bIWlKk/ShoVJfghA4Rt1OWnd34/dQmZM/vAe6fu6QKyOh44aAdqPtYQ2dbTyFXoknmu504etKJGEDllYNUJRfg==",
+      "requires": {
+        "@graphql-codegen/plugin-helpers": "^2.3.2",
+        "@graphql-tools/utils": "^8.1.1",
+        "tslib": "~2.3.0"
+      }
+    },
+    "@graphql-codegen/typescript": {
+      "version": "2.4.8",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/typescript/-/typescript-2.4.8.tgz",
+      "integrity": "sha512-tVsHIkuyenBany7c5IMU1yi4S1er2hgyXJGNY7PcyhpJMx0eChmbqz1VTiZxDEwi8mDBS2mn3TaSJMh6xuJM5g==",
+      "requires": {
+        "@graphql-codegen/plugin-helpers": "^2.4.0",
+        "@graphql-codegen/schema-ast": "^2.4.1",
+        "@graphql-codegen/visitor-plugin-common": "2.7.4",
+        "auto-bind": "~4.0.0",
+        "tslib": "~2.3.0"
+      }
+    },
+    "@graphql-codegen/visitor-plugin-common": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-2.7.4.tgz",
+      "integrity": "sha512-aaDoEudDD+B7DK/UwDSL2Fzej75N9hNJ3N8FQuTIeDyw6FNGWUxmkjVBLQGlzfnYfK8IYkdfYkrPn3Skq0pVxA==",
+      "requires": {
+        "@graphql-codegen/plugin-helpers": "^2.4.0",
+        "@graphql-tools/optimize": "^1.0.1",
+        "@graphql-tools/relay-operation-optimizer": "^6.3.7",
+        "@graphql-tools/utils": "^8.3.0",
+        "auto-bind": "~4.0.0",
+        "change-case-all": "1.0.14",
+        "dependency-graph": "^0.11.0",
+        "graphql-tag": "^2.11.0",
+        "parse-filepath": "^1.0.2",
+        "tslib": "~2.3.0"
+      }
+    },
+    "@graphql-tools/graphql-file-loader": {
+      "version": "7.3.7",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/graphql-file-loader/-/graphql-file-loader-7.3.7.tgz",
+      "integrity": "sha512-fwXLycYvabPhusGtYuFrOPbjeIvLWr6viGkQc9KmiBm2Z2kZrlNRNUlYkXXRzMoiqRkzqFJYhOgWDE7LsOnbjw==",
+      "requires": {
+        "@graphql-tools/import": "6.6.9",
+        "@graphql-tools/utils": "8.6.5",
+        "globby": "^11.0.3",
+        "tslib": "~2.3.0",
+        "unixify": "^1.0.0"
+      }
+    },
+    "@graphql-tools/import": {
+      "version": "6.6.9",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/import/-/import-6.6.9.tgz",
+      "integrity": "sha512-sKaLqvPmNLQlY4te+nnBhRrf5WBISoiyVkbriCLz0kHw805iHdJaU2KxUoHsRTR7WlYq0g9gzB0oVaRh99Q5aA==",
+      "requires": {
+        "@graphql-tools/utils": "8.6.5",
+        "resolve-from": "5.0.0",
+        "tslib": "~2.3.0"
+      },
+      "dependencies": {
+        "resolve-from": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+          "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="
+        }
+      }
+    },
+    "@graphql-tools/load": {
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/load/-/load-7.5.5.tgz",
+      "integrity": "sha512-qPasit140nwTbMQbFCfZcgaS7q/0+xMQGdkMGU11rtHt6/jMgJIKDUU8/fJGKltNY3EeHlEdVtZmggZD7Rr6bA==",
+      "requires": {
+        "@graphql-tools/schema": "8.3.5",
+        "@graphql-tools/utils": "8.6.5",
+        "p-limit": "3.1.0",
+        "tslib": "~2.3.0"
+      },
+      "dependencies": {
+        "p-limit": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+          "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+          "requires": {
+            "yocto-queue": "^0.1.0"
+          }
+        }
+      }
+    },
+    "@graphql-tools/merge": {
+      "version": "8.2.6",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-8.2.6.tgz",
+      "integrity": "sha512-dkwTm4czMISi/Io47IVvq2Fl9q4TIGKpJ0VZjuXYdEFkECyH6A5uwxZfPVandZG+gQs8ocFFoa6RisiUJLZrJw==",
+      "requires": {
+        "@graphql-tools/utils": "8.6.5",
+        "tslib": "~2.3.0"
+      }
+    },
+    "@graphql-tools/optimize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/optimize/-/optimize-1.2.0.tgz",
+      "integrity": "sha512-l0PTqgHeorQdeOizUor6RB49eOAng9+abSxiC5/aHRo6hMmXVaqv5eqndlmxCpx9BkgNb3URQbK+ZZHVktkP/g==",
+      "requires": {
+        "tslib": "~2.3.0"
+      }
+    },
+    "@graphql-tools/relay-operation-optimizer": {
+      "version": "6.4.5",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/relay-operation-optimizer/-/relay-operation-optimizer-6.4.5.tgz",
+      "integrity": "sha512-AB/eOfpjteO4Gt0is0U1TseDuFjs/DLV1N0cqF0t6TqQLNVBeWIw7yVb8jw7HIfg3jcKLj++8582lhvCsWMT5g==",
+      "requires": {
+        "@graphql-tools/utils": "8.6.5",
+        "relay-compiler": "12.0.0",
+        "tslib": "~2.3.0"
+      }
+    },
+    "@graphql-tools/schema": {
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-8.3.5.tgz",
+      "integrity": "sha512-3mJ/K7TdL+fnEUtCUqF4qkh1fcNMzaxgwKgO9fSYSTS7zyT16hbi5XSulSTshygHgaD2u+MO588iR4ZJcbZcIg==",
+      "requires": {
+        "@graphql-tools/merge": "8.2.6",
+        "@graphql-tools/utils": "8.6.5",
+        "tslib": "~2.3.0",
+        "value-or-promise": "1.0.11"
+      }
+    },
+    "@graphql-tools/utils": {
+      "version": "8.6.5",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.6.5.tgz",
+      "integrity": "sha512-mjOtaWiS2WIqRz/cq5gaeM3sVrllcu2xbtHROw1su1v3xWa3D3dKgn8Lrl7+tvWs5WUVySsBss/VZ3WdoPkCrA==",
+      "requires": {
+        "tslib": "~2.3.0"
+      }
+    },
     "@graphql-typed-document-node/core": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.1.1.tgz",
@@ -290,6 +1209,25 @@
       "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
       "dev": true
+    },
+    "@jridgewell/resolve-uri": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.5.tgz",
+      "integrity": "sha512-VPeQ7+wH0itvQxnG+lIzWgkysKIr3L9sslimFW55rHMdGu/qCQ5z5h9zq4gI8uBtqkpHhsF4Z/OwExufUCThew=="
+    },
+    "@jridgewell/sourcemap-codec": {
+      "version": "1.4.11",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.11.tgz",
+      "integrity": "sha512-Fg32GrJo61m+VqYSdRSjRXMjQ06j8YIYfcTqndLYVAaHmroZHLJZCydsWBOTDqXS2v+mjxohBWEMfg97GXmYQg=="
+    },
+    "@jridgewell/trace-mapping": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.4.tgz",
+      "integrity": "sha512-vFv9ttIedivx0ux3QSjhgtCVjPZd5l46ZOMDSCwnH1yUO2e964gO8LZGyv2QkqcgR6TnBU1v+1IFqmeoG+0UJQ==",
+      "requires": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
     },
     "@next/env": {
       "version": "12.0.10",
@@ -391,7 +1329,6 @@
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
       "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-      "dev": true,
       "requires": {
         "@nodelib/fs.stat": "2.0.5",
         "run-parallel": "^1.1.9"
@@ -400,14 +1337,12 @@
     "@nodelib/fs.stat": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
-      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-      "dev": true
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A=="
     },
     "@nodelib/fs.walk": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
       "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-      "dev": true,
       "requires": {
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
@@ -560,6 +1495,272 @@
         "@styled-system/core": "^5.1.2",
         "@styled-system/css": "^5.1.5"
       }
+    },
+    "@takeshape/cli": {
+      "version": "8.115.0",
+      "resolved": "https://registry.npmjs.org/@takeshape/cli/-/cli-8.115.0.tgz",
+      "integrity": "sha512-A9wm2wDOldoUS6UygOygEoWLYTKGD4hB6GASlMb5pym2FWkYKaOBaboxIWiGRysu70OuHscfg5BRwGPMXvxqXw==",
+      "requires": {
+        "@graphql-codegen/core": "^2.5.1",
+        "@graphql-codegen/plugin-helpers": "^2.4.1",
+        "@graphql-codegen/typescript": "^2.4.5",
+        "@graphql-tools/graphql-file-loader": "^7.3.3",
+        "@graphql-tools/load": "^7.5.1",
+        "@takeshape/schema": "8.115.0",
+        "@takeshape/ssg": "8.115.0",
+        "@takeshape/streams": "8.115.0",
+        "@takeshape/util": "8.115.0",
+        "archiver": "^1.3.0",
+        "async-retry": "^1.2.1",
+        "bluebird": "^3.4.6",
+        "chalk": "^2.4.2",
+        "chokidar": "^2.1.5",
+        "commander": "^2.9.0",
+        "dotenv": "^6.0.0",
+        "dotenv-stringify": "^1.0.0",
+        "email-validator": "^2.0.4",
+        "fs-extra": "^7.0.1",
+        "get-port": "^5.1.1",
+        "glob": "^7.1.2",
+        "ignore": "^5.1.8",
+        "inquirer": "^7.3.3",
+        "is-docker": "^2.1.1",
+        "jsonwebtoken": "^8.1.1",
+        "lodash": "^4.17.20",
+        "lokka": "^1.7.0",
+        "lokka-transport-http": "^1.6.1",
+        "meow": "^9.0.0",
+        "node-fetch": "^2.6.1",
+        "object-hash": "^1.3.1",
+        "open": "^7.0.3",
+        "ora": "^3.4.0",
+        "pretty-bytes": "^5.3.0",
+        "pusher-client": "^1.1.0",
+        "request": "^2.88.0",
+        "semver": "^6.3.0",
+        "stream-to-promise": "^2.2.0",
+        "tmp": "^0.0.33"
+      },
+      "dependencies": {
+        "node-fetch": {
+          "version": "2.6.7",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+          "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+          "requires": {
+            "whatwg-url": "^5.0.0"
+          }
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+        }
+      }
+    },
+    "@takeshape/errors": {
+      "version": "8.115.0",
+      "resolved": "https://registry.npmjs.org/@takeshape/errors/-/errors-8.115.0.tgz",
+      "integrity": "sha512-5UZi9+zc1m9vGkucxJMISnptT5YO+2ksD+PoYh/4BFkCS6Y8zlVVJQJ3A8mtOUG3crKZByBGlVzyvYX2U3rygA==",
+      "requires": {
+        "es6-error": "^3.0.0"
+      }
+    },
+    "@takeshape/json-schema": {
+      "version": "8.115.0",
+      "resolved": "https://registry.npmjs.org/@takeshape/json-schema/-/json-schema-8.115.0.tgz",
+      "integrity": "sha512-1UE3//PX1RV8Y7OpcLlNNfCz+RZT67ZMCi41gI1tLuQFuSLzvWf6xQZNWMatl0YhNIs5sJDuRDyUngl/rx+I1g==",
+      "requires": {
+        "@takeshape/util": "8.115.0",
+        "ajv": "^8.11.0",
+        "ajv-formats": "^2.1.1",
+        "lodash": "^4.17.21"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "8.11.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+          "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "json-schema-traverse": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+        }
+      }
+    },
+    "@takeshape/routing": {
+      "version": "8.115.0",
+      "resolved": "https://registry.npmjs.org/@takeshape/routing/-/routing-8.115.0.tgz",
+      "integrity": "sha512-ysPdIAiMOqczLlv5fL2Ka9meGggQWXo6qc1dWT4U8m/tJPCFQokfRXcSE+J7bf6UX649tQ6ogwWWvQpU8UzX0w==",
+      "requires": {
+        "lodash": "^4.17.20",
+        "query-string": "^6.5.0",
+        "slugg": "^1.1.0"
+      }
+    },
+    "@takeshape/schema": {
+      "version": "8.115.0",
+      "resolved": "https://registry.npmjs.org/@takeshape/schema/-/schema-8.115.0.tgz",
+      "integrity": "sha512-/VwIVatvbf0KQHnA2HyT+eGUVJ8J4THyqtea7ETcVPMUQ5mO+w7q+SRN1xlPflmxUvAwz8pvkSZmWk/zm4D2dA==",
+      "requires": {
+        "@takeshape/errors": "8.115.0",
+        "@takeshape/json-schema": "8.115.0",
+        "@takeshape/util": "8.115.0",
+        "ajv": "^8.10.0",
+        "ajv-formats": "^2.1.1",
+        "blueimp-md5": "^2.10.0",
+        "lodash": "^4.17.20",
+        "minimatch": "^3.0.4",
+        "p-reduce": "^2.1.0",
+        "semver": "^7.3.2"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "8.11.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+          "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "json-schema-traverse": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+        }
+      }
+    },
+    "@takeshape/ssg": {
+      "version": "8.115.0",
+      "resolved": "https://registry.npmjs.org/@takeshape/ssg/-/ssg-8.115.0.tgz",
+      "integrity": "sha512-IBT4xLhYJFGS5y9YxWulETarqIKoPma7MQygLanZuZw98WSc8tMFm5CM5iWisRIiEIU/ETrD+gVmD0BSSCPaVA==",
+      "requires": {
+        "@takeshape/routing": "8.115.0",
+        "@takeshape/streams": "8.115.0",
+        "@takeshape/util": "8.115.0",
+        "@takeshape/vm-nunjucks": "^0.3.1",
+        "async-iterator-to-stream": "^1.2.0",
+        "bluebird": "^3.7.2",
+        "commonmark": "^0.29.3",
+        "d3-format": "^1.3.2",
+        "es6-error": "^4.1.1",
+        "fs-extra": "^9.0.1",
+        "graphql": "15.6.0",
+        "js-yaml": "^3.14.1",
+        "json-variables": "^10.0.5",
+        "lodash": "^4.17.20",
+        "minimize": "^2.2.0",
+        "moment": "^2.29.1",
+        "moment-timezone": "^0.5.32",
+        "node-fetch": "^2.6.1",
+        "pluralize": "^8.0.0",
+        "prismjs": "^1.22.0",
+        "pumpify": "^2.0.1",
+        "resolve": "^1.19.0"
+      },
+      "dependencies": {
+        "argparse": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+          "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+          "requires": {
+            "sprintf-js": "~1.0.2"
+          }
+        },
+        "es6-error": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
+          "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg=="
+        },
+        "fs-extra": {
+          "version": "9.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+          "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+          "requires": {
+            "at-least-node": "^1.0.0",
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^2.0.0"
+          }
+        },
+        "graphql": {
+          "version": "15.6.0",
+          "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.6.0.tgz",
+          "integrity": "sha512-WJR872Zlc9hckiEPhXgyUftXH48jp2EjO5tgBBOyNMRJZ9fviL2mJBD6CAysk6N5S0r9BTs09Qk39nnJBkvOXQ=="
+        },
+        "js-yaml": {
+          "version": "3.14.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+          "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
+          }
+        },
+        "node-fetch": {
+          "version": "2.6.7",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+          "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+          "requires": {
+            "whatwg-url": "^5.0.0"
+          }
+        }
+      }
+    },
+    "@takeshape/streams": {
+      "version": "8.115.0",
+      "resolved": "https://registry.npmjs.org/@takeshape/streams/-/streams-8.115.0.tgz",
+      "integrity": "sha512-M/KnUW8Gwd3HYe3BedhCV5Z+9l++jqu3qLyzyIIXrKoBpf0UxtgHVZ9P9NYpox86jDUdht8UIajLf3ouYGx1NA==",
+      "requires": {
+        "bluebird": "^3.7.2",
+        "is-stream": "^2.0.0",
+        "p-queue": "^6.4.0",
+        "pump": "^3.0.0",
+        "through2": "^3.0.2"
+      }
+    },
+    "@takeshape/util": {
+      "version": "8.115.0",
+      "resolved": "https://registry.npmjs.org/@takeshape/util/-/util-8.115.0.tgz",
+      "integrity": "sha512-be3lT+UNAEGiy2tehJ5fSbRa4PGn5AIV2QTrrTgvOOkEN2Vc5llRxpWQ4Crl8eD+FQu0lGLE5wYNytiEVrtiRg==",
+      "requires": {
+        "@takeshape/routing": "8.115.0",
+        "@types/url-parse": "^1.4.4",
+        "aws-sdk": "2.1096.0",
+        "classnames": "^2.2.5",
+        "dom-serializer": "0.2.2",
+        "draft-js": "^0.11.7",
+        "htmlparser2": "^3.10.0",
+        "lodash": "^4.17.20",
+        "markdown-draft-js": "github:incompl/markdown-draft-js#deterministic-entity-keys-with-lib",
+        "mime-types": "^2.1.27",
+        "pify": "^5.0.0",
+        "prismjs": "^1.25.0",
+        "shortid": "^2.2.16",
+        "url-parse": "^1.5.3"
+      }
+    },
+    "@takeshape/vm-nunjucks": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@takeshape/vm-nunjucks/-/vm-nunjucks-0.3.1.tgz",
+      "integrity": "sha512-Vv9Jq6EV5nOlGr9RFkn3hciWeT4+rjHhvL920ktZXOZCp3b+raQTQI3HujnZIMufEB9qM+zbCmTDFTr6mZ4iiw==",
+      "requires": {
+        "@takeshape/vm2": "^3.9.5"
+      }
+    },
+    "@takeshape/vm2": {
+      "version": "3.9.5",
+      "resolved": "https://registry.npmjs.org/@takeshape/vm2/-/vm2-3.9.5.tgz",
+      "integrity": "sha512-5iOaNigjNS4IDEFvt4Go8JpP7HPVHDwxVi7vxdbALezXmgkwt257fNl1ad3WdXZi/M/4txGE1funVSA6vtb/ng=="
     },
     "@theme-ui/color": {
       "version": "0.13.1",
@@ -773,15 +1974,48 @@
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
       "dev": true
     },
+    "@types/minimist": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.2.tgz",
+      "integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ=="
+    },
     "@types/node": {
       "version": "17.0.14",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.14.tgz",
       "integrity": "sha512-SbjLmERksKOGzWzPNuW7fJM7fk3YXVTFiZWB/Hs99gwhk+/dnrQRPBQjPW9aO+fi1tAffi9PrwFvsmOKmDTyng=="
     },
+    "@types/normalize-package-data": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
+      "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw=="
+    },
     "@types/parse-json": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
       "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA=="
+    },
+    "@types/prop-types": {
+      "version": "15.7.4",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.4.tgz",
+      "integrity": "sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ==",
+      "dev": true
+    },
+    "@types/react": {
+      "version": "17.0.43",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.43.tgz",
+      "integrity": "sha512-8Q+LNpdxf057brvPu1lMtC5Vn7J119xrP1aq4qiaefNioQUYANF/CYeK4NsKorSZyUGJ66g0IM+4bbjwx45o2A==",
+      "dev": true,
+      "requires": {
+        "@types/prop-types": "*",
+        "@types/scheduler": "*",
+        "csstype": "^3.0.2"
+      }
+    },
+    "@types/scheduler": {
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
+      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
+      "dev": true
     },
     "@types/styled-system": {
       "version": "5.1.15",
@@ -790,6 +2024,11 @@
       "requires": {
         "csstype": "^3.0.2"
       }
+    },
+    "@types/url-parse": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/@types/url-parse/-/url-parse-1.4.8.tgz",
+      "integrity": "sha512-zqqcGKyNWgTLFBxmaexGUKQyWqeG7HjXj20EuQJSJWwXe54BjX0ihIo5cJB9yAQzH8dNugJ9GvkBYMjPXs/PJw=="
     },
     "@typescript-eslint/parser": {
       "version": "5.10.2",
@@ -889,7 +2128,6 @@
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "dev": true,
       "requires": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -897,11 +2135,51 @@
         "uri-js": "^4.2.2"
       }
     },
+    "ajv-formats": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+      "requires": {
+        "ajv": "^8.0.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "8.11.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+          "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "json-schema-traverse": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+        }
+      }
+    },
+    "ansi-escapes": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+      "requires": {
+        "type-fest": "^0.21.3"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "0.21.3",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+          "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w=="
+        }
+      }
+    },
     "ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
     },
     "ansi-styles": {
       "version": "3.2.1",
@@ -910,6 +2188,209 @@
       "requires": {
         "color-convert": "^1.9.0"
       }
+    },
+    "any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8="
+    },
+    "anymatch": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
+      "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
+      "requires": {
+        "micromatch": "^3.1.4",
+        "normalize-path": "^2.1.1"
+      },
+      "dependencies": {
+        "braces": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+          "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+          "requires": {
+            "arr-flatten": "^1.1.0",
+            "array-unique": "^0.3.2",
+            "extend-shallow": "^2.0.1",
+            "fill-range": "^4.0.0",
+            "isobject": "^3.0.1",
+            "repeat-element": "^1.1.2",
+            "snapdragon": "^0.8.1",
+            "snapdragon-node": "^2.0.1",
+            "split-string": "^3.0.2",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "fill-range": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+          "requires": {
+            "extend-shallow": "^2.0.1",
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1",
+            "to-regex-range": "^2.1.0"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "requires": {
+            "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "micromatch": {
+          "version": "3.1.10",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+          "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+          "requires": {
+            "arr-diff": "^4.0.0",
+            "array-unique": "^0.3.2",
+            "braces": "^2.3.1",
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "extglob": "^2.0.4",
+            "fragment-cache": "^0.2.1",
+            "kind-of": "^6.0.2",
+            "nanomatch": "^1.2.9",
+            "object.pick": "^1.3.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.2"
+          }
+        },
+        "to-regex-range": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+          "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+          "requires": {
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1"
+          }
+        }
+      }
+    },
+    "archiver": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/archiver/-/archiver-1.3.0.tgz",
+      "integrity": "sha1-TyGU1tj5nfP1MeaIHxTxXVX6ryI=",
+      "requires": {
+        "archiver-utils": "^1.3.0",
+        "async": "^2.0.0",
+        "buffer-crc32": "^0.2.1",
+        "glob": "^7.0.0",
+        "lodash": "^4.8.0",
+        "readable-stream": "^2.0.0",
+        "tar-stream": "^1.5.0",
+        "walkdir": "^0.0.11",
+        "zip-stream": "^1.1.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
+    },
+    "archiver-utils": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-1.3.0.tgz",
+      "integrity": "sha1-5QtMCccL89aA4y/xt5lOn52JUXQ=",
+      "requires": {
+        "glob": "^7.0.0",
+        "graceful-fs": "^4.1.0",
+        "lazystream": "^1.0.0",
+        "lodash": "^4.8.0",
+        "normalize-path": "^2.0.0",
+        "readable-stream": "^2.0.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
+    },
+    "argh": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/argh/-/argh-0.1.4.tgz",
+      "integrity": "sha1-PrTWEpc/xrbcbvM49W91nyrFw6Y="
     },
     "argparse": {
       "version": "2.0.1",
@@ -927,6 +2408,21 @@
         "@babel/runtime-corejs3": "^7.10.2"
       }
     },
+    "arr-diff": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+      "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
+    },
+    "arr-flatten": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
+    },
+    "arr-union": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+      "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
+    },
     "array-includes": {
       "version": "3.1.4",
       "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.4.tgz",
@@ -943,8 +2439,12 @@
     "array-union": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
-      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
-      "dev": true
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw=="
+    },
+    "array-unique": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+      "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
     },
     "array.prototype.flat": {
       "version": "1.2.5",
@@ -968,11 +2468,160 @@
         "es-abstract": "^1.19.0"
       }
     },
+    "arrayiffy-if-string": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/arrayiffy-if-string/-/arrayiffy-if-string-3.14.0.tgz",
+      "integrity": "sha512-pQQDnM+wOBvgElVGB8//y16IpZEsi3mU3jkjvhJCm3J7zSvRPlm/8Wl76gE1O9vnU1CWcz2u5JfsOLtD7yvuLw==",
+      "requires": {
+        "@babel/runtime": "^7.14.0"
+      }
+    },
+    "arrify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
+    },
+    "asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+    },
+    "asn1": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
+      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
+      "requires": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
+    "assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+    },
+    "assign-symbols": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
+      "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c="
+    },
+    "ast-get-values-by-key": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/ast-get-values-by-key/-/ast-get-values-by-key-3.1.0.tgz",
+      "integrity": "sha512-04J5hBbmFTvcw3/vhlV2JYz4ORUMAuz0Zgo9wijWwqYvt9TrMwJcNkcDyKhMRmKmXDzrj892EAM+j82fYPwciQ==",
+      "requires": {
+        "@babel/runtime": "^7.14.0",
+        "ast-monkey-traverse": "^2.1.0",
+        "lodash.clonedeep": "^4.5.0",
+        "matcher": "^4.0.0"
+      }
+    },
+    "ast-monkey-traverse": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ast-monkey-traverse/-/ast-monkey-traverse-2.1.0.tgz",
+      "integrity": "sha512-73CnVKu3Y5sWmwgKA1FaXkgFk80NoQ+q98kP6zCXoTEuRd6wdXdS3xOjrZc4fdRdM9E1aQ3PZ6oSWWYqOYXeCQ==",
+      "requires": {
+        "@babel/runtime": "^7.14.0",
+        "ast-monkey-util": "^1.4.0",
+        "lodash.clonedeep": "^4.5.0",
+        "lodash.isplainobject": "^4.0.6"
+      }
+    },
+    "ast-monkey-util": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/ast-monkey-util/-/ast-monkey-util-1.4.0.tgz",
+      "integrity": "sha512-GjdhxUtsWb/kbeGJzhHj7hnEWhxcaqkihAyxrE4hDiuYwcyU8CXG8YVZcF+WLp10dvZHdIcALQx7iye2HcyMZg==",
+      "requires": {
+        "@babel/runtime": "^7.14.0"
+      }
+    },
     "ast-types-flow": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
       "integrity": "sha1-9wtzXGvKGlycItmCw+Oef+ujva0=",
       "dev": true
+    },
+    "async": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+      "requires": {
+        "lodash": "^4.17.14"
+      }
+    },
+    "async-each": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
+      "integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ=="
+    },
+    "async-iterator-to-stream": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/async-iterator-to-stream/-/async-iterator-to-stream-1.2.0.tgz",
+      "integrity": "sha512-6R+mWdZgHpmXpvovdsl+/gidRgl0Wf18ADozWPA5isk9XBzJnzpVBH7qcZZbKG72eytJlNXBN3rWgmwzd4Wr8A==",
+      "requires": {
+        "readable-stream": "^3.0.5"
+      }
+    },
+    "async-retry": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
+      "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
+      "requires": {
+        "retry": "0.13.1"
+      }
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+    },
+    "at-least-node": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg=="
+    },
+    "atob": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
+      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
+    },
+    "auto-bind": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/auto-bind/-/auto-bind-4.0.0.tgz",
+      "integrity": "sha512-Hdw8qdNiqdJ8LqT0iK0sVzkFbzg6fhnQqqfWhBDxcHZvU75+B+ayzTy8x+k5Ix0Y92XOhOUlx74ps+bA6BeYMQ=="
+    },
+    "autolinker": {
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/autolinker/-/autolinker-3.15.0.tgz",
+      "integrity": "sha512-N/5Dk5AZnqL9k6kkHdFIGLm/0/rRuSnJwqYYhLCJjU7ZtiaJwCBzNTvjzy1zzJADngv/wvtHYcrPHytPnASeFA==",
+      "requires": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "aws-sdk": {
+      "version": "2.1096.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1096.0.tgz",
+      "integrity": "sha512-q+hotU57U8bGpz1pf5CkO4z630ay0xGJ9HedahKPZ0Xk3/X0GH+QFYPBWJ5IMTtO30bjfPH0zTaL2vJmMXLBrQ==",
+      "requires": {
+        "buffer": "4.9.2",
+        "events": "1.1.1",
+        "ieee754": "1.1.13",
+        "jmespath": "0.16.0",
+        "querystring": "0.2.0",
+        "sax": "1.2.1",
+        "url": "0.10.3",
+        "uuid": "3.3.2",
+        "xml2js": "0.4.19"
+      }
+    },
+    "aws-sign2": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+    },
+    "aws4": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
+      "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA=="
     },
     "axe-core": {
       "version": "4.4.0",
@@ -986,6 +2635,14 @@
       "integrity": "sha512-Td525n+iPOOyUQIeBfcASuG6uJsDOITl7Mds5gFyerkWiX7qhUTdYUBlSgNMyVqtSJqwpt1kXGLdUt6SykLMRA==",
       "dev": true
     },
+    "babel-plugin-dynamic-import-node": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.3.tgz",
+      "integrity": "sha512-jZVI+s9Zg3IqA/kdi0i6UDCybUI3aSBLnglhYbSSjKlV7yF1F/5LWv8MakQmvYpnbJDS6fcBL2KzHSxNCMtWSQ==",
+      "requires": {
+        "object.assign": "^4.1.0"
+      }
+    },
     "babel-plugin-macros": {
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-2.8.0.tgz",
@@ -996,17 +2653,209 @@
         "resolve": "^1.12.0"
       }
     },
+    "babel-plugin-syntax-trailing-function-commas": {
+      "version": "7.0.0-beta.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-7.0.0-beta.0.tgz",
+      "integrity": "sha512-Xj9XuRuz3nTSbaTXWv3itLOcxyF4oPD8douBBmj7U9BBC6nEBYfyOJYQMf/8PJAFotC62UY5dFfIGEPr7WswzQ=="
+    },
+    "babel-preset-fbjs": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-fbjs/-/babel-preset-fbjs-3.4.0.tgz",
+      "integrity": "sha512-9ywCsCvo1ojrw0b+XYk7aFvTH6D9064t0RIL1rtMf3nsa02Xw41MS7sZw216Im35xj/UY0PDBQsa1brUDDF1Ow==",
+      "requires": {
+        "@babel/plugin-proposal-class-properties": "^7.0.0",
+        "@babel/plugin-proposal-object-rest-spread": "^7.0.0",
+        "@babel/plugin-syntax-class-properties": "^7.0.0",
+        "@babel/plugin-syntax-flow": "^7.0.0",
+        "@babel/plugin-syntax-jsx": "^7.0.0",
+        "@babel/plugin-syntax-object-rest-spread": "^7.0.0",
+        "@babel/plugin-transform-arrow-functions": "^7.0.0",
+        "@babel/plugin-transform-block-scoped-functions": "^7.0.0",
+        "@babel/plugin-transform-block-scoping": "^7.0.0",
+        "@babel/plugin-transform-classes": "^7.0.0",
+        "@babel/plugin-transform-computed-properties": "^7.0.0",
+        "@babel/plugin-transform-destructuring": "^7.0.0",
+        "@babel/plugin-transform-flow-strip-types": "^7.0.0",
+        "@babel/plugin-transform-for-of": "^7.0.0",
+        "@babel/plugin-transform-function-name": "^7.0.0",
+        "@babel/plugin-transform-literals": "^7.0.0",
+        "@babel/plugin-transform-member-expression-literals": "^7.0.0",
+        "@babel/plugin-transform-modules-commonjs": "^7.0.0",
+        "@babel/plugin-transform-object-super": "^7.0.0",
+        "@babel/plugin-transform-parameters": "^7.0.0",
+        "@babel/plugin-transform-property-literals": "^7.0.0",
+        "@babel/plugin-transform-react-display-name": "^7.0.0",
+        "@babel/plugin-transform-react-jsx": "^7.0.0",
+        "@babel/plugin-transform-shorthand-properties": "^7.0.0",
+        "@babel/plugin-transform-spread": "^7.0.0",
+        "@babel/plugin-transform-template-literals": "^7.0.0",
+        "babel-plugin-syntax-trailing-function-commas": "^7.0.0-beta.0"
+      }
+    },
+    "babel-runtime": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+      "requires": {
+        "core-js": "^2.4.0",
+        "regenerator-runtime": "^0.11.0"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "2.6.12",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
+          "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ=="
+        },
+        "regenerator-runtime": {
+          "version": "0.11.1",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+          "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+        }
+      }
+    },
     "balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+    },
+    "base": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
+      "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+      "requires": {
+        "cache-base": "^1.0.1",
+        "class-utils": "^0.3.5",
+        "component-emitter": "^1.2.1",
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.1",
+        "mixin-deep": "^1.2.0",
+        "pascalcase": "^0.1.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "requires": {
+            "is-descriptor": "^1.0.0"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        }
+      }
+    },
+    "base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+    },
+    "bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+      "requires": {
+        "tweetnacl": "^0.14.3"
+      }
+    },
+    "binary-extensions": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
+      "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw=="
+    },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "bl": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.3.tgz",
+      "integrity": "sha512-pvcNpa0UU69UT341rO6AYy4FVAIkUHuZXRIWbq+zHnsVcRzDDjIAhGuuYoi0d//cwIwtt4pkpKycWEfjdV+vww==",
+      "requires": {
+        "readable-stream": "^2.3.5",
+        "safe-buffer": "^5.1.1"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          },
+          "dependencies": {
+            "safe-buffer": {
+              "version": "5.1.2",
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+            }
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          },
+          "dependencies": {
+            "safe-buffer": {
+              "version": "5.1.2",
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+            }
+          }
+        }
+      }
+    },
+    "bluebird": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
+    },
+    "blueimp-md5": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/blueimp-md5/-/blueimp-md5-2.19.0.tgz",
+      "integrity": "sha512-DRQrD6gJyy8FbiE4s+bDoXS9hiW3Vbx5uCdwvcCf3zLHL+Iv7LtGHLpr+GZV8rHG8tK766FGYBwRbu8pELTt+w=="
     },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -1016,7 +2865,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
       "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-      "dev": true,
       "requires": {
         "fill-range": "^7.0.1"
       }
@@ -1027,6 +2875,88 @@
       "integrity": "sha512-J8K9vdivK0Di+b8SBdE7EZxDr88TnATing7XoLw6+nFkXMQ6sVBh92K3NQvZlZU91AIkFRi0w3sztk5Z+vsswA==",
       "requires": {
         "lodash": ">=4.17.21"
+      }
+    },
+    "browserslist": {
+      "version": "4.20.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.20.2.tgz",
+      "integrity": "sha512-CQOBCqp/9pDvDbx3xfMi+86pr4KXIf2FDkTTdeuYw8OxS9t898LA1Khq57gtufFILXpfgsSx5woNgsBgvGjpsA==",
+      "requires": {
+        "caniuse-lite": "^1.0.30001317",
+        "electron-to-chromium": "^1.4.84",
+        "escalade": "^3.1.1",
+        "node-releases": "^2.0.2",
+        "picocolors": "^1.0.0"
+      },
+      "dependencies": {
+        "caniuse-lite": {
+          "version": "1.0.30001320",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001320.tgz",
+          "integrity": "sha512-MWPzG54AGdo3nWx7zHZTefseM5Y1ccM7hlQKHRqJkPozUaw3hNbBTMmLn16GG2FUzjR13Cr3NPfhIieX5PzXDA=="
+        }
+      }
+    },
+    "bser": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
+      "integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
+      "requires": {
+        "node-int64": "^0.4.0"
+      }
+    },
+    "buffer": {
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
+      "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
+      "requires": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
+      }
+    },
+    "buffer-alloc": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
+      "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
+      "requires": {
+        "buffer-alloc-unsafe": "^1.1.0",
+        "buffer-fill": "^1.0.0"
+      }
+    },
+    "buffer-alloc-unsafe": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
+      "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg=="
+    },
+    "buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="
+    },
+    "buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
+    },
+    "buffer-fill": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
+      "integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw="
+    },
+    "cache-base": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
+      "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+      "requires": {
+        "collection-visit": "^1.0.0",
+        "component-emitter": "^1.2.1",
+        "get-value": "^2.0.6",
+        "has-value": "^1.0.0",
+        "isobject": "^3.0.1",
+        "set-value": "^2.0.0",
+        "to-object-path": "^0.3.0",
+        "union-value": "^1.0.0",
+        "unset-value": "^1.0.0"
       }
     },
     "call-bind": {
@@ -1043,10 +2973,49 @@
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="
     },
+    "camel-case": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz",
+      "integrity": "sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==",
+      "requires": {
+        "pascal-case": "^3.1.2",
+        "tslib": "^2.0.3"
+      }
+    },
+    "camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
+    },
+    "camelcase-keys": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-6.2.2.tgz",
+      "integrity": "sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==",
+      "requires": {
+        "camelcase": "^5.3.1",
+        "map-obj": "^4.0.0",
+        "quick-lru": "^4.0.1"
+      }
+    },
     "caniuse-lite": {
       "version": "1.0.30001305",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001305.tgz",
       "integrity": "sha512-p7d9YQMji8haf0f+5rbcv9WlQ+N5jMPfRAnUmZRlNxsNeBO3Yr7RYG6M2uTY1h9tCVdlkJg6YNNc4kiAiBLdWA=="
+    },
+    "capital-case": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/capital-case/-/capital-case-1.0.4.tgz",
+      "integrity": "sha512-ds37W8CytHgwnhGGTi88pcPyR15qoNkOpYwmMMfnWqqWgESapLqvDx6huFjQ5vqWSn2Z06173XNA7LtMOeUh1A==",
+      "requires": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3",
+        "upper-case-first": "^2.0.2"
+      }
+    },
+    "caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
     "chalk": {
       "version": "2.4.2",
@@ -1056,6 +3025,250 @@
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
         "supports-color": "^5.3.0"
+      }
+    },
+    "change-case": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/change-case/-/change-case-4.1.2.tgz",
+      "integrity": "sha512-bSxY2ws9OtviILG1EiY5K7NNxkqg/JnRnFxLtKQ96JaviiIxi7djMrSd0ECT9AC+lttClmYwKw53BWpOMblo7A==",
+      "requires": {
+        "camel-case": "^4.1.2",
+        "capital-case": "^1.0.4",
+        "constant-case": "^3.0.4",
+        "dot-case": "^3.0.4",
+        "header-case": "^2.0.4",
+        "no-case": "^3.0.4",
+        "param-case": "^3.0.4",
+        "pascal-case": "^3.1.2",
+        "path-case": "^3.0.4",
+        "sentence-case": "^3.0.4",
+        "snake-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "change-case-all": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/change-case-all/-/change-case-all-1.0.14.tgz",
+      "integrity": "sha512-CWVm2uT7dmSHdO/z1CXT/n47mWonyypzBbuCy5tN7uMg22BsfkhwT6oHmFCAk+gL1LOOxhdbB9SZz3J1KTY3gA==",
+      "requires": {
+        "change-case": "^4.1.2",
+        "is-lower-case": "^2.0.2",
+        "is-upper-case": "^2.0.2",
+        "lower-case": "^2.0.2",
+        "lower-case-first": "^2.0.2",
+        "sponge-case": "^1.0.1",
+        "swap-case": "^2.0.2",
+        "title-case": "^3.0.3",
+        "upper-case": "^2.0.2",
+        "upper-case-first": "^2.0.2"
+      }
+    },
+    "chardet": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="
+    },
+    "chokidar": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
+      "integrity": "sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==",
+      "requires": {
+        "anymatch": "^2.0.0",
+        "async-each": "^1.0.1",
+        "braces": "^2.3.2",
+        "fsevents": "^1.2.7",
+        "glob-parent": "^3.1.0",
+        "inherits": "^2.0.3",
+        "is-binary-path": "^1.0.0",
+        "is-glob": "^4.0.0",
+        "normalize-path": "^3.0.0",
+        "path-is-absolute": "^1.0.0",
+        "readdirp": "^2.2.1",
+        "upath": "^1.1.1"
+      },
+      "dependencies": {
+        "braces": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+          "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+          "requires": {
+            "arr-flatten": "^1.1.0",
+            "array-unique": "^0.3.2",
+            "extend-shallow": "^2.0.1",
+            "fill-range": "^4.0.0",
+            "isobject": "^3.0.1",
+            "repeat-element": "^1.1.2",
+            "snapdragon": "^0.8.1",
+            "snapdragon-node": "^2.0.1",
+            "split-string": "^3.0.2",
+            "to-regex": "^3.0.1"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        },
+        "fill-range": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+          "requires": {
+            "extend-shallow": "^2.0.1",
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1",
+            "to-regex-range": "^2.1.0"
+          }
+        },
+        "glob-parent": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+          "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+          "requires": {
+            "is-glob": "^3.1.0",
+            "path-dirname": "^1.0.0"
+          },
+          "dependencies": {
+            "is-glob": {
+              "version": "3.1.0",
+              "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+              "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+              "requires": {
+                "is-extglob": "^2.1.0"
+              }
+            }
+          }
+        },
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "requires": {
+            "kind-of": "^3.0.2"
+          }
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        },
+        "normalize-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+          "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
+        },
+        "to-regex-range": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+          "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+          "requires": {
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1"
+          }
+        }
+      }
+    },
+    "class-utils": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
+      "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+      "requires": {
+        "arr-union": "^3.1.0",
+        "define-property": "^0.2.5",
+        "isobject": "^3.0.0",
+        "static-extend": "^0.1.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        }
+      }
+    },
+    "classnames": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz",
+      "integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA=="
+    },
+    "cli-color": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-1.4.0.tgz",
+      "integrity": "sha512-xu6RvQqqrWEo6MPR1eixqGPywhYBHRs653F9jfXB2Hx4jdM/3WxiNE1vppRmxtMIfl16SFYTpYlrnqH/HsK/2w==",
+      "requires": {
+        "ansi-regex": "^2.1.1",
+        "d": "1",
+        "es5-ext": "^0.10.46",
+        "es6-iterator": "^2.0.3",
+        "memoizee": "^0.4.14",
+        "timers-ext": "^0.1.5"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+        }
+      }
+    },
+    "cli-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+      "requires": {
+        "restore-cursor": "^3.1.0"
+      }
+    },
+    "cli-spinners": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.6.1.tgz",
+      "integrity": "sha512-x/5fWmGMnbKQAaNwN+UZlV79qBLM9JFnJuJ03gIi5whrob0xV0ofNVHy9DhwGdsMJQc2OKv0oGmLzvaqvAVv+g=="
+    },
+    "cli-width": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
+      "integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw=="
+    },
+    "cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "requires": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      }
+    },
+    "clone": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+      "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
+    },
+    "collection-visit": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
+      "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+      "requires": {
+        "map-visit": "^1.0.0",
+        "object-visit": "^1.0.0"
+      }
+    },
+    "color": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/color/-/color-3.2.1.tgz",
+      "integrity": "sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==",
+      "requires": {
+        "color-convert": "^1.9.3",
+        "color-string": "^1.6.0"
       }
     },
     "color-convert": {
@@ -1071,11 +3284,124 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
+    "color-string": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.0.tgz",
+      "integrity": "sha512-9Mrz2AQLefkH1UvASKj6v6hj/7eWgjnT/cVsR8CumieLoT+g900exWeNogqtweI8dxloXN9BDQTYro1oWu/5CQ==",
+      "requires": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
+    },
+    "colornames": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/colornames/-/colornames-1.1.1.tgz",
+      "integrity": "sha1-+IiQMGhcfE/54qVZ9Qd+t2qBb5Y="
+    },
+    "colorspace": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.1.4.tgz",
+      "integrity": "sha512-BgvKJiuVu1igBUF2kEjRCZXol6wiiGbY5ipL/oVPwm0BL9sIpMIzM8IK7vwuxIIzOXMV3Ey5w+vxhm0rR/TN8w==",
+      "requires": {
+        "color": "^3.1.3",
+        "text-hex": "1.0.x"
+      }
+    },
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
+    },
+    "commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+    },
+    "common-tags": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.2.tgz",
+      "integrity": "sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA=="
+    },
+    "commonmark": {
+      "version": "0.29.3",
+      "resolved": "https://registry.npmjs.org/commonmark/-/commonmark-0.29.3.tgz",
+      "integrity": "sha512-fvt/NdOFKaL2gyhltSy6BC4LxbbxbnPxBMl923ittqO/JBM0wQHaoYZliE4tp26cRxX/ZZtRsJlZzQrVdUkXAA==",
+      "requires": {
+        "entities": "~2.0",
+        "mdurl": "~1.0.1",
+        "minimist": ">=1.2.2",
+        "string.prototype.repeat": "^0.2.0"
+      },
+      "dependencies": {
+        "entities": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.3.tgz",
+          "integrity": "sha512-MyoZ0jgnLvB2X3Lg5HqpFmn1kybDiIfEQmKzTb5apr51Rb+T3KdmMiqa70T+bhGnyv7bQ6WMj2QMHpGMmlrUYQ=="
+        }
+      }
+    },
+    "component-emitter": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
+      "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg=="
+    },
+    "compress-commons": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-1.2.2.tgz",
+      "integrity": "sha1-UkqfEJA/OoEzibAiXSfEi7dRiQ8=",
+      "requires": {
+        "buffer-crc32": "^0.2.1",
+        "crc32-stream": "^2.0.0",
+        "normalize-path": "^2.0.0",
+        "readable-stream": "^2.0.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "constant-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-3.0.4.tgz",
+      "integrity": "sha512-I2hSBi7Vvs7BEuJDr5dDHfzb/Ruj3FyvFyh7KLilAjNQw3Be+xgqUBA2W6scVEcL0hL1dwPRtIqEPVUCKkSsyQ==",
+      "requires": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3",
+        "upper-case": "^2.0.2"
+      }
     },
     "convert-source-map": {
       "version": "1.7.0",
@@ -1092,6 +3418,11 @@
         }
       }
     },
+    "copy-descriptor": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+      "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
+    },
     "core-js": {
       "version": "3.21.0",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.21.0.tgz",
@@ -1103,6 +3434,11 @@
       "integrity": "sha512-VaJUunCZLnxuDbo1rNOzwbet9E1K9joiXS5+DQMPtgxd24wfsZbJZMMfQLGYMlCUvSxLfsRUUhoOR2x28mFfeg==",
       "dev": true
     },
+    "core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
+    },
     "cosmiconfig": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-6.0.0.tgz",
@@ -1113,6 +3449,81 @@
         "parse-json": "^5.0.0",
         "path-type": "^4.0.0",
         "yaml": "^1.7.2"
+      }
+    },
+    "crc": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/crc/-/crc-3.8.0.tgz",
+      "integrity": "sha512-iX3mfgcTMIq3ZKLIsVFAbv7+Mc10kxabAGQb8HvjA1o3T1PIYprbakQ65d3I+2HGHt6nSKkM9PYjgoJO2KcFBQ==",
+      "requires": {
+        "buffer": "^5.1.0"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+          "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.1.13"
+          }
+        }
+      }
+    },
+    "crc32-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-2.0.0.tgz",
+      "integrity": "sha1-483TtN8xaN10494/u8t7KX/pCPQ=",
+      "requires": {
+        "crc": "^3.4.4",
+        "readable-stream": "^2.0.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
+    },
+    "cross-fetch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
+      "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
+      "requires": {
+        "node-fetch": "2.6.7"
+      },
+      "dependencies": {
+        "node-fetch": {
+          "version": "2.6.7",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+          "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+          "requires": {
+            "whatwg-url": "^5.0.0"
+          }
+        }
       }
     },
     "cross-spawn": {
@@ -1131,11 +3542,33 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.10.tgz",
       "integrity": "sha512-2u44ZG2OcNUO9HDp/Jl8C07x6pU/eTR3ncV91SiK3dhG9TWvRVsCoJw14Ckx5DgWkzGA3waZWO3d7pgqpUI/XA=="
     },
+    "d": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
+      "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
+      "requires": {
+        "es5-ext": "^0.10.50",
+        "type": "^1.0.1"
+      }
+    },
+    "d3-format": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.4.5.tgz",
+      "integrity": "sha512-J0piedu6Z8iB6TbIGfZgDzfXxUFN3qQRMofy2oPdXzQibYGqPB/9iMcxr/TGalU+2RsyDO+U4f33id8tbnSRMQ=="
+    },
     "damerau-levenshtein": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
       "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
       "dev": true
+    },
+    "dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "requires": {
+        "assert-plus": "^1.0.0"
+      }
     },
     "data-uri-to-buffer": {
       "version": "4.0.0",
@@ -1151,10 +3584,35 @@
       "version": "4.3.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
       "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
-      "dev": true,
       "requires": {
         "ms": "2.1.2"
       }
+    },
+    "decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+    },
+    "decamelize-keys": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
+      "integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
+      "requires": {
+        "decamelize": "^1.1.0",
+        "map-obj": "^1.0.0"
+      },
+      "dependencies": {
+        "map-obj": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+          "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0="
+        }
+      }
+    },
+    "decode-uri-component": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
     },
     "deep-is": {
       "version": "0.1.4",
@@ -1167,20 +3625,83 @@
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
       "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg=="
     },
+    "defaults": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
+      "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
+      "requires": {
+        "clone": "^1.0.2"
+      }
+    },
     "define-properties": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
       "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
-      "dev": true,
       "requires": {
         "object-keys": "^1.0.12"
+      }
+    },
+    "define-property": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
+      "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+      "requires": {
+        "is-descriptor": "^1.0.2",
+        "isobject": "^3.0.1"
+      },
+      "dependencies": {
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        }
+      }
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+    },
+    "dependency-graph": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/dependency-graph/-/dependency-graph-0.11.0.tgz",
+      "integrity": "sha512-JeMq7fEshyepOWDfcfHK06N3MhyPhz++vtqWhMT5O9A3K42rdsEDpfdVqjaqaAhsw6a+ZqeDvQVtD0hFHQWrzg=="
+    },
+    "diagnostics": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/diagnostics/-/diagnostics-1.1.1.tgz",
+      "integrity": "sha512-8wn1PmdunLJ9Tqbx+Fx/ZEuHfJf4NKSN2ZBj7SJC/OWRWha843+WsTjqMe1B5E3p28jqBlp+mJ2fPVxPyNgYKQ==",
+      "requires": {
+        "colorspace": "1.1.x",
+        "enabled": "1.0.x",
+        "kuler": "1.0.x"
       }
     },
     "dir-glob": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
       "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
-      "dev": true,
       "requires": {
         "path-type": "^4.0.0"
       }
@@ -1194,11 +3715,192 @@
         "esutils": "^2.0.2"
       }
     },
+    "dom-serializer": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.2.2.tgz",
+      "integrity": "sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g==",
+      "requires": {
+        "domelementtype": "^2.0.1",
+        "entities": "^2.0.0"
+      }
+    },
+    "domelementtype": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.2.0.tgz",
+      "integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A=="
+    },
+    "domhandler": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
+      "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
+      "requires": {
+        "domelementtype": "1"
+      },
+      "dependencies": {
+        "domelementtype": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
+          "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w=="
+        }
+      }
+    },
+    "domutils": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.7.0.tgz",
+      "integrity": "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==",
+      "requires": {
+        "dom-serializer": "0",
+        "domelementtype": "1"
+      },
+      "dependencies": {
+        "domelementtype": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
+          "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w=="
+        }
+      }
+    },
+    "dot-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
+      "integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
+      "requires": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "dotenv": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-6.2.0.tgz",
+      "integrity": "sha512-HygQCKUBSFl8wKQZBSemMywRWcEDNidvNbjGVyZu3nbZ8qq9ubiPoGLMdRDpfSrpkkm9BXYFkpKxxFX38o/76w=="
+    },
+    "dotenv-stringify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv-stringify/-/dotenv-stringify-1.0.0.tgz",
+      "integrity": "sha1-HrjFuqoVfh45yOKEbo1LJu7zAyE=",
+      "requires": {
+        "babel-runtime": "^6.20.0"
+      }
+    },
+    "draft-js": {
+      "version": "0.11.7",
+      "resolved": "https://registry.npmjs.org/draft-js/-/draft-js-0.11.7.tgz",
+      "integrity": "sha512-ne7yFfN4sEL82QPQEn80xnADR8/Q6ALVworbC5UOSzOvjffmYfFsr3xSZtxbIirti14R7Y33EZC5rivpLgIbsg==",
+      "requires": {
+        "fbjs": "^2.0.0",
+        "immutable": "~3.7.4",
+        "object-assign": "^4.1.1"
+      },
+      "dependencies": {
+        "fbjs": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-2.0.0.tgz",
+          "integrity": "sha512-8XA8ny9ifxrAWlyhAbexXcs3rRMtxWcs3M0lctLfB49jRDHiaxj+Mo0XxbwE7nKZYzgCFoq64FS+WFd4IycPPQ==",
+          "requires": {
+            "core-js": "^3.6.4",
+            "cross-fetch": "^3.0.4",
+            "fbjs-css-vars": "^1.0.0",
+            "loose-envify": "^1.0.0",
+            "object-assign": "^4.1.0",
+            "promise": "^7.1.1",
+            "setimmediate": "^1.0.5",
+            "ua-parser-js": "^0.7.18"
+          }
+        }
+      }
+    },
+    "duplexify": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.2.tgz",
+      "integrity": "sha512-fz3OjcNCHmRP12MJoZMPglx8m4rrFP8rovnk4vT8Fs+aonZoCwGg10dSsQsfP/E62eZcPTMSMP6686fu9Qlqtw==",
+      "requires": {
+        "end-of-stream": "^1.4.1",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1",
+        "stream-shift": "^1.0.0"
+      }
+    },
+    "ecc-jsbn": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+      "requires": {
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
+    "ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "electron-to-chromium": {
+      "version": "1.4.94",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.94.tgz",
+      "integrity": "sha512-CoOKsuACoa0PAG3hQXxbh/XDiFcjGuSyGKUi09cjMHOt6RCi7/EXgXhaFF3I+aC89Omudqmkzd0YOQKxwtf/Bg=="
+    },
+    "email-validator": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/email-validator/-/email-validator-2.0.4.tgz",
+      "integrity": "sha512-gYCwo7kh5S3IDyZPLZf6hSS0MnZT8QmJFqYvbqlDZSbwdZlY6QZWxJ4i/6UhITOJ4XzyI647Bm2MXKCLqnJ4nQ=="
+    },
+    "emits": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/emits/-/emits-3.0.0.tgz",
+      "integrity": "sha1-MnUrupXhcHshlWI4Srm7ix/WL3A="
+    },
     "emoji-regex": {
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true
+    },
+    "enabled": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/enabled/-/enabled-1.0.2.tgz",
+      "integrity": "sha1-ll9lE9LC0cX0ZStkouM5ZGf8L5M=",
+      "requires": {
+        "env-variable": "0.0.x"
+      }
+    },
+    "encoding": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "requires": {
+        "iconv-lite": "^0.6.2"
+      },
+      "dependencies": {
+        "iconv-lite": {
+          "version": "0.6.3",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+          "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3.0.0"
+          }
+        }
+      }
+    },
+    "end-of-stream": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "requires": {
+        "once": "^1.4.0"
+      }
+    },
+    "entities": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="
+    },
+    "env-variable": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/env-variable/-/env-variable-0.0.6.tgz",
+      "integrity": "sha512-bHz59NlBbtS0NhftmR8+ExBEekE7br0e01jw+kk0NDro7TtZzBYZ5ScGPs3OmwnpyfHTHOtr1Y6uedCdrIldtg=="
     },
     "error-ex": {
       "version": "1.3.2",
@@ -1251,6 +3953,56 @@
         "is-date-object": "^1.0.1",
         "is-symbol": "^1.0.2"
       }
+    },
+    "es5-ext": {
+      "version": "0.10.59",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.59.tgz",
+      "integrity": "sha512-cOgyhW0tIJyQY1Kfw6Kr0viu9ZlUctVchRMZ7R0HiH3dxTSp5zJDLecwxUqPUrGKMsgBI1wd1FL+d9Jxfi4cLw==",
+      "requires": {
+        "es6-iterator": "^2.0.3",
+        "es6-symbol": "^3.1.3",
+        "next-tick": "^1.1.0"
+      }
+    },
+    "es6-error": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-3.2.0.tgz",
+      "integrity": "sha1-5WfP3LMk1OeuWSKjcAraXeh5oMo="
+    },
+    "es6-iterator": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+      "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
+      "requires": {
+        "d": "1",
+        "es5-ext": "^0.10.35",
+        "es6-symbol": "^3.1.1"
+      }
+    },
+    "es6-symbol": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
+      "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
+      "requires": {
+        "d": "^1.0.1",
+        "ext": "^1.1.2"
+      }
+    },
+    "es6-weak-map": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.3.tgz",
+      "integrity": "sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==",
+      "requires": {
+        "d": "1",
+        "es5-ext": "^0.10.46",
+        "es6-iterator": "^2.0.3",
+        "es6-symbol": "^3.1.1"
+      }
+    },
+    "escalade": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw=="
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -1595,6 +4347,11 @@
         "eslint-visitor-keys": "^3.1.0"
       }
     },
+    "esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+    },
     "esquery": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
@@ -1625,17 +4382,197 @@
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
     },
+    "event-emitter": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
+      "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
+      "requires": {
+        "d": "1",
+        "es5-ext": "~0.10.14"
+      }
+    },
+    "eventemitter2": {
+      "version": "6.4.5",
+      "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.5.tgz",
+      "integrity": "sha512-bXE7Dyc1i6oQElDG0jMRZJrRAn9QR2xyyFGmBdZleNmyQX0FqGYmhZIrIrpPfm/w//LTo4tVQGOGQcGCb5q9uw=="
+    },
+    "eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
+    },
+    "events": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
+    },
+    "expand-brackets": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+      "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+      "requires": {
+        "debug": "^2.3.3",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "posix-character-classes": "^0.1.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
+      }
+    },
+    "ext": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/ext/-/ext-1.6.0.tgz",
+      "integrity": "sha512-sdBImtzkq2HpkdRLtlLWDa6w4DX22ijZLKx8BMPUuKe1c5lbN6xwQDQCxSfxBQnHZ13ls/FH0MQZx/q/gr6FQg==",
+      "requires": {
+        "type": "^2.5.0"
+      },
+      "dependencies": {
+        "type": {
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/type/-/type-2.6.0.tgz",
+          "integrity": "sha512-eiDBDOmkih5pMbo9OqsqPRGMljLodLcwd5XD5JbtNB0o89xZAwynY9EdCDsJU7LtcVCClu9DvM7/0Ep1hYX3EQ=="
+        }
+      }
+    },
+    "extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+    },
+    "extend-shallow": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+      "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+      "requires": {
+        "assign-symbols": "^1.0.0",
+        "is-extendable": "^1.0.1"
+      },
+      "dependencies": {
+        "is-extendable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "requires": {
+            "is-plain-object": "^2.0.4"
+          }
+        }
+      }
+    },
+    "external-editor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
+      "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
+      "requires": {
+        "chardet": "^0.7.0",
+        "iconv-lite": "^0.4.24",
+        "tmp": "^0.0.33"
+      }
+    },
+    "extglob": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+      "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+      "requires": {
+        "array-unique": "^0.3.2",
+        "define-property": "^1.0.0",
+        "expand-brackets": "^2.1.4",
+        "extend-shallow": "^2.0.1",
+        "fragment-cache": "^0.2.1",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "requires": {
+            "is-descriptor": "^1.0.0"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        }
+      }
+    },
+    "extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+    },
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "fast-glob": {
       "version": "3.2.11",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
       "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
-      "dev": true,
       "requires": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
@@ -1648,7 +4585,6 @@
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
           "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-          "dev": true,
           "requires": {
             "is-glob": "^4.0.1"
           }
@@ -1658,8 +4594,7 @@
     "fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "dev": true
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -1676,10 +4611,36 @@
       "version": "1.13.0",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
       "integrity": "sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==",
-      "dev": true,
       "requires": {
         "reusify": "^1.0.4"
       }
+    },
+    "fb-watchman": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.1.tgz",
+      "integrity": "sha512-DkPJKQeY6kKwmuMretBhr7G6Vodr7bFwDYTXIkfG1gjvNpaxBTQV3PbXg6bR1c1UP4jPOX0jHUbbHANL9vRjVg==",
+      "requires": {
+        "bser": "2.1.1"
+      }
+    },
+    "fbjs": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-3.0.4.tgz",
+      "integrity": "sha512-ucV0tDODnGV3JCnnkmoszb5lf4bNpzjv80K41wd4k798Etq+UYD0y0TIfalLjZoKgjive6/adkRnszwapiDgBQ==",
+      "requires": {
+        "cross-fetch": "^3.1.5",
+        "fbjs-css-vars": "^1.0.0",
+        "loose-envify": "^1.0.0",
+        "object-assign": "^4.1.0",
+        "promise": "^7.1.1",
+        "setimmediate": "^1.0.5",
+        "ua-parser-js": "^0.7.30"
+      }
+    },
+    "fbjs-css-vars": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/fbjs-css-vars/-/fbjs-css-vars-1.0.2.tgz",
+      "integrity": "sha512-b2XGFAFdWZWg0phtAWLHCk836A1Xann+I+Dgd3Gk64MHKZO44FfoD1KxyvbSh0qZsIoXQGGlVztIY+oitJPpRQ=="
     },
     "fetch-blob": {
       "version": "3.1.4",
@@ -1688,6 +4649,14 @@
       "requires": {
         "node-domexception": "^1.0.0",
         "web-streams-polyfill": "^3.0.3"
+      }
+    },
+    "figures": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
+      "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
+      "requires": {
+        "escape-string-regexp": "^1.0.5"
       }
     },
     "file-entry-cache": {
@@ -1699,14 +4668,24 @@
         "flat-cache": "^3.0.4"
       }
     },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "optional": true
+    },
     "fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
       "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-      "dev": true,
       "requires": {
         "to-regex-range": "^5.0.1"
       }
+    },
+    "filter-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-1.1.0.tgz",
+      "integrity": "sha1-mzERErxsYSehbgFsbF1/GeCAXFs="
     },
     "find-root": {
       "version": "1.1.0",
@@ -1738,6 +4717,26 @@
       "integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==",
       "dev": true
     },
+    "for-in": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
+    },
+    "forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+    },
+    "form-data": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
+      }
+    },
     "formdata-polyfill": {
       "version": "4.0.10",
       "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
@@ -1746,11 +4745,58 @@
         "fetch-blob": "^3.1.2"
       }
     },
+    "fragment-cache": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
+      "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+      "requires": {
+        "map-cache": "^0.2.2"
+      }
+    },
+    "fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
+    },
+    "fs-extra": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "dependencies": {
+        "jsonfile": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+          "requires": {
+            "graceful-fs": "^4.1.6"
+          }
+        },
+        "universalify": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+          "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
+        }
+      }
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
+    "fsevents": {
+      "version": "1.2.13",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
+      "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
+      "optional": true,
+      "requires": {
+        "bindings": "^1.5.0",
+        "nan": "^2.12.1"
+      }
     },
     "function-bind": {
       "version": "1.1.1",
@@ -1763,6 +4809,16 @@
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
     },
+    "gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="
+    },
+    "get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
+    },
     "get-intrinsic": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
@@ -1772,6 +4828,11 @@
         "has": "^1.0.3",
         "has-symbols": "^1.0.1"
       }
+    },
+    "get-port": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/get-port/-/get-port-5.1.1.tgz",
+      "integrity": "sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ=="
     },
     "get-symbol-description": {
       "version": "1.0.0",
@@ -1783,11 +4844,23 @@
         "get-intrinsic": "^1.1.1"
       }
     },
+    "get-value": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+      "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg="
+    },
+    "getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "requires": {
+        "assert-plus": "^1.0.0"
+      }
+    },
     "glob": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
       "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
-      "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -1819,7 +4892,6 @@
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
       "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
-      "dev": true,
       "requires": {
         "array-union": "^2.1.0",
         "dir-glob": "^3.0.1",
@@ -1828,6 +4900,11 @@
         "merge2": "^1.4.1",
         "slash": "^3.0.0"
       }
+    },
+    "graceful-fs": {
+      "version": "4.2.9",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.9.tgz",
+      "integrity": "sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ=="
     },
     "graphql": {
       "version": "16.3.0",
@@ -1841,6 +4918,25 @@
       "requires": {
         "tslib": "^2.1.0"
       }
+    },
+    "har-schema": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+    },
+    "har-validator": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
+      "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
+      "requires": {
+        "ajv": "^6.12.3",
+        "har-schema": "^2.0.0"
+      }
+    },
+    "hard-rejection": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/hard-rejection/-/hard-rejection-2.1.0.tgz",
+      "integrity": "sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA=="
     },
     "has": {
       "version": "1.0.3",
@@ -1875,6 +4971,62 @@
         "has-symbols": "^1.0.2"
       }
     },
+    "has-value": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
+      "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+      "requires": {
+        "get-value": "^2.0.6",
+        "has-values": "^1.0.0",
+        "isobject": "^3.0.0"
+      }
+    },
+    "has-values": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
+      "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+      "requires": {
+        "is-number": "^3.0.0",
+        "kind-of": "^4.0.0"
+      },
+      "dependencies": {
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "requires": {
+            "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "kind-of": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+          "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "header-case": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/header-case/-/header-case-2.0.4.tgz",
+      "integrity": "sha512-H/vuk5TEEVZwrR0lp2zed9OCo1uAILMlx0JEMgC26rzyJJ3N1v6XkwHHXJQdR2doSjcGPM6OKPYoJgf0plJ11Q==",
+      "requires": {
+        "capital-case": "^1.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
     "hoist-non-react-statics": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
@@ -1883,11 +5035,71 @@
         "react-is": "^16.7.0"
       }
     },
+    "hosted-git-info": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
+      "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
+      "requires": {
+        "lru-cache": "^6.0.0"
+      }
+    },
+    "htmlparser2": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz",
+      "integrity": "sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==",
+      "requires": {
+        "domelementtype": "^1.3.1",
+        "domhandler": "^2.3.0",
+        "domutils": "^1.5.1",
+        "entities": "^1.1.1",
+        "inherits": "^2.0.1",
+        "readable-stream": "^3.1.1"
+      },
+      "dependencies": {
+        "domelementtype": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
+          "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w=="
+        },
+        "entities": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
+          "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w=="
+        }
+      }
+    },
+    "http-signature": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
+      }
+    },
+    "iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "requires": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      }
+    },
+    "ieee754": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
+    },
     "ignore": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
-      "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
-      "dev": true
+      "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ=="
+    },
+    "immutable": {
+      "version": "3.7.6",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.7.6.tgz",
+      "integrity": "sha1-E7TTyxK++hVIKib+Gy665kAHHks="
     },
     "import-fresh": {
       "version": "3.3.0",
@@ -1898,17 +5110,26 @@
         "resolve-from": "^4.0.0"
       }
     },
+    "import-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/import-from/-/import-from-4.0.0.tgz",
+      "integrity": "sha512-P9J71vT5nLlDeV8FHs5nNxaLbrpfAV5cF5srvbZfpwpcJoM/xZR3hiv+q+SAnuSmuGbXMWud063iIMx/V/EWZQ=="
+    },
     "imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
       "dev": true
     },
+    "indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="
+    },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -1917,8 +5138,72 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "inquirer": {
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.3.3.tgz",
+      "integrity": "sha512-JG3eIAj5V9CwcGvuOmoo6LB9kbAYT8HXffUl6memuszlwDC/qvFAJw49XJ5NROSFNPxp3iQg1GqkFhaY/CR0IA==",
+      "requires": {
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.1.0",
+        "cli-cursor": "^3.1.0",
+        "cli-width": "^3.0.0",
+        "external-editor": "^3.0.3",
+        "figures": "^3.0.0",
+        "lodash": "^4.17.19",
+        "mute-stream": "0.0.8",
+        "run-async": "^2.4.0",
+        "rxjs": "^6.6.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "through": "^2.3.6"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
     },
     "internal-slot": {
       "version": "1.0.3",
@@ -1929,6 +5214,41 @@
         "get-intrinsic": "^1.1.0",
         "has": "^1.0.3",
         "side-channel": "^1.0.4"
+      }
+    },
+    "invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "requires": {
+        "loose-envify": "^1.0.0"
+      }
+    },
+    "is-absolute": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-1.0.0.tgz",
+      "integrity": "sha512-dOWoqflvcydARa360Gvv18DZ/gRuHKi2NU/wU5X1ZFzdYfH29nkiNZsF3mp4OJ3H4yo9Mx8A/uAGNzpzPN3yBA==",
+      "requires": {
+        "is-relative": "^1.0.0",
+        "is-windows": "^1.0.1"
+      }
+    },
+    "is-accessor-descriptor": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+      "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+      "requires": {
+        "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
       }
     },
     "is-arrayish": {
@@ -1945,6 +5265,14 @@
         "has-bigints": "^1.0.1"
       }
     },
+    "is-binary-path": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+      "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
+      "requires": {
+        "binary-extensions": "^1.0.0"
+      }
+    },
     "is-boolean-object": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
@@ -1954,6 +5282,11 @@
         "call-bind": "^1.0.2",
         "has-tostringtag": "^1.0.0"
       }
+    },
+    "is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
     },
     "is-callable": {
       "version": "1.2.4",
@@ -1969,6 +5302,24 @@
         "has": "^1.0.3"
       }
     },
+    "is-data-descriptor": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+      "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+      "requires": {
+        "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
     "is-date-object": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
@@ -1978,19 +5329,57 @@
         "has-tostringtag": "^1.0.0"
       }
     },
+    "is-descriptor": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+      "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+      "requires": {
+        "is-accessor-descriptor": "^0.1.6",
+        "is-data-descriptor": "^0.1.4",
+        "kind-of": "^5.0.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+        }
+      }
+    },
+    "is-docker": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ=="
+    },
+    "is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
+    },
     "is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-      "dev": true
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
+    },
+    "is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
     },
     "is-glob": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dev": true,
       "requires": {
         "is-extglob": "^2.1.1"
+      }
+    },
+    "is-lower-case": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-lower-case/-/is-lower-case-2.0.2.tgz",
+      "integrity": "sha512-bVcMJy4X5Og6VZfdOZstSexlEy20Sr0k/p/b2IlQJlfdKAQuMpiv5w2Ccxb8sKdRUNAG1PnHVHjFSdRDVS6NlQ==",
+      "requires": {
+        "tslib": "^2.0.3"
       }
     },
     "is-negative-zero": {
@@ -2002,8 +5391,7 @@
     "is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
     },
     "is-number-object": {
       "version": "1.0.6",
@@ -2013,6 +5401,24 @@
       "requires": {
         "has-tostringtag": "^1.0.0"
       }
+    },
+    "is-plain-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
+    },
+    "is-plain-object": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "requires": {
+        "isobject": "^3.0.1"
+      }
+    },
+    "is-promise": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
+      "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ=="
     },
     "is-regex": {
       "version": "1.1.4",
@@ -2024,11 +5430,24 @@
         "has-tostringtag": "^1.0.0"
       }
     },
+    "is-relative": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-1.0.0.tgz",
+      "integrity": "sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==",
+      "requires": {
+        "is-unc-path": "^1.0.0"
+      }
+    },
     "is-shared-array-buffer": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.1.tgz",
       "integrity": "sha512-IU0NmyknYZN0rChcKhRO1X8LYz5Isj/Fsqh8NJOSf+N/hCOTwy29F32Ik7a+QszE63IdvmwdTPDd6cZ5pg4cwA==",
       "dev": true
+    },
+    "is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="
     },
     "is-string": {
       "version": "1.0.7",
@@ -2048,6 +5467,27 @@
         "has-symbols": "^1.0.2"
       }
     },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+    },
+    "is-unc-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-1.0.0.tgz",
+      "integrity": "sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==",
+      "requires": {
+        "unc-path-regex": "^0.1.2"
+      }
+    },
+    "is-upper-case": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-upper-case/-/is-upper-case-2.0.2.tgz",
+      "integrity": "sha512-44pxmxAvnnAOwBg4tHPnkfvgjPwbc5QIsSstNU+YcJ1ovxVzCWpSGosPJOZh/a1tdl81fbgnLc9LLv+x2ywbPQ==",
+      "requires": {
+        "tslib": "^2.0.3"
+      }
+    },
     "is-weakref": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
@@ -2057,11 +5497,44 @@
         "call-bind": "^1.0.2"
       }
     },
+    "is-windows": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
+    },
+    "is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "requires": {
+        "is-docker": "^2.0.0"
+      }
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+    },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
+    },
+    "isobject": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+    },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+    },
+    "jmespath": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.16.0.tgz",
+      "integrity": "sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw=="
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -2077,22 +5550,59 @@
         "argparse": "^2.0.1"
       }
     },
+    "jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
+    },
+    "jsesc": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA=="
+    },
     "json-parse-even-better-errors": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
     },
+    "json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="
+    },
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+    },
+    "json-variables": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/json-variables/-/json-variables-10.1.0.tgz",
+      "integrity": "sha512-WounEri9srpu0pPncFeTMdaRxbE4IypB5b4NWGqdH07J99Bu4ZQ2ZdhVY7y3vnLFQue13h++rbyL2CE7piG9Ng==",
+      "requires": {
+        "@babel/runtime": "^7.14.0",
+        "arrayiffy-if-string": "^3.14.0",
+        "ast-get-values-by-key": "^3.1.0",
+        "ast-monkey-traverse": "^2.1.0",
+        "matcher": "^4.0.0",
+        "object-path": "^0.11.5",
+        "ranges-apply": "^5.1.0",
+        "ranges-push": "^5.1.0",
+        "string-find-heads-tails": "^4.1.0",
+        "string-match-left-right": "^7.1.0",
+        "string-remove-duplicate-heads-tails": "^5.1.0"
+      }
     },
     "json5": {
       "version": "1.0.1",
@@ -2103,6 +5613,50 @@
         "minimist": "^1.2.0"
       }
     },
+    "jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "requires": {
+        "graceful-fs": "^4.1.6",
+        "universalify": "^2.0.0"
+      }
+    },
+    "jsonwebtoken": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
+      "integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
+      "requires": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^5.6.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+        }
+      }
+    },
+    "jsprim": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
+      "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.4.0",
+        "verror": "1.10.0"
+      }
+    },
     "jsx-ast-utils": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.2.1.tgz",
@@ -2111,6 +5665,38 @@
       "requires": {
         "array-includes": "^3.1.3",
         "object.assign": "^4.1.2"
+      }
+    },
+    "jwa": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+      "requires": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "requires": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
+    },
+    "kuler": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/kuler/-/kuler-1.0.1.tgz",
+      "integrity": "sha512-J9nVUucG1p/skKul6DU3PUZrhs0LPulNaeUOox0IyXDi8S4CztTHs1gQphhuZmzXG7VOQSf6NJfKuzteQLv9gQ==",
+      "requires": {
+        "colornames": "^1.1.1"
       }
     },
     "language-subtag-registry": {
@@ -2126,6 +5712,43 @@
       "dev": true,
       "requires": {
         "language-subtag-registry": "~0.3.2"
+      }
+    },
+    "lazystream": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.1.tgz",
+      "integrity": "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==",
+      "requires": {
+        "readable-stream": "^2.0.5"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
       }
     },
     "levn": {
@@ -2158,11 +5781,101 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
+    "lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
+    },
+    "lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
+    },
+    "lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
+    },
+    "lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M="
+    },
+    "lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w="
+    },
+    "lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+    },
+    "lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
+    },
     "lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
+    },
+    "lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
+    },
+    "log-symbols": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
+      "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
+      "requires": {
+        "chalk": "^2.0.1"
+      }
+    },
+    "lokka": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/lokka/-/lokka-1.7.0.tgz",
+      "integrity": "sha1-qy6DNGEtKv01mqiQR1R7194hBGw=",
+      "requires": {
+        "babel-runtime": "6.x.x",
+        "uuid": "2.x.x"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
+          "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho="
+        }
+      }
+    },
+    "lokka-transport-http": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/lokka-transport-http/-/lokka-transport-http-1.6.1.tgz",
+      "integrity": "sha1-DfvC3J6CX25YIYMPPz9/P4OkrWU=",
+      "requires": {
+        "babel-runtime": "6.x.x",
+        "node-fetch": "^1.5.2",
+        "whatwg-fetch": "^1.0.0"
+      },
+      "dependencies": {
+        "is-stream": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+        },
+        "node-fetch": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+          "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+          "requires": {
+            "encoding": "^0.1.11",
+            "is-stream": "^1.0.1"
+          }
+        }
+      }
     },
     "loose-envify": {
       "version": "1.4.0",
@@ -2172,36 +5885,170 @@
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
     },
+    "lower-case": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
+      "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
+      "requires": {
+        "tslib": "^2.0.3"
+      }
+    },
+    "lower-case-first": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/lower-case-first/-/lower-case-first-2.0.2.tgz",
+      "integrity": "sha512-EVm/rR94FJTZi3zefZ82fLWab+GX14LJN4HrWBcuo6Evmsl9hEfnqxgcHCKb9q+mNf6EVdsjx/qucYFIIB84pg==",
+      "requires": {
+        "tslib": "^2.0.3"
+      }
+    },
     "lru-cache": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "requires": {
         "yallist": "^4.0.0"
+      }
+    },
+    "lru-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz",
+      "integrity": "sha1-Jzi9nw089PhEkMVzbEhpmsYyzaM=",
+      "requires": {
+        "es5-ext": "~0.10.2"
+      }
+    },
+    "map-cache": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+      "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8="
+    },
+    "map-obj": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.3.0.tgz",
+      "integrity": "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ=="
+    },
+    "map-visit": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
+      "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+      "requires": {
+        "object-visit": "^1.0.0"
+      }
+    },
+    "markdown-draft-js": {
+      "version": "github:incompl/markdown-draft-js#8a3a1093ffcf8c2fcb06b5722b2aa343565ae6cc",
+      "from": "github:incompl/markdown-draft-js#deterministic-entity-keys-with-lib",
+      "requires": {
+        "remarkable": "^2.0.1"
+      }
+    },
+    "matcher": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/matcher/-/matcher-4.0.0.tgz",
+      "integrity": "sha512-S6x5wmcDmsDRRU/c2dkccDwQPXoFczc5+HpQ2lON8pnvHlnvHAHj5WlLVvw6n6vNyHuVugYrFohYxbS+pvFpKQ==",
+      "requires": {
+        "escape-string-regexp": "^4.0.0"
+      },
+      "dependencies": {
+        "escape-string-regexp": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
+        }
+      }
+    },
+    "mdurl": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
+      "integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4="
+    },
+    "memoizee": {
+      "version": "0.4.15",
+      "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.4.15.tgz",
+      "integrity": "sha512-UBWmJpLZd5STPm7PMUlOw/TSy972M+z8gcyQ5veOnSDRREz/0bmpyTfKt3/51DhEBqCZQn1udM/5flcSPYhkdQ==",
+      "requires": {
+        "d": "^1.0.1",
+        "es5-ext": "^0.10.53",
+        "es6-weak-map": "^2.0.3",
+        "event-emitter": "^0.3.5",
+        "is-promise": "^2.2.2",
+        "lru-queue": "^0.1.0",
+        "next-tick": "^1.1.0",
+        "timers-ext": "^0.1.7"
+      }
+    },
+    "meow": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-9.0.0.tgz",
+      "integrity": "sha512-+obSblOQmRhcyBt62furQqRAQpNyWXo8BuQ5bN7dG8wmwQ+vwHKp/rCFD4CrTP8CsDQD1sjoZ94K417XEUk8IQ==",
+      "requires": {
+        "@types/minimist": "^1.2.0",
+        "camelcase-keys": "^6.2.2",
+        "decamelize": "^1.2.0",
+        "decamelize-keys": "^1.1.0",
+        "hard-rejection": "^2.1.0",
+        "minimist-options": "4.1.0",
+        "normalize-package-data": "^3.0.0",
+        "read-pkg-up": "^7.0.1",
+        "redent": "^3.0.0",
+        "trim-newlines": "^3.0.0",
+        "type-fest": "^0.18.0",
+        "yargs-parser": "^20.2.3"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "0.18.1",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.18.1.tgz",
+          "integrity": "sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw=="
+        },
+        "yargs-parser": {
+          "version": "20.2.9",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+          "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w=="
+        }
       }
     },
     "merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
-      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-      "dev": true
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="
     },
     "micromatch": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
       "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
-      "dev": true,
       "requires": {
         "braces": "^3.0.1",
         "picomatch": "^2.2.3"
       }
     },
+    "mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
+    },
+    "mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "requires": {
+        "mime-db": "1.52.0"
+      }
+    },
+    "mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
+    },
+    "min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg=="
+    },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -2209,19 +6056,102 @@
     "minimist": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-      "dev": true
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+    },
+    "minimist-options": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-4.1.0.tgz",
+      "integrity": "sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==",
+      "requires": {
+        "arrify": "^1.0.1",
+        "is-plain-obj": "^1.1.0",
+        "kind-of": "^6.0.3"
+      }
+    },
+    "minimize": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/minimize/-/minimize-2.2.0.tgz",
+      "integrity": "sha512-IxR2XMbw9pXCxApkdD9BTcH2U4XlXhbeySUrv71rmMS9XDA8BVXEsIuFu24LtwCfBgfbL7Fuh8/ZzkO5DaTLlQ==",
+      "requires": {
+        "argh": "^0.1.4",
+        "async": "^2.1.5",
+        "cli-color": "^1.2.0",
+        "diagnostics": "^1.1.0",
+        "emits": "^3.0.0",
+        "htmlparser2": "^3.9.2",
+        "uuid": "^3.0.0"
+      }
+    },
+    "mixin-deep": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
+      "integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
+      "requires": {
+        "for-in": "^1.0.2",
+        "is-extendable": "^1.0.1"
+      },
+      "dependencies": {
+        "is-extendable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "requires": {
+            "is-plain-object": "^2.0.4"
+          }
+        }
+      }
+    },
+    "moment": {
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
+      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
+    },
+    "moment-timezone": {
+      "version": "0.5.34",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.34.tgz",
+      "integrity": "sha512-3zAEHh2hKUs3EXLESx/wsgw6IQdusOT8Bxm3D9UrHPQR7zlMmzwybC8zHEM1tQ4LJwP7fcxrWr8tuBg05fFCbg==",
+      "requires": {
+        "moment": ">= 2.9.0"
+      }
     },
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
+    "mute-stream": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="
+    },
+    "nan": {
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
+      "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==",
+      "optional": true
     },
     "nanoid": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.2.0.tgz",
       "integrity": "sha512-fmsZYa9lpn69Ad5eDn7FMcnnSR+8R34W9qJEijxYhTbfOWzr22n1QxCMzXLK+ODyW2973V3Fux959iQoUxzUIA=="
+    },
+    "nanomatch": {
+      "version": "1.2.13",
+      "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
+      "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
+      "requires": {
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "fragment-cache": "^0.2.1",
+        "is-windows": "^1.0.2",
+        "kind-of": "^6.0.2",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      }
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -2252,6 +6182,20 @@
         "use-subscription": "1.5.1"
       }
     },
+    "next-tick": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
+      "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
+    },
+    "no-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
+      "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
+      "requires": {
+        "lower-case": "^2.0.2",
+        "tslib": "^2.0.3"
+      }
+    },
     "node-domexception": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
@@ -2267,10 +6211,82 @@
         "formdata-polyfill": "^4.0.10"
       }
     },
+    "node-int64": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+      "integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs="
+    },
+    "node-releases": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.2.tgz",
+      "integrity": "sha512-XxYDdcQ6eKqp/YjI+tb2C5WM2LgjnZrfYg4vgQt49EK268b6gYCHsBLrK2qvJo4FmCtqmKezb0WZFK4fkrZNsg=="
+    },
+    "normalize-package-data": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
+      "integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
+      "requires": {
+        "hosted-git-info": "^4.0.1",
+        "is-core-module": "^2.5.0",
+        "semver": "^7.3.4",
+        "validate-npm-package-license": "^3.0.1"
+      }
+    },
+    "normalize-path": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+      "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+      "requires": {
+        "remove-trailing-separator": "^1.0.1"
+      }
+    },
+    "nullthrows": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/nullthrows/-/nullthrows-1.1.1.tgz",
+      "integrity": "sha512-2vPPEi+Z7WqML2jZYddDIfy5Dqb0r2fze2zTxNNknZaFpVHU3mFB3R+DWeJWGVx0ecvttSGlJTI+WG+8Z4cDWw=="
+    },
+    "oauth-sign": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
+    },
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+    },
+    "object-copy": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
+      "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+      "requires": {
+        "copy-descriptor": "^0.1.0",
+        "define-property": "^0.2.5",
+        "kind-of": "^3.0.3"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "object-hash": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-1.3.1.tgz",
+      "integrity": "sha512-OSuu/pU4ENM9kmREg0BdNrUDIl1heYa4mBZacJc+vVWz4GtAwu7jO8s4AIt2aGRUTqxykpWzI3Oqnsm13tTMDA=="
     },
     "object-inspect": {
       "version": "1.11.1",
@@ -2280,14 +6296,25 @@
     "object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-      "dev": true
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
+    },
+    "object-path": {
+      "version": "0.11.8",
+      "resolved": "https://registry.npmjs.org/object-path/-/object-path-0.11.8.tgz",
+      "integrity": "sha512-YJjNZrlXJFM42wTBn6zgOJVar9KFJvzx6sTWDte8sWZF//cnjl0BxHNpfZx+ZffXX63A9q0b1zsFiBX4g4X5KA=="
+    },
+    "object-visit": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
+      "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+      "requires": {
+        "isobject": "^3.0.0"
+      }
     },
     "object.assign": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
       "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
-      "dev": true,
       "requires": {
         "call-bind": "^1.0.0",
         "define-properties": "^1.1.3",
@@ -2327,6 +6354,14 @@
         "es-abstract": "^1.19.1"
       }
     },
+    "object.pick": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+      "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+      "requires": {
+        "isobject": "^3.0.1"
+      }
+    },
     "object.values": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.5.tgz",
@@ -2342,9 +6377,25 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "requires": {
         "wrappy": "1"
+      }
+    },
+    "onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "requires": {
+        "mimic-fn": "^2.1.0"
+      }
+    },
+    "open": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
+      "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
+      "requires": {
+        "is-docker": "^2.0.0",
+        "is-wsl": "^2.1.1"
       }
     },
     "optimism": {
@@ -2370,6 +6421,74 @@
         "word-wrap": "^1.2.3"
       }
     },
+    "ora": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-3.4.0.tgz",
+      "integrity": "sha512-eNwHudNbO1folBP3JsZ19v9azXWtQZjICdr3Q0TDPIaeBQ3mXLrh54wM+er0+hSp+dWKf+Z8KM58CYzEyIYxYg==",
+      "requires": {
+        "chalk": "^2.4.2",
+        "cli-cursor": "^2.1.0",
+        "cli-spinners": "^2.0.0",
+        "log-symbols": "^2.2.0",
+        "strip-ansi": "^5.2.0",
+        "wcwidth": "^1.0.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
+          "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g=="
+        },
+        "cli-cursor": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+          "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+          "requires": {
+            "restore-cursor": "^2.0.0"
+          }
+        },
+        "mimic-fn": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+          "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
+        },
+        "onetime": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+          "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+          "requires": {
+            "mimic-fn": "^1.0.0"
+          }
+        },
+        "restore-cursor": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+          "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+          "requires": {
+            "onetime": "^2.0.0",
+            "signal-exit": "^3.0.2"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        }
+      }
+    },
+    "os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+    },
+    "p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
+    },
     "p-limit": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
@@ -2388,11 +6507,42 @@
         "p-limit": "^1.1.0"
       }
     },
+    "p-queue": {
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz",
+      "integrity": "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==",
+      "requires": {
+        "eventemitter3": "^4.0.4",
+        "p-timeout": "^3.2.0"
+      }
+    },
+    "p-reduce": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-2.1.0.tgz",
+      "integrity": "sha512-2USApvnsutq8uoxZBGbbWM0JIYLiEMJ9RlaN7fAzVNb9OZN0SHjjTTfIcb667XynS5Y1VhwDJVDa72TnPzAYWw=="
+    },
+    "p-timeout": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+      "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+      "requires": {
+        "p-finally": "^1.0.0"
+      }
+    },
     "p-try": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
       "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
       "dev": true
+    },
+    "param-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
+      "integrity": "sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==",
+      "requires": {
+        "dot-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
     },
     "parent-module": {
       "version": "1.0.1",
@@ -2400,6 +6550,16 @@
       "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
       "requires": {
         "callsites": "^3.0.0"
+      }
+    },
+    "parse-filepath": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/parse-filepath/-/parse-filepath-1.0.2.tgz",
+      "integrity": "sha1-pjISf1Oq89FYdvWHLz/6x2PWyJE=",
+      "requires": {
+        "is-absolute": "^1.0.0",
+        "map-cache": "^0.2.0",
+        "path-root": "^0.1.1"
       }
     },
     "parse-json": {
@@ -2413,6 +6573,34 @@
         "lines-and-columns": "^1.1.6"
       }
     },
+    "pascal-case": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
+      "integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
+      "requires": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "pascalcase": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
+      "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ="
+    },
+    "path-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/path-case/-/path-case-3.0.4.tgz",
+      "integrity": "sha512-qO4qCFjXqVTrcbPt/hQfhTQ+VhFsqNKOPtytgNKkKxSoEp3XPUQ8ObFuePylOIok5gjn69ry8XiULxCwot3Wfg==",
+      "requires": {
+        "dot-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "path-dirname": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
+      "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA="
+    },
     "path-exists": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
@@ -2422,8 +6610,7 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-key": {
       "version": "3.1.1",
@@ -2436,10 +6623,28 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
     },
+    "path-root": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/path-root/-/path-root-0.1.1.tgz",
+      "integrity": "sha1-mkpoFMrBwM1zNgqV8yCDyOpHRbc=",
+      "requires": {
+        "path-root-regex": "^0.1.0"
+      }
+    },
+    "path-root-regex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/path-root-regex/-/path-root-regex-0.1.2.tgz",
+      "integrity": "sha1-v8zcjfWxLcUsi0PsONGNcsBLqW0="
+    },
     "path-type": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
       "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="
+    },
+    "performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
     "picocolors": {
       "version": "1.0.0",
@@ -2449,8 +6654,17 @@
     "picomatch": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="
+    },
+    "pify": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-5.0.0.tgz",
+      "integrity": "sha512-eW/gHNMlxdSP6dmG6uJip6FXN0EQBwm2clYYd8Wul42Cwu/DK8HEftzsapcNdYe2MfLiIwZqsDk2RDEsTE79hA=="
+    },
+    "pluralize": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
+      "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA=="
     },
     "polished": {
       "version": "4.1.4",
@@ -2470,6 +6684,11 @@
         }
       }
     },
+    "posix-character-classes": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+      "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
+    },
     "postcss": {
       "version": "8.4.5",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.5.tgz",
@@ -2486,6 +6705,29 @@
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
       "dev": true
     },
+    "pretty-bytes": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.6.0.tgz",
+      "integrity": "sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg=="
+    },
+    "prismjs": {
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.27.0.tgz",
+      "integrity": "sha512-t13BGPUlFDR7wRB5kQDG4jjl7XeuH6jbJGt11JHPL96qwsEHNX2+68tFXqc1/k+/jALsbSWJKUOT/hcYAZ5LkA=="
+    },
+    "process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+    },
+    "promise": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+      "requires": {
+        "asap": "~2.0.3"
+      }
+    },
     "promise-polyfill": {
       "version": "8.2.1",
       "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.2.1.tgz",
@@ -2501,11 +6743,45 @@
         "react-is": "^16.8.1"
       }
     },
+    "psl": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
+      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
+    },
+    "pump": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "requires": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "pumpify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-2.0.1.tgz",
+      "integrity": "sha512-m7KOje7jZxrmutanlkS1daj1dS6z6BgslzOXmcSEpIlCxM3VJH7lG5QLeck/6hgF6F4crFf01UtQmNsJfweTAw==",
+      "requires": {
+        "duplexify": "^4.1.1",
+        "inherits": "^2.0.3",
+        "pump": "^3.0.0"
+      }
+    },
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "dev": true
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+    },
+    "pusher-client": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pusher-client/-/pusher-client-1.1.0.tgz",
+      "integrity": "sha1-pcNdtMlpaCiE4FSgZpaLvrpQnAM=",
+      "requires": {
+        "eventemitter2": "*",
+        "request": "*",
+        "underscore": "*",
+        "ws": "*"
+      }
     },
     "qs": {
       "version": "6.10.3",
@@ -2515,11 +6791,74 @@
         "side-channel": "^1.0.4"
       }
     },
+    "query-string": {
+      "version": "6.14.1",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.14.1.tgz",
+      "integrity": "sha512-XDxAeVmpfu1/6IjyT/gXHOl+S0vQ9owggJ30hhWKdHAsNPOcasn5o9BW0eejZqL2e4vMjhAxoW3jVHcD6mbcYw==",
+      "requires": {
+        "decode-uri-component": "^0.2.0",
+        "filter-obj": "^1.1.0",
+        "split-on-first": "^1.0.0",
+        "strict-uri-encode": "^2.0.0"
+      }
+    },
+    "querystring": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
+    },
+    "querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
+    },
     "queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
-      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-      "dev": true
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="
+    },
+    "quick-lru": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
+      "integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g=="
+    },
+    "ranges-apply": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/ranges-apply/-/ranges-apply-5.1.0.tgz",
+      "integrity": "sha512-VF3a0XUuYS/BQHv2RaIyX1K7S1hbfrs64hkGKgPVk0Y7p4XFwSucjTTttrBqmkcmB/PZx5ISTZdxErRZi/89aQ==",
+      "requires": {
+        "@babel/runtime": "^7.14.0",
+        "ranges-merge": "^7.1.0"
+      }
+    },
+    "ranges-merge": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/ranges-merge/-/ranges-merge-7.1.0.tgz",
+      "integrity": "sha512-coTHcyAEIhoEdsBs9f5f+q0rmy7UHvS/5nfuXzuj5oLX/l/tbqM5uxRb6eh8WMdetXia3lK67ZO4tarH4ieulQ==",
+      "requires": {
+        "@babel/runtime": "^7.14.0",
+        "ranges-push": "^5.1.0",
+        "ranges-sort": "^4.1.0"
+      }
+    },
+    "ranges-push": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/ranges-push/-/ranges-push-5.1.0.tgz",
+      "integrity": "sha512-vqGcaGq7GWV1zBa9w83E+dzYkOvE9/3pIRUPvLf12c+mGQCf1nesrkBI7Ob8taN2CC9V1HDSJx0KAQl0SgZftA==",
+      "requires": {
+        "@babel/runtime": "^7.14.0",
+        "ranges-merge": "^7.1.0",
+        "string-collapse-leading-whitespace": "^5.1.0",
+        "string-trim-spaces-only": "^3.1.0"
+      }
+    },
+    "ranges-sort": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/ranges-sort/-/ranges-sort-4.1.0.tgz",
+      "integrity": "sha512-GOQgk6UtsrfKFeYa53YLiBVnLINwYmOk5l2QZG1csZpT6GdImUwooh+/cRrp7b+fYawZX/rnyA3Ul+pdgQBIzA==",
+      "requires": {
+        "@babel/runtime": "^7.14.0"
+      }
     },
     "react": {
       "version": "17.0.2",
@@ -2555,10 +6894,271 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
+    "read-pkg": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
+      "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
+      "requires": {
+        "@types/normalize-package-data": "^2.4.0",
+        "normalize-package-data": "^2.5.0",
+        "parse-json": "^5.0.0",
+        "type-fest": "^0.6.0"
+      },
+      "dependencies": {
+        "hosted-git-info": {
+          "version": "2.8.9",
+          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+          "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw=="
+        },
+        "normalize-package-data": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+          "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+          "requires": {
+            "hosted-git-info": "^2.1.4",
+            "resolve": "^1.10.0",
+            "semver": "2 || 3 || 4 || 5",
+            "validate-npm-package-license": "^3.0.1"
+          }
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+        },
+        "type-fest": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+          "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg=="
+        }
+      }
+    },
+    "read-pkg-up": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
+      "integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
+      "requires": {
+        "find-up": "^4.1.0",
+        "read-pkg": "^5.2.0",
+        "type-fest": "^0.8.1"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        },
+        "p-try": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
+        },
+        "type-fest": {
+          "version": "0.8.1",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+          "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA=="
+        }
+      }
+    },
+    "readable-stream": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "requires": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      }
+    },
+    "readdirp": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
+      "integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
+      "requires": {
+        "graceful-fs": "^4.1.11",
+        "micromatch": "^3.1.10",
+        "readable-stream": "^2.0.2"
+      },
+      "dependencies": {
+        "braces": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+          "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+          "requires": {
+            "arr-flatten": "^1.1.0",
+            "array-unique": "^0.3.2",
+            "extend-shallow": "^2.0.1",
+            "fill-range": "^4.0.0",
+            "isobject": "^3.0.1",
+            "repeat-element": "^1.1.2",
+            "snapdragon": "^0.8.1",
+            "snapdragon-node": "^2.0.1",
+            "split-string": "^3.0.2",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "fill-range": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+          "requires": {
+            "extend-shallow": "^2.0.1",
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1",
+            "to-regex-range": "^2.1.0"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "requires": {
+            "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "micromatch": {
+          "version": "3.1.10",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+          "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+          "requires": {
+            "arr-diff": "^4.0.0",
+            "array-unique": "^0.3.2",
+            "braces": "^2.3.1",
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "extglob": "^2.0.4",
+            "fragment-cache": "^0.2.1",
+            "kind-of": "^6.0.2",
+            "nanomatch": "^1.2.9",
+            "object.pick": "^1.3.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.2"
+          }
+        },
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        },
+        "to-regex-range": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+          "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+          "requires": {
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1"
+          }
+        }
+      }
+    },
+    "redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "requires": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      }
+    },
     "regenerator-runtime": {
       "version": "0.13.9",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
       "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
+    },
+    "regex-not": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
+      "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
+      "requires": {
+        "extend-shallow": "^3.0.2",
+        "safe-regex": "^1.1.0"
+      }
     },
     "regexp.prototype.flags": {
       "version": "1.4.1",
@@ -2576,6 +7176,173 @@
       "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
       "dev": true
     },
+    "relay-compiler": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/relay-compiler/-/relay-compiler-12.0.0.tgz",
+      "integrity": "sha512-SWqeSQZ+AMU/Cr7iZsHi1e78Z7oh00I5SvR092iCJq79aupqJ6Ds+I1Pz/Vzo5uY5PY0jvC4rBJXzlIN5g9boQ==",
+      "requires": {
+        "@babel/core": "^7.14.0",
+        "@babel/generator": "^7.14.0",
+        "@babel/parser": "^7.14.0",
+        "@babel/runtime": "^7.0.0",
+        "@babel/traverse": "^7.14.0",
+        "@babel/types": "^7.0.0",
+        "babel-preset-fbjs": "^3.4.0",
+        "chalk": "^4.0.0",
+        "fb-watchman": "^2.0.0",
+        "fbjs": "^3.0.0",
+        "glob": "^7.1.1",
+        "immutable": "~3.7.6",
+        "invariant": "^2.2.4",
+        "nullthrows": "^1.1.1",
+        "relay-runtime": "12.0.0",
+        "signedsource": "^1.0.0",
+        "yargs": "^15.3.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "relay-runtime": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/relay-runtime/-/relay-runtime-12.0.0.tgz",
+      "integrity": "sha512-QU6JKr1tMsry22DXNy9Whsq5rmvwr3LSZiiWV/9+DFpuTWvp+WFhobWMc8TC4OjKFfNhEZy7mOiqUAn5atQtug==",
+      "requires": {
+        "@babel/runtime": "^7.0.0",
+        "fbjs": "^3.0.0",
+        "invariant": "^2.2.4"
+      }
+    },
+    "remarkable": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/remarkable/-/remarkable-2.0.1.tgz",
+      "integrity": "sha512-YJyMcOH5lrR+kZdmB0aJJ4+93bEojRZ1HGDn9Eagu6ibg7aVZhc3OWbbShRid+Q5eAfsEqWxpe+g5W5nYNfNiA==",
+      "requires": {
+        "argparse": "^1.0.10",
+        "autolinker": "^3.11.0"
+      },
+      "dependencies": {
+        "argparse": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+          "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+          "requires": {
+            "sprintf-js": "~1.0.2"
+          }
+        }
+      }
+    },
+    "remove-trailing-separator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
+    },
+    "repeat-element": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.4.tgz",
+      "integrity": "sha512-LFiNfRcSu7KK3evMyYOuCzv3L10TW7yC1G2/+StMjK8Y6Vqd2MG7r/Qjw4ghtuCOjFvlnms/iMmLqpvW/ES/WQ=="
+    },
+    "repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
+    },
+    "request": {
+      "version": "2.88.2",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+      "requires": {
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.8.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.2",
+        "har-validator": "~5.1.3",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.19",
+        "oauth-sign": "~0.9.0",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.2",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "~2.5.0",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "qs": {
+          "version": "6.5.3",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
+          "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA=="
+        }
+      }
+    },
+    "require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
+    },
+    "require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
+    },
+    "require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
+    },
+    "requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
+    },
     "resolve": {
       "version": "1.20.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
@@ -2590,11 +7357,34 @@
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
     },
+    "resolve-url": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+      "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
+    },
+    "restore-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+      "requires": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
+    "ret": {
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
+    },
+    "retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg=="
+    },
     "reusify": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
-      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
-      "dev": true
+      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw=="
     },
     "rimraf": {
       "version": "3.0.2",
@@ -2605,14 +7395,56 @@
         "glob": "^7.1.3"
       }
     },
+    "run-async": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
+      "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ=="
+    },
     "run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
       "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-      "dev": true,
       "requires": {
         "queue-microtask": "^1.2.2"
       }
+    },
+    "rxjs": {
+      "version": "6.6.7",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+      "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+      "requires": {
+        "tslib": "^1.9.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+    },
+    "safe-regex": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+      "requires": {
+        "ret": "~0.1.10"
+      }
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "sax": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+      "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
     },
     "scheduler": {
       "version": "0.20.2",
@@ -2627,10 +7459,50 @@
       "version": "7.3.5",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
       "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-      "dev": true,
       "requires": {
         "lru-cache": "^6.0.0"
       }
+    },
+    "sentence-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-3.0.4.tgz",
+      "integrity": "sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg==",
+      "requires": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3",
+        "upper-case-first": "^2.0.2"
+      }
+    },
+    "set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+    },
+    "set-value": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
+      "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
+      "requires": {
+        "extend-shallow": "^2.0.1",
+        "is-extendable": "^0.1.1",
+        "is-plain-object": "^2.0.3",
+        "split-string": "^3.0.1"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        }
+      }
+    },
+    "setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
     },
     "shebang-command": {
       "version": "2.0.0",
@@ -2647,6 +7519,21 @@
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true
     },
+    "shortid": {
+      "version": "2.2.16",
+      "resolved": "https://registry.npmjs.org/shortid/-/shortid-2.2.16.tgz",
+      "integrity": "sha512-Ugt+GIZqvGXCIItnsL+lvFJOiN7RYqlGy7QE41O3YC1xbNSeDGIRO7xg2JJXIAj1cAGnOeC1r7/T9pgrtQbv4g==",
+      "requires": {
+        "nanoid": "^2.1.0"
+      },
+      "dependencies": {
+        "nanoid": {
+          "version": "2.1.11",
+          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-2.1.11.tgz",
+          "integrity": "sha512-s/snB+WGm6uwi0WjsZdaVcuf3KJXlfGl2LcxgwkEwJF0D/BWzVWAZW/XY4bFaiR7s0Jk3FPvlnepg1H1b1UwlA=="
+        }
+      }
+    },
     "side-channel": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
@@ -2657,16 +7544,397 @@
         "object-inspect": "^1.9.0"
       }
     },
+    "signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
+    },
+    "signedsource": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/signedsource/-/signedsource-1.0.0.tgz",
+      "integrity": "sha1-HdrOSYF5j5O9gzlzgD2A1S6TrWo="
+    },
+    "simple-swizzle": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+      "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
+      "requires": {
+        "is-arrayish": "^0.3.1"
+      },
+      "dependencies": {
+        "is-arrayish": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+          "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
+        }
+      }
+    },
     "slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-      "dev": true
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="
+    },
+    "slugg": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/slugg/-/slugg-1.2.1.tgz",
+      "integrity": "sha1-51KvIkGvPycURjxd4iXOpHYIdAo="
+    },
+    "snake-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.4.tgz",
+      "integrity": "sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==",
+      "requires": {
+        "dot-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "snapdragon": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
+      "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
+      "requires": {
+        "base": "^0.11.1",
+        "debug": "^2.2.0",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "map-cache": "^0.2.2",
+        "source-map": "^0.5.6",
+        "source-map-resolve": "^0.5.0",
+        "use": "^3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
+      }
+    },
+    "snapdragon-node": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+      "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+      "requires": {
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.0",
+        "snapdragon-util": "^3.0.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "requires": {
+            "is-descriptor": "^1.0.0"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        }
+      }
+    },
+    "snapdragon-util": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
+      "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+      "requires": {
+        "kind-of": "^3.2.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
     },
     "source-map-js": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
       "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw=="
+    },
+    "source-map-resolve": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
+      "integrity": "sha512-Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw==",
+      "requires": {
+        "atob": "^2.1.2",
+        "decode-uri-component": "^0.2.0",
+        "resolve-url": "^0.2.1",
+        "source-map-url": "^0.4.0",
+        "urix": "^0.1.0"
+      }
+    },
+    "source-map-url": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.1.tgz",
+      "integrity": "sha512-cPiFOTLUKvJFIg4SKVScy4ilPPW6rFgMgfuZJPNoDuMs3nC1HbMUycBoJw77xFIp6z1UJQJOfx6C9GMH80DiTw=="
+    },
+    "spdx-correct": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
+      "integrity": "sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==",
+      "requires": {
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "spdx-exceptions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
+      "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A=="
+    },
+    "spdx-expression-parse": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+      "requires": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "spdx-license-ids": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.11.tgz",
+      "integrity": "sha512-Ctl2BrFiM0X3MANYgj3CkygxhRmr9mi6xhejbdO960nF6EDJApTYpn0BQnDKlnNBULKiCN1n3w9EBkHK8ZWg+g=="
+    },
+    "split-on-first": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
+      "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw=="
+    },
+    "split-string": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
+      "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+      "requires": {
+        "extend-shallow": "^3.0.0"
+      }
+    },
+    "sponge-case": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sponge-case/-/sponge-case-1.0.1.tgz",
+      "integrity": "sha512-dblb9Et4DAtiZ5YSUZHLl4XhH4uK80GhAZrVXdN4O2P4gQ40Wa5UIOPUHlA/nFd2PLblBZWUioLMMAVrgpoYcA==",
+      "requires": {
+        "tslib": "^2.0.3"
+      }
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+    },
+    "sshpk": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.17.0.tgz",
+      "integrity": "sha512-/9HIEs1ZXGhSPE8X6Ccm7Nam1z8KcoCqPdI7ecm1N33EzAetWahvQWVqLZtaZQ+IDKX4IyA2o0gBzqIMkAagHQ==",
+      "requires": {
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
+      }
+    },
+    "static-extend": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
+      "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+      "requires": {
+        "define-property": "^0.2.5",
+        "object-copy": "^0.1.0"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        }
+      }
+    },
+    "stream-shift": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
+      "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ=="
+    },
+    "stream-to-array": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/stream-to-array/-/stream-to-array-2.3.0.tgz",
+      "integrity": "sha1-u/azn19D7DC8cbq8s3VXrOzzQ1M=",
+      "requires": {
+        "any-promise": "^1.1.0"
+      }
+    },
+    "stream-to-promise": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/stream-to-promise/-/stream-to-promise-2.2.0.tgz",
+      "integrity": "sha1-se2y4cjLESidG1A8CNPyrvUeZQ8=",
+      "requires": {
+        "any-promise": "~1.3.0",
+        "end-of-stream": "~1.1.0",
+        "stream-to-array": "~2.3.0"
+      },
+      "dependencies": {
+        "end-of-stream": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz",
+          "integrity": "sha1-6TUyWLqpEIll78QcsO+K3i88+wc=",
+          "requires": {
+            "once": "~1.3.0"
+          }
+        },
+        "once": {
+          "version": "1.3.3",
+          "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+          "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
+          "requires": {
+            "wrappy": "1"
+          }
+        }
+      }
+    },
+    "strict-uri-encode": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
+      "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY="
+    },
+    "string-character-is-astral-surrogate": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/string-character-is-astral-surrogate/-/string-character-is-astral-surrogate-1.13.0.tgz",
+      "integrity": "sha512-tKRG2qaGiV2ntUur32sfeAypqTvMUtl+8spEYSJzDsee4lKGMFxQmdHIyCw/uiWWQSve+DQmde2japDYZlQpLA==",
+      "requires": {
+        "@babel/runtime": "^7.14.0"
+      }
+    },
+    "string-collapse-leading-whitespace": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/string-collapse-leading-whitespace/-/string-collapse-leading-whitespace-5.1.0.tgz",
+      "integrity": "sha512-mYz9/Kb5uvRB4DZj46zILwI4y9lD9JsvXG9Xb7zjbwm0I/R40G7oFfMsqJ28l2d7gWMTLJL569NfJQVLQbnHCw==",
+      "requires": {
+        "@babel/runtime": "^7.14.0"
+      }
+    },
+    "string-find-heads-tails": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/string-find-heads-tails/-/string-find-heads-tails-4.1.0.tgz",
+      "integrity": "sha512-57EGQB5tK4KGy9o5RyHCrXcu3ZxrE8MEgKv7oBrKh8VvxvcNK8yoZnEV+tS7q9/AjJqR/Nw2AGj0R2+/AOZ01A==",
+      "requires": {
+        "@babel/runtime": "^7.14.0",
+        "arrayiffy-if-string": "^3.14.0",
+        "string-match-left-right": "^7.1.0"
+      }
+    },
+    "string-match-left-right": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/string-match-left-right/-/string-match-left-right-7.1.0.tgz",
+      "integrity": "sha512-PSyXWesECKYnTJy6xaXAz/2AiyIjrga2hhMN8QbSNGwsnxcpWxt5pMpc7JQIzPkkEwDwip8PdIuU110xKuBevg==",
+      "requires": {
+        "@babel/runtime": "^7.14.0",
+        "arrayiffy-if-string": "^3.14.0",
+        "lodash.isplainobject": "^4.0.6",
+        "string-character-is-astral-surrogate": "^1.13.0"
+      }
+    },
+    "string-remove-duplicate-heads-tails": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/string-remove-duplicate-heads-tails/-/string-remove-duplicate-heads-tails-5.1.0.tgz",
+      "integrity": "sha512-mkINau8YeQrQxs2SCJdyzr0Y+92WLFd8cOYlKiR61+dnA6XFSxF+wC8LXvbHdr3Hs09mTNNdchV3HdFWweYQPA==",
+      "requires": {
+        "@babel/runtime": "^7.14.0",
+        "arrayiffy-if-string": "^3.14.0",
+        "lodash.isplainobject": "^4.0.6",
+        "ranges-apply": "^5.1.0",
+        "ranges-push": "^5.1.0",
+        "string-match-left-right": "^7.1.0",
+        "string-trim-spaces-only": "^3.1.0"
+      }
+    },
+    "string-trim-spaces-only": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/string-trim-spaces-only/-/string-trim-spaces-only-3.1.0.tgz",
+      "integrity": "sha512-AW7RSi3+QtE6wR+4m/kmwlyy39neBbCIzrzzu1/RGzNRiPKQOeB3rGzr4ubg4UIQgYtr2w0PrxhKPXgyqJ0vaQ==",
+      "requires": {
+        "@babel/runtime": "^7.14.0"
+      }
+    },
+    "string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "requires": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "dependencies": {
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+        }
+      }
     },
     "string.prototype.matchall": {
       "version": "4.0.6",
@@ -2683,6 +7951,11 @@
         "regexp.prototype.flags": "^1.3.1",
         "side-channel": "^1.0.4"
       }
+    },
+    "string.prototype.repeat": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.repeat/-/string.prototype.repeat-0.2.0.tgz",
+      "integrity": "sha1-q6Nt4I3O5qWjN9SbLqHaGyj8Ds8="
     },
     "string.prototype.trimend": {
       "version": "1.0.4",
@@ -2704,11 +7977,18 @@
         "define-properties": "^1.1.3"
       }
     },
+    "string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "requires": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "requires": {
         "ansi-regex": "^5.0.1"
       }
@@ -2718,6 +7998,14 @@
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
       "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
       "dev": true
+    },
+    "strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "requires": {
+        "min-indent": "^1.0.0"
+      }
     },
     "strip-json-comments": {
       "version": "3.1.1",
@@ -2772,10 +8060,66 @@
         "has-flag": "^3.0.0"
       }
     },
+    "swap-case": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/swap-case/-/swap-case-2.0.2.tgz",
+      "integrity": "sha512-kc6S2YS/2yXbtkSMunBtKdah4VFETZ8Oh6ONSmSd9bRxhqTrtARUCBUiWXH3xVPpvR7tz2CSnkuXVE42EcGnMw==",
+      "requires": {
+        "tslib": "^2.0.3"
+      }
+    },
     "symbol-observable": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-4.0.0.tgz",
       "integrity": "sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ=="
+    },
+    "tar-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz",
+      "integrity": "sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==",
+      "requires": {
+        "bl": "^1.0.0",
+        "buffer-alloc": "^1.2.0",
+        "end-of-stream": "^1.0.0",
+        "fs-constants": "^1.0.0",
+        "readable-stream": "^2.3.0",
+        "to-buffer": "^1.1.1",
+        "xtend": "^4.0.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
+    },
+    "text-hex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
+      "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg=="
     },
     "text-table": {
       "version": "0.2.0",
@@ -2783,19 +8127,110 @@
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
     },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+    },
+    "through2": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.2.tgz",
+      "integrity": "sha512-enaDQ4MUyP2W6ZyT6EsMzqBPZaM/avg8iuo+l2d3QCs0J+6RaqkHV/2/lOwDTueBHeJ/2LG9lrLW3d5rWPucuQ==",
+      "requires": {
+        "inherits": "^2.0.4",
+        "readable-stream": "2 || 3"
+      }
+    },
+    "timers-ext": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.7.tgz",
+      "integrity": "sha512-b85NUNzTSdodShTIbky6ZF02e8STtVVfD+fu4aXXShEELpozH+bCpJLYMPZbsABN2wDH7fJpqIoXxJpzbf0NqQ==",
+      "requires": {
+        "es5-ext": "~0.10.46",
+        "next-tick": "1"
+      }
+    },
+    "title-case": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/title-case/-/title-case-3.0.3.tgz",
+      "integrity": "sha512-e1zGYRvbffpcHIrnuqT0Dh+gEJtDaxDSoG4JAIpq4oDFyooziLBIiYQv0GBT4FUAnUop5uZ1hiIAj7oAF6sOCA==",
+      "requires": {
+        "tslib": "^2.0.3"
+      }
+    },
+    "tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "requires": {
+        "os-tmpdir": "~1.0.2"
+      }
+    },
+    "to-buffer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
+      "integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg=="
+    },
     "to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
       "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
     },
+    "to-object-path": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
+      "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+      "requires": {
+        "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "to-regex": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
+      "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+      "requires": {
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "regex-not": "^1.0.2",
+        "safe-regex": "^1.1.0"
+      }
+    },
     "to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
       "requires": {
         "is-number": "^7.0.0"
       }
+    },
+    "tough-cookie": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+      "requires": {
+        "psl": "^1.1.28",
+        "punycode": "^2.1.1"
+      }
+    },
+    "tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+    },
+    "trim-newlines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
+      "integrity": "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw=="
     },
     "ts-invariant": {
       "version": "0.9.4",
@@ -2839,6 +8274,24 @@
         }
       }
     },
+    "tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
+    },
+    "type": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
+      "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg=="
+    },
     "type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -2854,6 +8307,17 @@
       "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
       "dev": true
     },
+    "typescript": {
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
+      "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==",
+      "dev": true
+    },
+    "ua-parser-js": {
+      "version": "0.7.31",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.31.tgz",
+      "integrity": "sha512-qLK/Xe9E2uzmYI3qLeOmI0tEOt+TBBQyUIAh4aAgU05FVYzeZrKUdkAZfBNVGRaHVgV0TDkdEngJSw/SyQchkQ=="
+    },
     "unbox-primitive": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
@@ -2866,19 +8330,144 @@
         "which-boxed-primitive": "^1.0.2"
       }
     },
+    "unc-path-regex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
+      "integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo="
+    },
+    "underscore": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.2.tgz",
+      "integrity": "sha512-ekY1NhRzq0B08g4bGuX4wd2jZx5GnKz6mKSqFL4nqBlfyMGiG10gDFhDTMEfYmDL6Jy0FUIZp7wiRB+0BP7J2g=="
+    },
     "unfetch": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/unfetch/-/unfetch-4.2.0.tgz",
       "integrity": "sha512-F9p7yYCn6cIW9El1zi0HI6vqpeIvBsr3dSuRO6Xuppb1u5rXpCPmMvLSyECLhybr9isec8Ohl0hPekMVrEinDA=="
     },
+    "union-value": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
+      "integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
+      "requires": {
+        "arr-union": "^3.1.0",
+        "get-value": "^2.0.6",
+        "is-extendable": "^0.1.1",
+        "set-value": "^2.0.1"
+      }
+    },
+    "universalify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
+    },
+    "unixify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unixify/-/unixify-1.0.0.tgz",
+      "integrity": "sha1-OmQcjC/7zk2mg6XHDwOkYpQMIJA=",
+      "requires": {
+        "normalize-path": "^2.1.1"
+      }
+    },
+    "unset-value": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
+      "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+      "requires": {
+        "has-value": "^0.3.1",
+        "isobject": "^3.0.0"
+      },
+      "dependencies": {
+        "has-value": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
+          "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+          "requires": {
+            "get-value": "^2.0.3",
+            "has-values": "^0.1.4",
+            "isobject": "^2.0.0"
+          },
+          "dependencies": {
+            "isobject": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+              "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+              "requires": {
+                "isarray": "1.0.0"
+              }
+            }
+          }
+        },
+        "has-values": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
+          "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E="
+        }
+      }
+    },
+    "upath": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
+      "integrity": "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg=="
+    },
+    "upper-case": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-2.0.2.tgz",
+      "integrity": "sha512-KgdgDGJt2TpuwBUIjgG6lzw2GWFRCW9Qkfkiv0DxqHHLYJHmtmdUIKcZd8rHgFSjopVTlw6ggzCm1b8MFQwikg==",
+      "requires": {
+        "tslib": "^2.0.3"
+      }
+    },
+    "upper-case-first": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-2.0.2.tgz",
+      "integrity": "sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg==",
+      "requires": {
+        "tslib": "^2.0.3"
+      }
+    },
     "uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-      "dev": true,
       "requires": {
         "punycode": "^2.1.0"
       }
+    },
+    "urix": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
+      "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI="
+    },
+    "url": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+      "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
+      "requires": {
+        "punycode": "1.3.2",
+        "querystring": "0.2.0"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+        }
+      }
+    },
+    "url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "requires": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
+      }
+    },
+    "use": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
+      "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ=="
     },
     "use-subscription": {
       "version": "1.5.1",
@@ -2888,16 +8477,89 @@
         "object-assign": "^4.1.1"
       }
     },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
+    "uuid": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+    },
     "v8-compile-cache": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
       "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
       "dev": true
     },
+    "validate-npm-package-license": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+      "requires": {
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "value-or-promise": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/value-or-promise/-/value-or-promise-1.0.11.tgz",
+      "integrity": "sha512-41BrgH+dIbCFXClcSapVs5M6GkENd3gQOJpEfPDNa71LsUGMXDL0jMWpI/Rh7WhX+Aalfz2TTS3Zt5pUsbnhLg=="
+    },
+    "verror": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
+      },
+      "dependencies": {
+        "core-util-is": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+        }
+      }
+    },
+    "walkdir": {
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/walkdir/-/walkdir-0.0.11.tgz",
+      "integrity": "sha1-oW0CXrkxvQO1LzCMrtD0D86+lTI="
+    },
+    "wcwidth": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+      "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
+      "requires": {
+        "defaults": "^1.0.3"
+      }
+    },
     "web-streams-polyfill": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.0.tgz",
       "integrity": "sha512-EqPmREeOzttaLRm5HS7io98goBgZ7IVz79aDvqjD0kYXLtFZTc0T/U6wHTPKyIjb+MdN7DFIIX6hgdBEpWmfPA=="
+    },
+    "webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+    },
+    "whatwg-fetch": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-1.1.1.tgz",
+      "integrity": "sha1-rDydOfMgxtzlM5lp0FTvQ90zMxk="
+    },
+    "whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+      "requires": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
     },
     "which": {
       "version": "2.0.2",
@@ -2921,28 +8583,170 @@
         "is-symbol": "^1.0.3"
       }
     },
+    "which-module": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
+    },
     "word-wrap": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
       "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
       "dev": true
     },
+    "wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "requires": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        }
+      }
+    },
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
+    "ws": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
+      "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg=="
+    },
+    "xml2js": {
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+      "requires": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~9.0.1"
+      }
+    },
+    "xmlbuilder": {
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
+    },
+    "xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
+    },
+    "y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="
     },
     "yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "yaml": {
       "version": "1.10.2",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
       "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg=="
+    },
+    "yargs": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "requires": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        },
+        "p-try": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
+        }
+      }
+    },
+    "yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "requires": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      }
+    },
+    "yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="
     },
     "zen-observable": {
       "version": "0.8.15",
@@ -2955,6 +8759,46 @@
       "integrity": "sha512-hc/TGiPkAWpByykMwDcem3SdUgA4We+0Qb36bItSuJC9xD0XVBZoFHYoadAomDSNf64CG8Ydj0Qb8Od8BUWz5g==",
       "requires": {
         "zen-observable": "0.8.15"
+      }
+    },
+    "zip-stream": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-1.2.0.tgz",
+      "integrity": "sha1-qLxF9MG0lpnGuQGYuqyqzbzUugQ=",
+      "requires": {
+        "archiver-utils": "^1.3.0",
+        "compress-commons": "^1.2.0",
+        "lodash": "^4.8.0",
+        "readable-stream": "^2.0.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start",
     "export": "next build && next export",
-    "lint": "next lint"
+    "lint": "next lint",
+    "typegen": "takeshape schema && takeshape types --to ./lib/takeshape/types.d.ts"
   },
   "dependencies": {
     "@apollo/client": "^3.5.8",
@@ -16,6 +17,7 @@
     "@emotion/styled": "^11.6.0",
     "@stripe/react-stripe-js": "^1.7.0",
     "@stripe/stripe-js": "^1.22.0",
+    "@takeshape/cli": "^8.115.0",
     "@theme-ui/color": "^0.13.1",
     "@theme-ui/components": "0.13.1",
     "@theme-ui/core": "0.13.1",
@@ -56,7 +58,9 @@
     ]
   },
   "devDependencies": {
+    "@types/react": "^17.0.43",
     "eslint": "8.8.0",
-    "eslint-config-next": "12.0.10"
+    "eslint-config-next": "12.0.10",
+    "typescript": "^4.6.3"
   }
 }

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -1,8 +1,8 @@
 import { Heading, Divider, Alert, Spinner, Container } from '@theme-ui/components';
 import { Page } from 'components/layout';
 import { ProductList } from 'components/products';
-import { takeshapeApiUrl, takeshapeApiKey } from 'lib/config';
 import { GetStripeProducts } from 'lib/queries';
+import { takeshapeApiUrl, takeshapeApiKey } from 'lib/config';
 import { createApolloClient } from 'lib/apollo';
 
 function HomePage({ products, error }) {

--- a/pages/product/[id].tsx
+++ b/pages/product/[id].tsx
@@ -1,5 +1,5 @@
 import { NextPage, GetStaticProps, GetStaticPaths } from 'next';
-import { Heading, Divider, Alert, Spinner, Container } from '@theme-ui/components';
+import { Heading, Divider } from '@theme-ui/components';
 import { Page } from 'components/layout';
 import { ProductCard } from 'components/products';
 import { takeshapeApiUrl, takeshapeApiKey } from 'lib/config';
@@ -12,6 +12,7 @@ import {
   GetStripeProducts,
   StripeProducts
 } from 'lib/queries';
+import { getSingle } from 'lib/utils/types';
 
 interface ProductPageProps {
   product: Stripe_Product;
@@ -27,13 +28,6 @@ const ProductPage: NextPage<ProductPageProps> = (props) => {
   );
 };
 
-function getSingle<T>(param?: T | T[]): T | undefined {
-  if (Array.isArray(param)) {
-    return param[0];
-  }
-  return param;
-}
-
 export const getStaticProps: GetStaticProps<ProductPageProps> = async (context) => {
   const { params } = context;
   const id = getSingle(params.id);
@@ -42,7 +36,7 @@ export const getStaticProps: GetStaticProps<ProductPageProps> = async (context) 
     data: { product }
   } = await client.query<GetStripeProductQuery, GetStripeProductArgs>({
     query: GetStripeProduct,
-    variables: { id: id }
+    variables: { id }
   });
   return {
     props: {

--- a/pages/product/[id].tsx
+++ b/pages/product/[id].tsx
@@ -1,0 +1,68 @@
+import { NextPage, GetStaticProps, GetStaticPaths } from 'next';
+import { Heading, Divider, Alert, Spinner, Container } from '@theme-ui/components';
+import { Page } from 'components/layout';
+import { ProductCard } from 'components/products';
+import { takeshapeApiUrl, takeshapeApiKey } from 'lib/config';
+import { createApolloClient } from 'lib/apollo';
+import { Stripe_Product } from 'lib/takeshape/types';
+import {
+  GetStripeProduct,
+  GetStripeProductArgs,
+  GetStripeProductQuery,
+  GetStripeProducts,
+  StripeProducts
+} from 'lib/queries';
+
+interface ProductPageProps {
+  product: Stripe_Product;
+}
+
+const ProductPage: NextPage<ProductPageProps> = (props) => {
+  return (
+    <Page>
+      <Heading as="h1">{props.product.name ?? 'Product'}</Heading>
+      <Divider />
+      <ProductCard product={props.product} />
+    </Page>
+  );
+};
+
+function getSingle<T>(param?: T | T[]): T | undefined {
+  if (Array.isArray(param)) {
+    return param[0];
+  }
+  return param;
+}
+
+export const getStaticProps: GetStaticProps<ProductPageProps> = async (context) => {
+  const { params } = context;
+  const id = getSingle(params.id);
+  const client = createApolloClient(takeshapeApiUrl, () => takeshapeApiKey);
+  const {
+    data: { product }
+  } = await client.query<GetStripeProductQuery, GetStripeProductArgs>({
+    query: GetStripeProduct,
+    variables: { id: id }
+  });
+  return {
+    props: {
+      product
+    }
+  };
+};
+
+export const getStaticPaths: GetStaticPaths = async () => {
+  const client = createApolloClient(takeshapeApiUrl, () => takeshapeApiKey);
+  const { data } = await client.query<StripeProducts>({
+    query: GetStripeProducts
+  });
+  const paths = data.products.items.map((product) => ({
+    params: { id: product.id }
+  }));
+  return {
+    paths,
+    fallback: true
+  };
+};
+
+export default ProductPage;

--- a/takeshape-project.graphql
+++ b/takeshape-project.graphql
@@ -1,0 +1,14075 @@
+"""Root of the Schema"""
+type Query {
+  taxonomySuggest(
+    shapeNames: [String]
+    shapeIds: [String]
+    contentTypeNames: [String]
+    contentTypeIds: [String]
+    terms: String
+    locale: String
+    enableLocaleFallback: Boolean = true
+
+    """The offset from the first result you want to fetch."""
+    from: Int
+
+    """The maximum number of items to return."""
+    size: Int
+
+    """An elasticsearch style filter. Overrides onlyEnabled."""
+    filter: JSON
+
+    """An list of fields to sort by."""
+    sort: [TSSearchSort]
+  ): TSSuggestionPaginatedList
+
+  """List Versions for a piece of content"""
+  getContentVersion(id: ID!, version: Int!, locale: String, enableLocaleFallback: Boolean = true): TSVersionResponse
+
+  """List Versions for a piece of content"""
+  getContentVersionList(id: ID!, from: Int, size: Int): TSVersionsPaginatedList
+
+  """Get a Asset by ID"""
+  getAsset(_id: ID!, locale: String, enableLocaleFallback: Boolean = true): Asset
+
+  """Returns a list Asset in natural order."""
+  getAssetList(
+    terms: String
+
+    """The offset from the first result you want to fetch."""
+    from: Int
+
+    """The maximum number of items to return."""
+    size: Int
+
+    """An elasticsearch style filter. Overrides onlyEnabled."""
+    filter: JSONObject
+
+    """An list of fields to sort by."""
+    sort: [TSSearchSortInput]
+    locale: String
+    enableLocaleFallback: Boolean = true
+
+    """Filter out content that is not enabled. Defaults to true."""
+    onlyEnabled: Boolean = true
+
+    """
+    The where clause uses the boolean AND, OR, and NOT parameters to construct complex filters based on the values of your fields. It applies an implicit AND to all the top-level keys. To avoid this, use a single OR or NOT key as the only top-level key.
+    """
+    where: TSWhereAssetInput
+  ): AssetPaginatedList
+
+  """Get a TsStaticSite by ID"""
+  getTsStaticSite(_id: ID!, locale: String, enableLocaleFallback: Boolean = true): TsStaticSite
+
+  """Returns a list TsStaticSite in natural order."""
+  getTsStaticSiteList(
+    terms: String
+
+    """The offset from the first result you want to fetch."""
+    from: Int
+
+    """The maximum number of items to return."""
+    size: Int
+
+    """An elasticsearch style filter. Overrides onlyEnabled."""
+    filter: JSONObject
+
+    """An list of fields to sort by."""
+    sort: [TSSearchSortInput]
+    locale: String
+    enableLocaleFallback: Boolean = true
+
+    """Filter out content that is not enabled. Defaults to true."""
+    onlyEnabled: Boolean = true
+
+    """
+    The where clause uses the boolean AND, OR, and NOT parameters to construct complex filters based on the values of your fields. It applies an implicit AND to all the top-level keys. To avoid this, use a single OR or NOT key as the only top-level key.
+    """
+    where: TSWhereTsStaticSiteInput
+  ): TsStaticSitePaginatedList
+
+  """Fetch Stripe products from the API Index."""
+  getIndexedProductList(
+    terms: String
+
+    """The offset from the first result you want to fetch."""
+    from: Int
+
+    """The maximum number of items to return."""
+    size: Int
+
+    """An elasticsearch style filter. Overrides onlyEnabled."""
+    filter: JSONObject
+
+    """An list of fields to sort by."""
+    sort: [TSSearchSortInput]
+    locale: String
+    enableLocaleFallback: Boolean = true
+
+    """Filter out content that is not enabled. Defaults to true."""
+    onlyEnabled: Boolean = true
+
+    """
+    The where clause uses the boolean AND, OR, and NOT parameters to construct complex filters based on the values of your fields. It applies an implicit AND to all the top-level keys. To avoid this, use a single OR or NOT key as the only top-level key.
+    """
+    where: TSWhereStripeProductInput
+  ): Stripe_ProductPaginatedList
+
+  """Get my profile"""
+  getMyProfile: Profile
+
+  """Get my subscriptions"""
+  getMySubscriptions(expand: [String]): [Stripe_Subscription]
+
+  """Get my invoices"""
+  getMyInvoices(expand: [String], status: String, limit: Float, created: JSON, startingAfter: String): [Stripe_Invoice]
+
+  """Get my payments"""
+  getMyPayments(expand: [String], limit: Float, created: JSON, startingAfter: String, endingBefore: String): [Stripe_PaymentIntent]
+
+  """Get Stripe products."""
+  getStripeProducts: Stripe_ListProductsResponse
+
+  """Get a profile by ID"""
+  getProfile(_id: ID!, locale: String, enableLocaleFallback: Boolean = true): Profile
+
+  """Returns a list of profiles in natural order."""
+  getProfileList(
+    terms: String
+
+    """The offset from the first result you want to fetch."""
+    from: Int
+
+    """The maximum number of items to return."""
+    size: Int
+
+    """An elasticsearch style filter. Overrides onlyEnabled."""
+    filter: JSONObject
+
+    """An list of fields to sort by."""
+    sort: [TSSearchSortInput]
+    locale: String
+    enableLocaleFallback: Boolean = true
+
+    """Filter out content that is not enabled. Defaults to true."""
+    onlyEnabled: Boolean = true
+
+    """
+    The where clause uses the boolean AND, OR, and NOT parameters to construct complex filters based on the values of your fields. It applies an implicit AND to all the top-level keys. To avoid this, use a single OR or NOT key as the only top-level key.
+    """
+    where: TSWhereProfileInput
+  ): ProfilePaginatedList
+
+  """
+  <p>Returns a list of your products. The products are returned sorted by creation date, with the most recently created products appearing first.</p>
+  """
+  Stripe_listProducts(active: Boolean, created: JSON, ending_before: String, expand: [String], ids: [String], limit: Int, shippable: Boolean, starting_after: String, url: String): Stripe_ListProductsResponse
+
+  """
+  <p>Retrieves the details of an existing product. Supply the unique product ID from either a product creation request or the product list, and Stripe will return the corresponding product information.</p>
+  """
+  Stripe_getProduct(expand: [String], id: String!): Stripe_Product
+  searchAssetIndex(
+    terms: String
+
+    """The offset from the first result you want to fetch."""
+    from: Int
+
+    """The maximum number of items to return."""
+    size: Int
+
+    """An elasticsearch style filter. Overrides onlyEnabled."""
+    filter: JSONObject
+
+    """An list of fields to sort by."""
+    sort: [TSSearchSortInput]
+    locale: String
+    enableLocaleFallback: Boolean = true
+
+    """
+    The where clause uses the boolean AND, OR, and NOT parameters to construct complex filters based on the values of your fields. It applies an implicit AND to all the top-level keys. To avoid this, use a single OR or NOT key as the only top-level key.
+    """
+    where: TSWhereAssetInput
+  ): AssetSearchResults
+  searchTsStaticSiteIndex(
+    terms: String
+
+    """The offset from the first result you want to fetch."""
+    from: Int
+
+    """The maximum number of items to return."""
+    size: Int
+
+    """An elasticsearch style filter. Overrides onlyEnabled."""
+    filter: JSONObject
+
+    """An list of fields to sort by."""
+    sort: [TSSearchSortInput]
+    locale: String
+    enableLocaleFallback: Boolean = true
+
+    """
+    The where clause uses the boolean AND, OR, and NOT parameters to construct complex filters based on the values of your fields. It applies an implicit AND to all the top-level keys. To avoid this, use a single OR or NOT key as the only top-level key.
+    """
+    where: TSWhereTsStaticSiteInput
+  ): TsStaticSiteSearchResults
+  searchProfileIndex(
+    terms: String
+
+    """The offset from the first result you want to fetch."""
+    from: Int
+
+    """The maximum number of items to return."""
+    size: Int
+
+    """An elasticsearch style filter. Overrides onlyEnabled."""
+    filter: JSONObject
+
+    """An list of fields to sort by."""
+    sort: [TSSearchSortInput]
+    locale: String
+    enableLocaleFallback: Boolean = true
+
+    """
+    The where clause uses the boolean AND, OR, and NOT parameters to construct complex filters based on the values of your fields. It applies an implicit AND to all the top-level keys. To avoid this, use a single OR or NOT key as the only top-level key.
+    """
+    where: TSWhereProfileInput
+  ): ProfileSearchResults
+  search(
+    terms: String
+
+    """The offset from the first result you want to fetch."""
+    from: Int
+
+    """The maximum number of items to return."""
+    size: Int
+
+    """An elasticsearch style filter. Overrides onlyEnabled."""
+    filter: JSONObject
+
+    """An list of fields to sort by."""
+    sort: [TSSearchSortInput]
+    locale: String
+    enableLocaleFallback: Boolean = true
+    shapeNames: [String]
+    shapeIds: [String]
+    contentTypeNames: [String]
+    contentTypeIds: [String]
+
+    """
+    The where clause uses the boolean AND, OR, and NOT parameters to construct complex filters based on the values of your fields. It applies an implicit AND to all the top-level keys. To avoid this, use a single OR or NOT key as the only top-level key.
+    """
+    where: TSWhereInput
+  ): TSSearchableSearchResults
+  withContext(locale: String, enableLocaleFallback: Boolean): WithContext
+}
+
+type TSSuggestionPaginatedList {
+  items: [TSSuggestion]
+  total: Int
+}
+
+type TSSuggestion {
+  _id: ID
+  _shapeId: ID
+  _shapeName: String
+  text: String
+  summary: String
+}
+
+"""
+The `JSON` scalar type represents JSON values as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
+"""
+scalar JSON
+
+input TSSearchSort {
+  field: String!
+
+  """"asc" for ascending or "desc" for descending"""
+  order: String!
+}
+
+type TSVersionResponse {
+  content: JSONObject
+  schema: JSONObject
+}
+
+"""
+The `JSONObject` scalar type represents JSON objects as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
+"""
+scalar JSONObject
+
+type TSVersionsPaginatedList {
+  items: [TSVersion]
+  total: Int
+  from: Int
+  size: Int
+}
+
+type TSVersion {
+  id: String
+  version: Int
+  status: String
+  enabled: Boolean
+  color: String
+  updatedAt: String
+  updatedBy: TSProjectMember
+  item(locale: String, enableLocaleFallback: Boolean = true): TSVersionResponse
+}
+
+type TSProjectMember {
+  id: ID
+  email: String
+  fullName: String
+  role: String
+  avatarPath: String
+}
+
+type Asset implements TSSearchable {
+  title: String
+  description: String
+  filename: String!
+  caption: JSON
+  captionHtml(
+    imageConfig: JSON
+    images: TSImagesConfig
+
+    """A prefix to be added to all CSS classes in the generated HTML"""
+    classPrefix: String = ""
+
+    """
+    A prefix to be added to all id properties on header elements in the generated HTML
+    """
+    headerIdPrefix: String = ""
+  ): String
+  credit: JSON
+  creditHtml(
+    imageConfig: JSON
+    images: TSImagesConfig
+
+    """A prefix to be added to all CSS classes in the generated HTML"""
+    classPrefix: String = ""
+
+    """
+    A prefix to be added to all id properties on header elements in the generated HTML
+    """
+    headerIdPrefix: String = ""
+  ): String
+  path: String!
+  mimeType: String
+  sourceUrl: String
+  uploadStatus: String
+  _shapeId: String
+  _id: ID
+  _version: Int
+  _shapeName: String
+  _createdAt: String
+  _createdBy: TSUser
+  _updatedAt: String
+  _updatedBy: TSUser
+  _schemaVersion: Float
+  _enabled: Boolean @deprecated(reason: "Use _status instead")
+  _enabledAt: String @deprecated(reason: "Use a custom date field instead")
+  _status: DefaultWorkflow
+  _contentTypeId: String
+  _contentTypeName: String
+  s3Key: String @deprecated(reason: "Use path instead")
+  searchSummary: String
+}
+
+interface TSSearchable {
+  _id: ID
+  _shapeId: String
+  searchSummary: String
+}
+
+input TSImagesConfig {
+  """Default image parameters. See https://docs.imgix.com/apis/url """
+  default: JSON
+
+  """Small image parameters. See https://docs.imgix.com/apis/url """
+  small: JSON
+
+  """Medium image parameters. See https://docs.imgix.com/apis/url """
+  medium: JSON
+
+  """Large image parameters. See https://docs.imgix.com/apis/url """
+  large: JSON
+}
+
+type TSUser {
+  id: String!
+  email: String!
+  fullName: String!
+  avatarPath: String
+}
+
+enum DefaultWorkflow {
+  disabled
+  enabled
+}
+
+type AssetPaginatedList {
+  items: [Asset!]!
+  total: Int!
+}
+
+input TSSearchSortInput {
+  field: String!
+
+  """"asc" for ascending or "desc" for descending"""
+  order: String!
+}
+
+input TSWhereAssetInput {
+  title: TSWhereStringInput
+  description: TSWhereStringInput
+  filename: TSWhereStringInput
+  caption: TSWhereDraftjsInput
+  credit: TSWhereDraftjsInput
+  path: TSWhereStringInput
+  mimeType: TSWhereStringInput
+  sourceUrl: TSWhereStringInput
+  uploadStatus: TSWhereStringInput
+  _shapeId: TSWhereIDInput
+  _id: TSWhereIDInput
+  _version: TSWhereIntegerInput
+  _shapeName: TSWhereStringInput
+  _createdAt: TSWhereDateInput
+  _updatedAt: TSWhereDateInput
+  _schemaVersion: TSWhereNumberInput
+  _status: TSWhereWorkflowInput
+  _contentTypeId: TSWhereIDInput
+  _contentTypeName: TSWhereStringInput
+  s3Key: TSWhereStringInput
+  AND: [TSWhereAssetInput]
+  OR: [TSWhereAssetInput]
+  NOT: TSWhereAssetInput
+}
+
+input TSWhereStringInput {
+  """Exact match"""
+  eq: String
+
+  """Array of possible exact match values."""
+  in: [String]
+
+  """Full text searching with fuzzy matching."""
+  match: String
+
+  """
+  Regular expression string matching. Use of * wildcards could degrade performance.
+  """
+  regexp: String
+}
+
+input TSWhereDraftjsInput {
+  """Full text searching with fuzzy matching."""
+  match: String
+}
+
+input TSWhereIDInput {
+  """Exact match"""
+  eq: String
+
+  """Array of possible exact match values."""
+  in: [String]
+}
+
+input TSWhereIntegerInput {
+  """Exact match"""
+  eq: Int
+
+  """Less than"""
+  lt: Int
+
+  """Less than or equal"""
+  lte: Int
+
+  """Greater than"""
+  gt: Int
+
+  """Greater than or equal"""
+  gte: Int
+
+  """Array of possible exact match values."""
+  in: [Int]
+}
+
+input TSWhereDateInput {
+  """Exact match"""
+  eq: String
+
+  """Less than"""
+  lt: String
+
+  """Less than or equal"""
+  lte: String
+
+  """Greater than"""
+  gt: String
+
+  """Greater than or equal"""
+  gte: String
+}
+
+input TSWhereNumberInput {
+  """Exact match"""
+  eq: Float
+
+  """Less than"""
+  lt: Float
+
+  """Less than or equal"""
+  lte: Float
+
+  """Greater than"""
+  gt: Float
+
+  """Greater than or equal"""
+  gte: Float
+
+  """Array of possible exact match values."""
+  in: [Float]
+}
+
+input TSWhereWorkflowInput {
+  """Exact match"""
+  eq: String
+
+  """Less than"""
+  lt: String
+
+  """Less than or equal"""
+  lte: String
+
+  """Greater than"""
+  gt: String
+
+  """Greater than or equal"""
+  gte: String
+
+  """Array of possible exact match values."""
+  in: [String]
+}
+
+type TsStaticSite implements TSSearchable {
+  title: String!
+  baseUrl: String
+  provider: String!
+  idKey: String
+  secretKey: String
+  destination: String!
+  privateAcl: Boolean
+  environmentVariables: [TsStaticSiteEnvironmentVariables]
+  triggers: [TsStaticSiteTriggers]
+  templateHash: String
+  _shapeId: String
+  _id: ID
+  _version: Int
+  _shapeName: String
+  _createdAt: String
+  _createdBy: TSUser
+  _updatedAt: String
+  _updatedBy: TSUser
+  _schemaVersion: Float
+  _enabled: Boolean @deprecated(reason: "Use _status instead")
+  _enabledAt: String @deprecated(reason: "Use a custom date field instead")
+  _status: DefaultWorkflow
+  _contentTypeId: String
+  _contentTypeName: String
+  searchSummary: String
+}
+
+type TsStaticSiteEnvironmentVariables {
+  name: String
+  value: String
+}
+
+type TsStaticSiteTriggers {
+  contentTypeId: String
+  status: String
+}
+
+type TsStaticSitePaginatedList {
+  items: [TsStaticSite!]!
+  total: Int!
+}
+
+input TSWhereTsStaticSiteInput {
+  title: TSWhereStringInput
+  baseUrl: TSWhereStringInput
+  provider: TSWhereStringInput
+  idKey: TSWhereStringInput
+  destination: TSWhereStringInput
+  privateAcl: TSWhereBooleanInput
+  environmentVariables: TSWhereTsStaticSiteEnvironmentVariablesInput
+  triggers: TSWhereTsStaticSiteTriggersInput
+  templateHash: TSWhereStringInput
+  _shapeId: TSWhereIDInput
+  _id: TSWhereIDInput
+  _version: TSWhereIntegerInput
+  _shapeName: TSWhereStringInput
+  _createdAt: TSWhereDateInput
+  _updatedAt: TSWhereDateInput
+  _schemaVersion: TSWhereNumberInput
+  _status: TSWhereWorkflowInput
+  _contentTypeId: TSWhereIDInput
+  _contentTypeName: TSWhereStringInput
+  AND: [TSWhereTsStaticSiteInput]
+  OR: [TSWhereTsStaticSiteInput]
+  NOT: TSWhereTsStaticSiteInput
+}
+
+input TSWhereBooleanInput {
+  """Exact match"""
+  eq: Boolean
+}
+
+input TSWhereTsStaticSiteEnvironmentVariablesInput {
+  name: TSWhereStringInput
+  value: TSWhereStringInput
+}
+
+input TSWhereTsStaticSiteTriggersInput {
+  contentTypeId: TSWhereStringInput
+  status: TSWhereStringInput
+}
+
+type Stripe_ProductPaginatedList {
+  items: [Stripe_Product!]!
+  total: Int!
+}
+
+type Stripe_Product implements TSSearchable {
+  """Whether the product is currently available for purchase."""
+  active: Boolean
+
+  """
+  Time at which the object was created. Measured in seconds since the Unix epoch.
+  """
+  created: Int
+
+  """
+  The product's description, meant to be displayable to the customer. Use this field to optionally store a long form explanation of the product being sold for your own rendering purposes.
+  """
+  description: String
+
+  """Unique identifier for the object."""
+  id: String
+
+  """
+  A list of up to 8 URLs of images for this product, meant to be displayable to the customer.
+  """
+  images: [String]
+
+  """
+  Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode.
+  """
+  livemode: Boolean
+
+  """
+  Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format.
+  """
+  metadata: JSONObject
+
+  """
+  The product's name, meant to be displayable to the customer. Whenever this product is sold via a subscription, name will show up on associated invoice line item descriptions.
+  """
+  name: String
+
+  """
+  String representing the object's type. Objects of the same type share the same value.
+  """
+  object: Stripe_ProductObjectProperty
+  package_dimensions: Stripe_PackageDimensions
+
+  """Whether this product is shipped (i.e., physical goods)."""
+  shippable: Boolean
+
+  """
+  Extra information about a product which will appear on your customer's credit card statement. In the case that multiple products are billed at once, the first statement descriptor will be used.
+  """
+  statement_descriptor: String
+  tax_code: Stripe_ProductTaxCodeProperty
+
+  """
+  A label that represents units of this product in Stripe and on customers’ receipts and invoices. When set, this will be included in associated invoice line item descriptions.
+  """
+  unit_label: String
+
+  """
+  Time at which the object was last updated. Measured in seconds since the Unix epoch.
+  """
+  updated: Int
+
+  """A URL of a publicly-accessible webpage for this product."""
+  url: String
+  prices: [Stripe_Price]
+  _shapeId: String
+  _id: ID
+  searchSummary: String
+}
+
+enum Stripe_ProductObjectProperty {
+  product
+}
+
+type Stripe_PackageDimensions {
+  """Height, in inches."""
+  height: Float
+
+  """Length, in inches."""
+  length: Float
+
+  """Weight, in ounces."""
+  weight: Float
+
+  """Width, in inches."""
+  width: Float
+}
+
+union Stripe_ProductTaxCodeProperty = WrappedString | Stripe_TaxCode
+
+type WrappedString {
+  value: String!
+}
+
+type Stripe_TaxCode {
+  """
+  A detailed description of which types of products the tax code represents.
+  """
+  description: String
+
+  """Unique identifier for the object."""
+  id: String
+
+  """A short name for the tax code."""
+  name: String
+
+  """
+  String representing the object's type. Objects of the same type share the same value.
+  """
+  object: Stripe_TaxCodeObjectProperty
+}
+
+enum Stripe_TaxCodeObjectProperty {
+  tax_code
+}
+
+type Stripe_Price {
+  """Whether the price can be used for new purchases."""
+  active: Boolean
+
+  """
+  Describes how to compute the price per period. Either `per_unit` or `tiered`. `per_unit` indicates that the fixed amount (specified in `unit_amount` or `unit_amount_decimal`) will be charged per unit in `quantity` (for prices with `usage_type=licensed`), or per unit of total usage (for prices with `usage_type=metered`). `tiered` indicates that the unit pricing will be computed using a tiering strategy as defined using the `tiers` and `tiers_mode` attributes.
+  """
+  billing_scheme: Stripe_PriceBillingSchemeProperty
+
+  """
+  Time at which the object was created. Measured in seconds since the Unix epoch.
+  """
+  created: Int
+
+  """
+  Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
+  """
+  currency: String
+
+  """Unique identifier for the object."""
+  id: String
+
+  """
+  Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode.
+  """
+  livemode: Boolean
+
+  """A lookup key used to retrieve prices dynamically from a static string."""
+  lookup_key: String
+
+  """
+  Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format.
+  """
+  metadata: JSONObject
+
+  """A brief description of the price, hidden from customers."""
+  nickname: String
+
+  """
+  String representing the object's type. Objects of the same type share the same value.
+  """
+  object: Stripe_PriceObjectProperty
+
+  """The Stripe product associated with this subscription."""
+  product: Stripe_Product
+  recurring: Stripe_Recurring
+
+  """
+  Specifies whether the price is considered inclusive of taxes or exclusive of taxes. One of `inclusive`, `exclusive`, or `unspecified`. Once specified as either `inclusive` or `exclusive`, it cannot be changed.
+  """
+  tax_behavior: Stripe_PriceTaxBehaviorProperty
+
+  """
+  Each element represents a pricing tier. This parameter requires `billing_scheme` to be set to `tiered`. See also the documentation for `billing_scheme`.
+  """
+  tiers: [Stripe_PriceTier]
+
+  """
+  Defines if the tiering price should be `graduated` or `volume` based. In `volume`-based tiering, the maximum quantity within a period determines the per unit price. In `graduated` tiering, pricing can change as the quantity grows.
+  """
+  tiers_mode: Stripe_PriceTiersModeProperty
+  transform_quantity: Stripe_TransformQuantity
+
+  """
+  One of `one_time` or `recurring` depending on whether the price is for a one-time purchase or a recurring (subscription) purchase.
+  """
+  type: Stripe_PriceTypeProperty
+
+  """
+  The unit amount in %s to be charged, represented as a whole integer if possible. Only set if `billing_scheme=per_unit`.
+  """
+  unit_amount: Int
+
+  """
+  The unit amount in %s to be charged, represented as a decimal string with at most 12 decimal places. Only set if `billing_scheme=per_unit`.
+  """
+  unit_amount_decimal: String
+}
+
+enum Stripe_PriceBillingSchemeProperty {
+  per_unit
+  tiered
+}
+
+enum Stripe_PriceObjectProperty {
+  price
+}
+
+type Stripe_Recurring {
+  """
+  Specifies a usage aggregation strategy for prices of `usage_type=metered`. Allowed values are `sum` for summing up all usage during a period, `last_during_period` for using the last usage record reported within a period, `last_ever` for using the last usage record ever (across period bounds) or `max` which uses the usage record with the maximum reported usage during a period. Defaults to `sum`.
+  """
+  aggregate_usage: Stripe_RecurringAggregateUsageProperty
+
+  """
+  The frequency at which a subscription is billed. One of `day`, `week`, `month` or `year`.
+  """
+  interval: Stripe_RecurringIntervalProperty
+
+  """
+  The number of intervals (specified in the `interval` attribute) between subscription billings. For example, `interval=month` and `interval_count=3` bills every 3 months.
+  """
+  interval_count: Int
+
+  """
+  Configures how the quantity per period should be determined. Can be either `metered` or `licensed`. `licensed` automatically bills the `quantity` set when adding it to a subscription. `metered` aggregates the total usage based on usage records. Defaults to `licensed`.
+  """
+  usage_type: Stripe_RecurringUsageTypeProperty
+}
+
+enum Stripe_RecurringAggregateUsageProperty {
+  last_during_period
+  last_ever
+  max
+  sum
+}
+
+enum Stripe_RecurringIntervalProperty {
+  day
+  month
+  week
+  year
+}
+
+enum Stripe_RecurringUsageTypeProperty {
+  licensed
+  metered
+}
+
+enum Stripe_PriceTaxBehaviorProperty {
+  exclusive
+  inclusive
+  unspecified
+}
+
+type Stripe_PriceTier {
+  """Price for the entire tier."""
+  flat_amount: Int
+
+  """
+  Same as `flat_amount`, but contains a decimal value with at most 12 decimal places.
+  """
+  flat_amount_decimal: String
+
+  """Per unit price for units relevant to the tier."""
+  unit_amount: Int
+
+  """
+  Same as `unit_amount`, but contains a decimal value with at most 12 decimal places.
+  """
+  unit_amount_decimal: String
+
+  """Up to and including to this quantity will be contained in the tier."""
+  up_to: Int
+}
+
+enum Stripe_PriceTiersModeProperty {
+  graduated
+  volume
+}
+
+type Stripe_TransformQuantity {
+  """Divide usage by this number."""
+  divide_by: Int
+
+  """After division, either round the result `up` or `down`."""
+  round: Stripe_TransformQuantityRoundProperty
+}
+
+enum Stripe_TransformQuantityRoundProperty {
+  down
+  up
+}
+
+enum Stripe_PriceTypeProperty {
+  one_time
+  recurring
+}
+
+input TSWhereStripeProductInput {
+  active: TSWhereBooleanInput
+  created: TSWhereIntegerInput
+  description: TSWhereStringInput
+  id: TSWhereStringInput
+  images: TSWhereStripe_ProductImagesInput
+  livemode: TSWhereBooleanInput
+  name: TSWhereStringInput
+  object: TSWhereInput
+  package_dimensions: TSWhereStripe_PackageDimensionsInput
+  shippable: TSWhereBooleanInput
+  statement_descriptor: TSWhereStringInput
+  unit_label: TSWhereStringInput
+  updated: TSWhereIntegerInput
+  url: TSWhereStringInput
+  _shapeId: TSWhereIDInput
+  _id: TSWhereIDInput
+  AND: [TSWhereStripeProductInput]
+  OR: [TSWhereStripeProductInput]
+  NOT: TSWhereStripeProductInput
+}
+
+input TSWhereStripe_ProductImagesInput {
+  """Exact match"""
+  eq: String
+
+  """Array of possible exact match values."""
+  in: [String]
+
+  """Full text searching with fuzzy matching."""
+  match: String
+
+  """
+  Regular expression string matching. Use of * wildcards could degrade performance.
+  """
+  regexp: String
+}
+
+input TSWhereInput {
+  title: TSWhereStringInput
+  description: TSWhereStringInput
+  filename: TSWhereStringInput
+  caption: TSWhereDraftjsInput
+  credit: TSWhereDraftjsInput
+  path: TSWhereStringInput
+  mimeType: TSWhereStringInput
+  sourceUrl: TSWhereStringInput
+  uploadStatus: TSWhereStringInput
+  _shapeId: TSWhereIDInput
+  _id: TSWhereIDInput
+  _version: TSWhereIntegerInput
+  _shapeName: TSWhereStringInput
+  _createdAt: TSWhereDateInput
+  _updatedAt: TSWhereDateInput
+  _schemaVersion: TSWhereNumberInput
+  _status: TSWhereWorkflowInput
+  _contentTypeId: TSWhereIDInput
+  _contentTypeName: TSWhereStringInput
+  s3Key: TSWhereStringInput
+  baseUrl: TSWhereStringInput
+  provider: TSWhereStringInput
+  idKey: TSWhereStringInput
+  destination: TSWhereStringInput
+  privateAcl: TSWhereBooleanInput
+  environmentVariables: TSWhereTsStaticSiteEnvironmentVariablesInput
+  triggers: TSWhereTsStaticSiteTriggersInput
+  templateHash: TSWhereStringInput
+  active: TSWhereBooleanInput
+  created: TSWhereIntegerInput
+  id: TSWhereStringInput
+  images: TSWhereStripe_ProductImagesInput
+  livemode: TSWhereBooleanInput
+  name: TSWhereStringInput
+  object: TSWhereInput
+  package_dimensions: TSWhereStripe_PackageDimensionsInput
+  shippable: TSWhereBooleanInput
+  statement_descriptor: TSWhereStringInput
+  unit_label: TSWhereStringInput
+  updated: TSWhereIntegerInput
+  url: TSWhereStringInput
+  email: TSWhereStringInput
+  bio: TSWhereStringInput
+  avatar: TSWhereAssetRelationshipInput
+  stripeCustomerId: TSWhereStringInput
+  AND: [TSWhereInput]
+  OR: [TSWhereInput]
+  NOT: TSWhereInput
+}
+
+input TSWhereStripe_PackageDimensionsInput {
+  height: TSWhereNumberInput
+  length: TSWhereNumberInput
+  weight: TSWhereNumberInput
+  width: TSWhereNumberInput
+}
+
+input TSWhereAssetRelationshipInput {
+  title: TSWhereStringInput
+  description: TSWhereStringInput
+  filename: TSWhereStringInput
+  caption: TSWhereDraftjsInput
+  credit: TSWhereDraftjsInput
+  path: TSWhereStringInput
+  mimeType: TSWhereStringInput
+  sourceUrl: TSWhereStringInput
+  uploadStatus: TSWhereStringInput
+  _shapeId: TSWhereIDInput
+  _id: TSWhereIDInput
+  _version: TSWhereIntegerInput
+  _shapeName: TSWhereStringInput
+  _createdAt: TSWhereDateInput
+  _updatedAt: TSWhereDateInput
+  _schemaVersion: TSWhereNumberInput
+  _status: TSWhereWorkflowInput
+  _contentTypeId: TSWhereIDInput
+  _contentTypeName: TSWhereStringInput
+  s3Key: TSWhereStringInput
+}
+
+type Profile implements TSSearchable {
+  """"""
+  id: String
+
+  """"""
+  name: String
+
+  """"""
+  email: String
+
+  """"""
+  bio: String
+  avatar(locale: String, enableLocaleFallback: Boolean = true): Asset
+
+  """"""
+  stripeCustomerId: String
+
+  """"""
+  stripeCustomer: Stripe_Customer
+  _shapeId: String
+  _id: ID
+  _version: Int
+  _shapeName: String
+  _createdAt: String
+  _createdBy: TSUser
+  _updatedAt: String
+  _updatedBy: TSUser
+  _schemaVersion: Float
+  _enabled: Boolean @deprecated(reason: "Use _status instead")
+  _enabledAt: String @deprecated(reason: "Use a custom date field instead")
+  _status: DefaultWorkflow
+  _contentTypeId: String
+  _contentTypeName: String
+  searchSummary: String
+}
+
+type Stripe_Customer {
+  address: Stripe_Address
+
+  """
+  Current balance, if any, being stored on the customer. If negative, the customer has credit to apply to their next invoice. If positive, the customer has an amount owed that will be added to their next invoice. The balance does not refer to any unpaid invoices; it solely takes into account amounts that have yet to be successfully applied to any invoice. This balance is only taken into account as invoices are finalized.
+  """
+  balance: Int
+
+  """
+  Time at which the object was created. Measured in seconds since the Unix epoch.
+  """
+  created: Int
+
+  """
+  Three-letter [ISO code for the currency](https://stripe.com/docs/currencies) the customer can be charged in for recurring billing purposes.
+  """
+  currency: String
+  default_source: Stripe_CustomerDefaultSourceProperty
+
+  """
+  When the customer's latest invoice is billed by charging automatically, `delinquent` is `true` if the invoice's latest charge failed. When the customer's latest invoice is billed by sending an invoice, `delinquent` is `true` if the invoice isn't paid by its due date.
+  
+  If an invoice is marked uncollectible by [dunning](https://stripe.com/docs/billing/automatic-collection), `delinquent` doesn't get reset to `false`.
+  """
+  delinquent: Boolean
+
+  """
+  An arbitrary string attached to the object. Often useful for displaying to users.
+  """
+  description: String
+  discount: Stripe_Discount
+
+  """The customer's email address."""
+  email: String
+
+  """Unique identifier for the object."""
+  id: String
+
+  """The prefix for the customer used to generate unique invoice numbers."""
+  invoice_prefix: String
+  invoice_settings: Stripe_InvoiceSettingCustomerSetting
+
+  """
+  Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode.
+  """
+  livemode: Boolean
+
+  """
+  Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format.
+  """
+  metadata: JSONObject
+
+  """The customer's full name or business name."""
+  name: String
+
+  """The suffix of the customer's next invoice number, e.g., 0001."""
+  next_invoice_sequence: Int
+
+  """
+  String representing the object's type. Objects of the same type share the same value.
+  """
+  object: Stripe_CustomerObjectProperty
+
+  """The customer's phone number."""
+  phone: String
+
+  """The customer's preferred locales (languages), ordered by preference."""
+  preferred_locales: [String]
+  shipping: Stripe_Shipping
+
+  """The customer's payment sources, if any."""
+  sources: Stripe_CustomerSourcesProperty
+
+  """The customer's current subscriptions, if any."""
+  subscriptions: Stripe_CustomerSubscriptionsProperty
+  tax: Stripe_CustomerTax
+
+  """
+  Describes the customer's tax exemption status. One of `none`, `exempt`, or `reverse`. When set to `reverse`, invoice and receipt PDFs include the text **"Reverse charge"**.
+  """
+  tax_exempt: Stripe_CustomerTaxExemptProperty
+
+  """The customer's tax IDs."""
+  tax_ids: Stripe_CustomerTaxIdsProperty
+}
+
+type Stripe_Address {
+  """City, district, suburb, town, or village."""
+  city: String
+
+  """
+  Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
+  """
+  country: String
+
+  """Address line 1 (e.g., street, PO Box, or company name)."""
+  line1: String
+
+  """Address line 2 (e.g., apartment, suite, unit, or building)."""
+  line2: String
+
+  """ZIP or postal code."""
+  postal_code: String
+
+  """State, county, province, or region."""
+  state: String
+}
+
+union Stripe_CustomerDefaultSourceProperty = WrappedString | Stripe_AlipayAccount | Stripe_BankAccount | Stripe_BitcoinReceiver | Stripe_Card | Stripe_Source
+
+type Stripe_AlipayAccount {
+  """
+  Time at which the object was created. Measured in seconds since the Unix epoch.
+  """
+  created: Int
+  customer: Stripe_AlipayAccountCustomerProperty
+
+  """
+  Uniquely identifies the account and will be the same across all Alipay account objects that are linked to the same Alipay account.
+  """
+  fingerprint: String
+
+  """Unique identifier for the object."""
+  id: String
+
+  """
+  Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode.
+  """
+  livemode: Boolean
+
+  """
+  Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format.
+  """
+  metadata: JSONObject
+
+  """
+  String representing the object's type. Objects of the same type share the same value.
+  """
+  object: Stripe_AlipayAccountObjectProperty
+
+  """
+  If the Alipay account object is not reusable, the exact amount that you can create a charge for.
+  """
+  payment_amount: Int
+
+  """
+  If the Alipay account object is not reusable, the exact currency that you can create a charge for.
+  """
+  payment_currency: String
+
+  """
+  True if you can create multiple payments using this account. If the account is reusable, then you can freely choose the amount of each payment.
+  """
+  reusable: Boolean
+
+  """Whether this Alipay account object has ever been used for a payment."""
+  used: Boolean
+
+  """The username for the Alipay account."""
+  username: String
+}
+
+union Stripe_AlipayAccountCustomerProperty = WrappedString | Stripe_Customer | Stripe_DeletedCustomer
+
+type Stripe_DeletedCustomer {
+  """Unique identifier for the object."""
+  id: String
+
+  """
+  String representing the object's type. Objects of the same type share the same value.
+  """
+  object: Stripe_DeletedCustomerObjectProperty
+}
+
+enum Stripe_DeletedCustomerObjectProperty {
+  customer
+}
+
+enum Stripe_AlipayAccountObjectProperty {
+  alipay_account
+}
+
+type Stripe_BankAccount {
+  account: Stripe_BankAccountAccountProperty
+
+  """The name of the person or business that owns the bank account."""
+  account_holder_name: String
+
+  """
+  The type of entity that holds the account. This can be either `individual` or `company`.
+  """
+  account_holder_type: String
+
+  """
+  A set of available payout methods for this bank account. Only values from this set should be passed as the `method` when creating a payout.
+  """
+  available_payout_methods: [Stripe_BankAccountAvailablePayoutMethodsProperty]
+
+  """
+  Name of the bank associated with the routing number (e.g., `WELLS FARGO`).
+  """
+  bank_name: String
+
+  """
+  Two-letter ISO code representing the country the bank account is located in.
+  """
+  country: String
+
+  """
+  Three-letter [ISO code for the currency](https://stripe.com/docs/payouts) paid out to the bank account.
+  """
+  currency: String
+  customer: Stripe_BankAccountCustomerProperty
+
+  """
+  Whether this bank account is the default external account for its currency.
+  """
+  default_for_currency: Boolean
+
+  """
+  Uniquely identifies this particular bank account. You can use this attribute to check whether two bank accounts are the same.
+  """
+  fingerprint: String
+
+  """Unique identifier for the object."""
+  id: String
+
+  """The last four digits of the bank account number."""
+  last4: String
+
+  """
+  Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format.
+  """
+  metadata: JSONObject
+
+  """
+  String representing the object's type. Objects of the same type share the same value.
+  """
+  object: Stripe_BankAccountObjectProperty
+
+  """The routing transit number for the bank account."""
+  routing_number: String
+
+  """
+  For bank accounts, possible values are `new`, `validated`, `verified`, `verification_failed`, or `errored`. A bank account that hasn't had any activity or validation performed is `new`. If Stripe can determine that the bank account exists, its status will be `validated`. Note that there often isn’t enough information to know (e.g., for smaller credit unions), and the validation is not always run. If customer bank account verification has succeeded, the bank account status will be `verified`. If the verification failed for any reason, such as microdeposit failure, the status will be `verification_failed`. If a transfer sent to this bank account fails, we'll set the status to `errored` and will not continue to send transfers until the bank details are updated.
+  
+  For external accounts, possible values are `new` and `errored`. Validations aren't run against external accounts because they're only used for payouts. This means the other statuses don't apply. If a transfer fails, the status is set to `errored` and transfers are stopped until account details are updated.
+  """
+  status: String
+}
+
+union Stripe_BankAccountAccountProperty = WrappedString | Stripe_Account
+
+type Stripe_Account {
+  business_profile: Stripe_AccountBusinessProfile
+
+  """The business type."""
+  business_type: Stripe_AccountBusinessTypeProperty
+  capabilities: Stripe_AccountCapabilities
+
+  """Whether the account can create live charges."""
+  charges_enabled: Boolean
+  company: Stripe_LegalEntityCompany
+  controller: Stripe_AccountController
+
+  """The account's country."""
+  country: String
+
+  """
+  Time at which the object was created. Measured in seconds since the Unix epoch.
+  """
+  created: Int
+
+  """
+  Three-letter ISO currency code representing the default currency for the account. This must be a currency that [Stripe supports in the account's country](https://stripe.com/docs/payouts).
+  """
+  default_currency: String
+
+  """
+  Whether account details have been submitted. Standard accounts cannot receive payouts before this is true.
+  """
+  details_submitted: Boolean
+
+  """
+  An email address associated with the account. You can treat this as metadata: it is not used for authentication or messaging account holders.
+  """
+  email: String
+
+  """
+  External accounts (bank accounts and debit cards) currently attached to this account
+  """
+  external_accounts: Stripe_AccountExternalAccountsProperty
+
+  """Unique identifier for the object."""
+  id: String
+  individual: Stripe_Person
+
+  """
+  Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format.
+  """
+  metadata: JSONObject
+
+  """
+  String representing the object's type. Objects of the same type share the same value.
+  """
+  object: Stripe_AccountObjectProperty
+
+  """Whether Stripe can send payouts to this account."""
+  payouts_enabled: Boolean
+  requirements: Stripe_AccountRequirements
+  settings: Stripe_AccountSettings
+  tos_acceptance: Stripe_AccountTosAcceptance
+
+  """The Stripe account type. Can be `standard`, `express`, or `custom`."""
+  type: Stripe_AccountTypeProperty
+}
+
+type Stripe_AccountBusinessProfile {
+  """
+  [The merchant category code for the account](https://stripe.com/docs/connect/setting-mcc). MCCs are used to classify businesses based on the goods or services they provide.
+  """
+  mcc: String
+
+  """The customer-facing business name."""
+  name: String
+
+  """
+  Internal-only description of the product sold or service provided by the business. It's used by Stripe for risk and underwriting purposes.
+  """
+  product_description: String
+  support_address: Stripe_Address
+
+  """A publicly available email address for sending support issues to."""
+  support_email: String
+
+  """A publicly available phone number to call with support issues."""
+  support_phone: String
+
+  """A publicly available website for handling support issues."""
+  support_url: String
+
+  """The business's publicly available website."""
+  url: String
+}
+
+enum Stripe_AccountBusinessTypeProperty {
+  company
+  government_entity
+  individual
+  non_profit
+}
+
+type Stripe_AccountCapabilities {
+  """
+  The status of the ACSS Direct Debits payments capability of the account, or whether the account can directly process ACSS Direct Debits charges.
+  """
+  acss_debit_payments: Stripe_AccountCapabilitiesAcssDebitPaymentsProperty
+
+  """
+  The status of the Afterpay Clearpay capability of the account, or whether the account can directly process Afterpay Clearpay charges.
+  """
+  afterpay_clearpay_payments: Stripe_AccountCapabilitiesAfterpayClearpayPaymentsProperty
+
+  """
+  The status of the BECS Direct Debit (AU) payments capability of the account, or whether the account can directly process BECS Direct Debit (AU) charges.
+  """
+  au_becs_debit_payments: Stripe_AccountCapabilitiesAuBecsDebitPaymentsProperty
+
+  """
+  The status of the Bacs Direct Debits payments capability of the account, or whether the account can directly process Bacs Direct Debits charges.
+  """
+  bacs_debit_payments: Stripe_AccountCapabilitiesBacsDebitPaymentsProperty
+
+  """
+  The status of the Bancontact payments capability of the account, or whether the account can directly process Bancontact charges.
+  """
+  bancontact_payments: Stripe_AccountCapabilitiesBancontactPaymentsProperty
+
+  """
+  The status of the boleto payments capability of the account, or whether the account can directly process boleto charges.
+  """
+  boleto_payments: Stripe_AccountCapabilitiesBoletoPaymentsProperty
+
+  """
+  The status of the card issuing capability of the account, or whether you can use Issuing to distribute funds on cards
+  """
+  card_issuing: Stripe_AccountCapabilitiesCardIssuingProperty
+
+  """
+  The status of the card payments capability of the account, or whether the account can directly process credit and debit card charges.
+  """
+  card_payments: Stripe_AccountCapabilitiesCardPaymentsProperty
+
+  """
+  The status of the Cartes Bancaires payments capability of the account, or whether the account can directly process Cartes Bancaires card charges in EUR currency.
+  """
+  cartes_bancaires_payments: Stripe_AccountCapabilitiesCartesBancairesPaymentsProperty
+
+  """
+  The status of the EPS payments capability of the account, or whether the account can directly process EPS charges.
+  """
+  eps_payments: Stripe_AccountCapabilitiesEpsPaymentsProperty
+
+  """
+  The status of the FPX payments capability of the account, or whether the account can directly process FPX charges.
+  """
+  fpx_payments: Stripe_AccountCapabilitiesFpxPaymentsProperty
+
+  """
+  The status of the giropay payments capability of the account, or whether the account can directly process giropay charges.
+  """
+  giropay_payments: Stripe_AccountCapabilitiesGiropayPaymentsProperty
+
+  """
+  The status of the GrabPay payments capability of the account, or whether the account can directly process GrabPay charges.
+  """
+  grabpay_payments: Stripe_AccountCapabilitiesGrabpayPaymentsProperty
+
+  """
+  The status of the iDEAL payments capability of the account, or whether the account can directly process iDEAL charges.
+  """
+  ideal_payments: Stripe_AccountCapabilitiesIdealPaymentsProperty
+
+  """
+  The status of the JCB payments capability of the account, or whether the account (Japan only) can directly process JCB credit card charges in JPY currency.
+  """
+  jcb_payments: Stripe_AccountCapabilitiesJcbPaymentsProperty
+
+  """The status of the legacy payments capability of the account."""
+  legacy_payments: Stripe_AccountCapabilitiesLegacyPaymentsProperty
+
+  """
+  The status of the OXXO payments capability of the account, or whether the account can directly process OXXO charges.
+  """
+  oxxo_payments: Stripe_AccountCapabilitiesOxxoPaymentsProperty
+
+  """
+  The status of the P24 payments capability of the account, or whether the account can directly process P24 charges.
+  """
+  p24_payments: Stripe_AccountCapabilitiesP24PaymentsProperty
+
+  """
+  The status of the SEPA Direct Debits payments capability of the account, or whether the account can directly process SEPA Direct Debits charges.
+  """
+  sepa_debit_payments: Stripe_AccountCapabilitiesSepaDebitPaymentsProperty
+
+  """
+  The status of the Sofort payments capability of the account, or whether the account can directly process Sofort charges.
+  """
+  sofort_payments: Stripe_AccountCapabilitiesSofortPaymentsProperty
+
+  """The status of the tax reporting 1099-K (US) capability of the account."""
+  tax_reporting_us_1099_k: Stripe_AccountCapabilitiesTaxReportingUs1099KProperty
+
+  """
+  The status of the tax reporting 1099-MISC (US) capability of the account.
+  """
+  tax_reporting_us_1099_misc: Stripe_AccountCapabilitiesTaxReportingUs1099MiscProperty
+
+  """
+  The status of the transfers capability of the account, or whether your platform can transfer funds to the account.
+  """
+  transfers: Stripe_AccountCapabilitiesTransfersProperty
+}
+
+enum Stripe_AccountCapabilitiesAcssDebitPaymentsProperty {
+  active
+  inactive
+  pending
+}
+
+enum Stripe_AccountCapabilitiesAfterpayClearpayPaymentsProperty {
+  active
+  inactive
+  pending
+}
+
+enum Stripe_AccountCapabilitiesAuBecsDebitPaymentsProperty {
+  active
+  inactive
+  pending
+}
+
+enum Stripe_AccountCapabilitiesBacsDebitPaymentsProperty {
+  active
+  inactive
+  pending
+}
+
+enum Stripe_AccountCapabilitiesBancontactPaymentsProperty {
+  active
+  inactive
+  pending
+}
+
+enum Stripe_AccountCapabilitiesBoletoPaymentsProperty {
+  active
+  inactive
+  pending
+}
+
+enum Stripe_AccountCapabilitiesCardIssuingProperty {
+  active
+  inactive
+  pending
+}
+
+enum Stripe_AccountCapabilitiesCardPaymentsProperty {
+  active
+  inactive
+  pending
+}
+
+enum Stripe_AccountCapabilitiesCartesBancairesPaymentsProperty {
+  active
+  inactive
+  pending
+}
+
+enum Stripe_AccountCapabilitiesEpsPaymentsProperty {
+  active
+  inactive
+  pending
+}
+
+enum Stripe_AccountCapabilitiesFpxPaymentsProperty {
+  active
+  inactive
+  pending
+}
+
+enum Stripe_AccountCapabilitiesGiropayPaymentsProperty {
+  active
+  inactive
+  pending
+}
+
+enum Stripe_AccountCapabilitiesGrabpayPaymentsProperty {
+  active
+  inactive
+  pending
+}
+
+enum Stripe_AccountCapabilitiesIdealPaymentsProperty {
+  active
+  inactive
+  pending
+}
+
+enum Stripe_AccountCapabilitiesJcbPaymentsProperty {
+  active
+  inactive
+  pending
+}
+
+enum Stripe_AccountCapabilitiesLegacyPaymentsProperty {
+  active
+  inactive
+  pending
+}
+
+enum Stripe_AccountCapabilitiesOxxoPaymentsProperty {
+  active
+  inactive
+  pending
+}
+
+enum Stripe_AccountCapabilitiesP24PaymentsProperty {
+  active
+  inactive
+  pending
+}
+
+enum Stripe_AccountCapabilitiesSepaDebitPaymentsProperty {
+  active
+  inactive
+  pending
+}
+
+enum Stripe_AccountCapabilitiesSofortPaymentsProperty {
+  active
+  inactive
+  pending
+}
+
+enum Stripe_AccountCapabilitiesTaxReportingUs1099KProperty {
+  active
+  inactive
+  pending
+}
+
+enum Stripe_AccountCapabilitiesTaxReportingUs1099MiscProperty {
+  active
+  inactive
+  pending
+}
+
+enum Stripe_AccountCapabilitiesTransfersProperty {
+  active
+  inactive
+  pending
+}
+
+type Stripe_LegalEntityCompany {
+  address: Stripe_Address
+  address_kana: Stripe_LegalEntityJapanAddress
+  address_kanji: Stripe_LegalEntityJapanAddress
+
+  """
+  Whether the company's directors have been provided. This Boolean will be `true` if you've manually indicated that all directors are provided via [the `directors_provided` parameter](https://stripe.com/docs/api/accounts/update#update_account-company-directors_provided).
+  """
+  directors_provided: Boolean
+
+  """
+  Whether the company's executives have been provided. This Boolean will be `true` if you've manually indicated that all executives are provided via [the `executives_provided` parameter](https://stripe.com/docs/api/accounts/update#update_account-company-executives_provided), or if Stripe determined that sufficient executives were provided.
+  """
+  executives_provided: Boolean
+
+  """The company's legal name."""
+  name: String
+
+  """The Kana variation of the company's legal name (Japan only)."""
+  name_kana: String
+
+  """The Kanji variation of the company's legal name (Japan only)."""
+  name_kanji: String
+
+  """
+  Whether the company's owners have been provided. This Boolean will be `true` if you've manually indicated that all owners are provided via [the `owners_provided` parameter](https://stripe.com/docs/api/accounts/update#update_account-company-owners_provided), or if Stripe determined that sufficient owners were provided. Stripe determines ownership requirements using both the number of owners provided and their total percent ownership (calculated by adding the `percent_ownership` of each owner together).
+  """
+  owners_provided: Boolean
+
+  """The company's phone number (used for verification)."""
+  phone: String
+
+  """
+  The category identifying the legal structure of the company or legal entity. See [Business structure](https://stripe.com/docs/connect/identity-verification#business-structure) for more details.
+  """
+  structure: Stripe_LegalEntityCompanyStructureProperty
+
+  """Whether the company's business ID number was provided."""
+  tax_id_provided: Boolean
+
+  """
+  The jurisdiction in which the `tax_id` is registered (Germany-based companies only).
+  """
+  tax_id_registrar: String
+
+  """Whether the company's business VAT number was provided."""
+  vat_id_provided: Boolean
+  verification: Stripe_LegalEntityCompanyVerification
+}
+
+type Stripe_LegalEntityJapanAddress {
+  """City/Ward."""
+  city: String
+
+  """
+  Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
+  """
+  country: String
+
+  """Block/Building number."""
+  line1: String
+
+  """Building details."""
+  line2: String
+
+  """ZIP or postal code."""
+  postal_code: String
+
+  """Prefecture."""
+  state: String
+
+  """Town/cho-me."""
+  town: String
+}
+
+enum Stripe_LegalEntityCompanyStructureProperty {
+  free_zone_establishment
+  free_zone_llc
+  government_instrumentality
+  governmental_unit
+  incorporated_non_profit
+  limited_liability_partnership
+  llc
+  multi_member_llc
+  private_company
+  private_corporation
+  private_partnership
+  public_company
+  public_corporation
+  public_partnership
+  single_member_llc
+  sole_establishment
+  sole_proprietorship
+  tax_exempt_government_instrumentality
+  unincorporated_association
+  unincorporated_non_profit
+}
+
+type Stripe_LegalEntityCompanyVerification {
+  document: Stripe_LegalEntityCompanyVerificationDocument
+}
+
+type Stripe_LegalEntityCompanyVerificationDocument {
+  back: Stripe_LegalEntityCompanyVerificationDocumentBackProperty
+
+  """
+  A user-displayable string describing the verification state of this document.
+  """
+  details: String
+
+  """
+  One of `document_corrupt`, `document_expired`, `document_failed_copy`, `document_failed_greyscale`, `document_failed_other`, `document_failed_test_mode`, `document_fraudulent`, `document_incomplete`, `document_invalid`, `document_manipulated`, `document_not_readable`, `document_not_uploaded`, `document_type_not_supported`, or `document_too_large`. A machine-readable code specifying the verification state for this document.
+  """
+  details_code: String
+  front: Stripe_LegalEntityCompanyVerificationDocumentFrontProperty
+}
+
+union Stripe_LegalEntityCompanyVerificationDocumentBackProperty = WrappedString | Stripe_File
+
+type Stripe_File {
+  """
+  Time at which the object was created. Measured in seconds since the Unix epoch.
+  """
+  created: Int
+
+  """
+  The time at which the file expires and is no longer available in epoch seconds.
+  """
+  expires_at: Int
+
+  """A filename for the file, suitable for saving to a filesystem."""
+  filename: String
+
+  """Unique identifier for the object."""
+  id: String
+
+  """
+  A list of [file links](https://stripe.com/docs/api#file_links) that point at this file.
+  """
+  links: Stripe_FileLinksProperty
+
+  """
+  String representing the object's type. Objects of the same type share the same value.
+  """
+  object: Stripe_FileObjectProperty
+
+  """
+  The [purpose](https://stripe.com/docs/file-upload#uploading-a-file) of the uploaded file.
+  """
+  purpose: Stripe_FilePurposeProperty
+
+  """The size in bytes of the file object."""
+  size: Int
+
+  """A user friendly title for the document."""
+  title: String
+
+  """The type of the file returned (e.g., `csv`, `pdf`, `jpg`, or `png`)."""
+  type: String
+
+  """
+  The URL from which the file can be downloaded using your live secret API key.
+  """
+  url: String
+}
+
+"""
+A list of [file links](https://stripe.com/docs/api#file_links) that point at this file.
+"""
+type Stripe_FileLinksProperty {
+  """Details about each object."""
+  data: [Stripe_FileLink!]!
+
+  """
+  True if this list has another page of items after this one that can be fetched.
+  """
+  has_more: Boolean!
+
+  """
+  String representing the object's type. Objects of the same type share the same value. Always has the value `list`.
+  """
+  object: Stripe_FileLinksObjectProperty!
+
+  """The URL where this list can be accessed."""
+  url: String!
+}
+
+type Stripe_FileLink {
+  """
+  Time at which the object was created. Measured in seconds since the Unix epoch.
+  """
+  created: Int
+
+  """Whether this link is already expired."""
+  expired: Boolean
+
+  """Time at which the link expires."""
+  expires_at: Int
+  file: Stripe_FileLinkFileProperty
+
+  """Unique identifier for the object."""
+  id: String
+
+  """
+  Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode.
+  """
+  livemode: Boolean
+
+  """
+  Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format.
+  """
+  metadata: JSONObject
+
+  """
+  String representing the object's type. Objects of the same type share the same value.
+  """
+  object: Stripe_FileLinkObjectProperty
+
+  """The publicly accessible URL to download the file."""
+  url: String
+}
+
+union Stripe_FileLinkFileProperty = WrappedString | Stripe_File
+
+enum Stripe_FileLinkObjectProperty {
+  file_link
+}
+
+enum Stripe_FileLinksObjectProperty {
+  list
+}
+
+enum Stripe_FileObjectProperty {
+  file
+}
+
+enum Stripe_FilePurposeProperty {
+  account_requirement
+  additional_verification
+  business_icon
+  business_logo
+  customer_signature
+  dispute_evidence
+  document_provider_identity_document
+  finance_report_run
+  identity_document
+  identity_document_downloadable
+  pci_document
+  selfie
+  sigma_scheduled_query
+  tax_document_user_upload
+}
+
+union Stripe_LegalEntityCompanyVerificationDocumentFrontProperty = WrappedString | Stripe_File
+
+type Stripe_AccountController {
+  """
+  `true` if the Connect application retrieving the resource controls the account and can therefore exercise [platform controls](https://stripe.com/docs/connect/platform-controls-for-standard-accounts). Otherwise, this field is null.
+  """
+  is_controller: Boolean
+
+  """
+  The controller type. Can be `application`, if a Connect application controls the account, or `account`, if the account controls itself.
+  """
+  type: Stripe_AccountControllerTypeProperty
+}
+
+enum Stripe_AccountControllerTypeProperty {
+  account
+  application
+}
+
+"""
+External accounts (bank accounts and debit cards) currently attached to this account
+"""
+type Stripe_AccountExternalAccountsProperty {
+  """
+  The list contains all external accounts that have been attached to the Stripe account. These may be bank accounts or cards.
+  """
+  data: [Stripe_AccountExternalAccountsDataProperty!]!
+
+  """
+  True if this list has another page of items after this one that can be fetched.
+  """
+  has_more: Boolean!
+
+  """
+  String representing the object's type. Objects of the same type share the same value. Always has the value `list`.
+  """
+  object: Stripe_AccountExternalAccountsObjectProperty!
+
+  """The URL where this list can be accessed."""
+  url: String!
+}
+
+union Stripe_AccountExternalAccountsDataProperty = Stripe_BankAccount | Stripe_Card
+
+type Stripe_Card {
+  account: Stripe_CardAccountProperty
+
+  """City/District/Suburb/Town/Village."""
+  address_city: String
+
+  """Billing address country, if provided when creating card."""
+  address_country: String
+
+  """Address line 1 (Street address/PO Box/Company name)."""
+  address_line1: String
+
+  """
+  If `address_line1` was provided, results of the check: `pass`, `fail`, `unavailable`, or `unchecked`.
+  """
+  address_line1_check: String
+
+  """Address line 2 (Apartment/Suite/Unit/Building)."""
+  address_line2: String
+
+  """State/County/Province/Region."""
+  address_state: String
+
+  """ZIP or postal code."""
+  address_zip: String
+
+  """
+  If `address_zip` was provided, results of the check: `pass`, `fail`, `unavailable`, or `unchecked`.
+  """
+  address_zip_check: String
+
+  """
+  A set of available payout methods for this card. Only values from this set should be passed as the `method` when creating a payout.
+  """
+  available_payout_methods: [Stripe_CardAvailablePayoutMethodsProperty]
+
+  """
+  Card brand. Can be `American Express`, `Diners Club`, `Discover`, `JCB`, `MasterCard`, `UnionPay`, `Visa`, or `Unknown`.
+  """
+  brand: String
+
+  """
+  Two-letter ISO code representing the country of the card. You could use this attribute to get a sense of the international breakdown of cards you've collected.
+  """
+  country: String
+
+  """
+  Three-letter [ISO code for currency](https://stripe.com/docs/payouts). Only applicable on accounts (not customers or recipients). The card can be used as a transfer destination for funds in this currency.
+  """
+  currency: String
+  customer: Stripe_CardCustomerProperty
+
+  """
+  If a CVC was provided, results of the check: `pass`, `fail`, `unavailable`, or `unchecked`. A result of unchecked indicates that CVC was provided but hasn't been checked yet. Checks are typically performed when attaching a card to a Customer object, or when creating a charge. For more details, see [Check if a card is valid without a charge](https://support.stripe.com/questions/check-if-a-card-is-valid-without-a-charge).
+  """
+  cvc_check: String
+
+  """Whether this card is the default external account for its currency."""
+  default_for_currency: Boolean
+
+  """
+  (For tokenized numbers only.) The last four digits of the device account number.
+  """
+  dynamic_last4: String
+
+  """Two-digit number representing the card's expiration month."""
+  exp_month: Int
+
+  """Four-digit number representing the card's expiration year."""
+  exp_year: Int
+
+  """
+  Uniquely identifies this particular card number. You can use this attribute to check whether two customers who’ve signed up with you are using the same card number, for example. For payment methods that tokenize card information (Apple Pay, Google Pay), the tokenized number might be provided instead of the underlying card number.
+  
+  *Starting May 1, 2021, card fingerprint in India for Connect will change to allow two fingerprints for the same card --- one for India and one for the rest of the world.*
+  """
+  fingerprint: String
+
+  """Card funding type. Can be `credit`, `debit`, `prepaid`, or `unknown`."""
+  funding: String
+
+  """Unique identifier for the object."""
+  id: String
+
+  """The last four digits of the card."""
+  last4: String
+
+  """
+  Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format.
+  """
+  metadata: JSONObject
+
+  """Cardholder name."""
+  name: String
+
+  """
+  String representing the object's type. Objects of the same type share the same value.
+  """
+  object: Stripe_CardObjectProperty
+  recipient: Stripe_CardRecipientProperty
+
+  """
+  If the card number is tokenized, this is the method that was used. Can be `android_pay` (includes Google Pay), `apple_pay`, `masterpass`, `visa_checkout`, or null.
+  """
+  tokenization_method: String
+}
+
+union Stripe_CardAccountProperty = WrappedString | Stripe_Account
+
+enum Stripe_CardAvailablePayoutMethodsProperty {
+  instant
+  standard
+}
+
+union Stripe_CardCustomerProperty = WrappedString | Stripe_Customer | Stripe_DeletedCustomer
+
+enum Stripe_CardObjectProperty {
+  card
+}
+
+union Stripe_CardRecipientProperty = WrappedString | Stripe_Recipient
+
+type Stripe_Recipient {
+  active_account: Stripe_BankAccount
+
+  """"""
+  cards: Stripe_RecipientCardsProperty
+
+  """
+  Time at which the object was created. Measured in seconds since the Unix epoch.
+  """
+  created: Int
+  default_card: Stripe_RecipientDefaultCardProperty
+
+  """
+  An arbitrary string attached to the object. Often useful for displaying to users.
+  """
+  description: String
+  email: String
+
+  """Unique identifier for the object."""
+  id: String
+
+  """
+  Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode.
+  """
+  livemode: Boolean
+
+  """
+  Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format.
+  """
+  metadata: JSONObject
+  migrated_to: Stripe_RecipientMigratedToProperty
+
+  """Full, legal name of the recipient."""
+  name: String
+
+  """
+  String representing the object's type. Objects of the same type share the same value.
+  """
+  object: Stripe_RecipientObjectProperty
+  rolled_back_from: Stripe_RecipientRolledBackFromProperty
+
+  """Type of the recipient, one of `individual` or `corporation`."""
+  type: String
+}
+
+""""""
+type Stripe_RecipientCardsProperty {
+  data: [Stripe_Card!]!
+
+  """
+  True if this list has another page of items after this one that can be fetched.
+  """
+  has_more: Boolean!
+
+  """
+  String representing the object's type. Objects of the same type share the same value. Always has the value `list`.
+  """
+  object: Stripe_RecipientCardsObjectProperty!
+
+  """The URL where this list can be accessed."""
+  url: String!
+}
+
+enum Stripe_RecipientCardsObjectProperty {
+  list
+}
+
+union Stripe_RecipientDefaultCardProperty = WrappedString | Stripe_Card
+
+union Stripe_RecipientMigratedToProperty = WrappedString | Stripe_Account
+
+enum Stripe_RecipientObjectProperty {
+  recipient
+}
+
+union Stripe_RecipientRolledBackFromProperty = WrappedString | Stripe_Account
+
+enum Stripe_AccountExternalAccountsObjectProperty {
+  list
+}
+
+type Stripe_Person {
+  """The account the person is associated with."""
+  account: String
+  address: Stripe_Address
+  address_kana: Stripe_LegalEntityJapanAddress
+  address_kanji: Stripe_LegalEntityJapanAddress
+
+  """
+  Time at which the object was created. Measured in seconds since the Unix epoch.
+  """
+  created: Int
+  dob: Stripe_LegalEntityDob
+
+  """The person's email address."""
+  email: String
+
+  """The person's first name."""
+  first_name: String
+
+  """The Kana variation of the person's first name (Japan only)."""
+  first_name_kana: String
+
+  """The Kanji variation of the person's first name (Japan only)."""
+  first_name_kanji: String
+
+  """
+  The person's gender (International regulations require either "male" or "female").
+  """
+  gender: String
+
+  """Unique identifier for the object."""
+  id: String
+
+  """Whether the person's `id_number` was provided."""
+  id_number_provided: Boolean
+
+  """The person's last name."""
+  last_name: String
+
+  """The Kana variation of the person's last name (Japan only)."""
+  last_name_kana: String
+
+  """The Kanji variation of the person's last name (Japan only)."""
+  last_name_kanji: String
+
+  """The person's maiden name."""
+  maiden_name: String
+
+  """
+  Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format.
+  """
+  metadata: JSONObject
+
+  """The country where the person is a national."""
+  nationality: String
+
+  """
+  String representing the object's type. Objects of the same type share the same value.
+  """
+  object: Stripe_PersonObjectProperty
+
+  """The person's phone number."""
+  phone: String
+
+  """
+  Indicates if the person or any of their representatives, family members, or other closely related persons, declares that they hold or have held an important public job or function, in any jurisdiction.
+  """
+  political_exposure: Stripe_PersonPoliticalExposureProperty
+  relationship: Stripe_PersonRelationship
+  requirements: Stripe_PersonRequirements
+
+  """
+  Whether the last four digits of the person's Social Security number have been provided (U.S. only).
+  """
+  ssn_last_4_provided: Boolean
+  verification: Stripe_LegalEntityPersonVerification
+}
+
+type Stripe_LegalEntityDob {
+  """The day of birth, between 1 and 31."""
+  day: Int
+
+  """The month of birth, between 1 and 12."""
+  month: Int
+
+  """The four-digit year of birth."""
+  year: Int
+}
+
+enum Stripe_PersonObjectProperty {
+  person
+}
+
+enum Stripe_PersonPoliticalExposureProperty {
+  existing
+  none
+}
+
+type Stripe_PersonRelationship {
+  """
+  Whether the person is a director of the account's legal entity. Currently only required for accounts in the EU. Directors are typically members of the governing board of the company, or responsible for ensuring the company meets its regulatory obligations.
+  """
+  director: Boolean
+
+  """
+  Whether the person has significant responsibility to control, manage, or direct the organization.
+  """
+  executive: Boolean
+
+  """Whether the person is an owner of the account’s legal entity."""
+  owner: Boolean
+
+  """The percent owned by the person of the account's legal entity."""
+  percent_ownership: Float
+
+  """
+  Whether the person is authorized as the primary representative of the account. This is the person nominated by the business to provide information about themselves, and general information about the account. There can only be one representative at any given time. At the time the account is created, this person should be set to the person responsible for opening the account.
+  """
+  representative: Boolean
+
+  """The person's title (e.g., CEO, Support Engineer)."""
+  title: String
+}
+
+type Stripe_PersonRequirements {
+  """
+  Fields that need to be collected to keep the person's account enabled. If not collected by the account's `current_deadline`, these fields appear in `past_due` as well, and the account is disabled.
+  """
+  currently_due: [String]
+
+  """
+  Fields that are `currently_due` and need to be collected again because validation or verification failed.
+  """
+  errors: [Stripe_AccountRequirementsError]
+
+  """
+  Fields that need to be collected assuming all volume thresholds are reached. As they become required, they appear in `currently_due` as well, and the account's `current_deadline` becomes set.
+  """
+  eventually_due: [String]
+
+  """
+  Fields that weren't collected by the account's `current_deadline`. These fields need to be collected to enable the person's account.
+  """
+  past_due: [String]
+
+  """
+  Fields that may become required depending on the results of verification or review. Will be an empty array unless an asynchronous verification is pending. If verification fails, these fields move to `eventually_due`, `currently_due`, or `past_due`.
+  """
+  pending_verification: [String]
+}
+
+type Stripe_AccountRequirementsError {
+  """The code for the type of error."""
+  code: Stripe_AccountRequirementsErrorCodeProperty
+
+  """
+  An informative message that indicates the error type and provides additional details about the error.
+  """
+  reason: String
+
+  """
+  The specific user onboarding requirement field (in the requirements hash) that needs to be resolved.
+  """
+  requirement: String
+}
+
+enum Stripe_AccountRequirementsErrorCodeProperty {
+  invalid_address_city_state_postal_code
+  invalid_street_address
+  invalid_value_other
+  verification_document_address_mismatch
+  verification_document_address_missing
+  verification_document_corrupt
+  verification_document_country_not_supported
+  verification_document_dob_mismatch
+  verification_document_duplicate_type
+  verification_document_expired
+  verification_document_failed_copy
+  verification_document_failed_greyscale
+  verification_document_failed_other
+  verification_document_failed_test_mode
+  verification_document_fraudulent
+  verification_document_id_number_mismatch
+  verification_document_id_number_missing
+  verification_document_incomplete
+  verification_document_invalid
+  verification_document_issue_or_expiry_date_missing
+  verification_document_manipulated
+  verification_document_missing_back
+  verification_document_missing_front
+  verification_document_name_mismatch
+  verification_document_name_missing
+  verification_document_nationality_mismatch
+  verification_document_not_readable
+  verification_document_not_signed
+  verification_document_not_uploaded
+  verification_document_photo_mismatch
+  verification_document_too_large
+  verification_document_type_not_supported
+  verification_failed_address_match
+  verification_failed_business_iec_number
+  verification_failed_document_match
+  verification_failed_id_number_match
+  verification_failed_keyed_identity
+  verification_failed_keyed_match
+  verification_failed_name_match
+  verification_failed_other
+  verification_failed_tax_id_match
+  verification_failed_tax_id_not_issued
+  verification_missing_executives
+  verification_missing_owners
+  verification_requires_additional_memorandum_of_associations
+}
+
+type Stripe_LegalEntityPersonVerification {
+  additional_document: Stripe_LegalEntityPersonVerificationDocument
+
+  """
+  A user-displayable string describing the verification state for the person. For example, this may say "Provided identity information could not be verified".
+  """
+  details: String
+
+  """
+  One of `document_address_mismatch`, `document_dob_mismatch`, `document_duplicate_type`, `document_id_number_mismatch`, `document_name_mismatch`, `document_nationality_mismatch`, `failed_keyed_identity`, or `failed_other`. A machine-readable code specifying the verification state for the person.
+  """
+  details_code: String
+  document: Stripe_LegalEntityPersonVerificationDocument
+
+  """
+  The state of verification for the person. Possible values are `unverified`, `pending`, or `verified`.
+  """
+  status: String
+}
+
+type Stripe_LegalEntityPersonVerificationDocument {
+  back: Stripe_LegalEntityPersonVerificationDocumentBackProperty
+
+  """
+  A user-displayable string describing the verification state of this document. For example, if a document is uploaded and the picture is too fuzzy, this may say "Identity document is too unclear to read".
+  """
+  details: String
+
+  """
+  One of `document_corrupt`, `document_country_not_supported`, `document_expired`, `document_failed_copy`, `document_failed_other`, `document_failed_test_mode`, `document_fraudulent`, `document_failed_greyscale`, `document_incomplete`, `document_invalid`, `document_manipulated`, `document_missing_back`, `document_missing_front`, `document_not_readable`, `document_not_uploaded`, `document_photo_mismatch`, `document_too_large`, or `document_type_not_supported`. A machine-readable code specifying the verification state for this document.
+  """
+  details_code: String
+  front: Stripe_LegalEntityPersonVerificationDocumentFrontProperty
+}
+
+union Stripe_LegalEntityPersonVerificationDocumentBackProperty = WrappedString | Stripe_File
+
+union Stripe_LegalEntityPersonVerificationDocumentFrontProperty = WrappedString | Stripe_File
+
+enum Stripe_AccountObjectProperty {
+  account
+}
+
+type Stripe_AccountRequirements {
+  """
+  Date by which the fields in `currently_due` must be collected to keep the account enabled. These fields may disable the account sooner if the next threshold is reached before they are collected.
+  """
+  current_deadline: Int
+
+  """
+  Fields that need to be collected to keep the account enabled. If not collected by `current_deadline`, these fields appear in `past_due` as well, and the account is disabled.
+  """
+  currently_due: [String]
+
+  """
+  If the account is disabled, this string describes why. Can be `requirements.past_due`, `requirements.pending_verification`, `listed`, `platform_paused`, `rejected.fraud`, `rejected.listed`, `rejected.terms_of_service`, `rejected.other`, `under_review`, or `other`.
+  """
+  disabled_reason: String
+
+  """
+  Fields that are `currently_due` and need to be collected again because validation or verification failed.
+  """
+  errors: [Stripe_AccountRequirementsError]
+
+  """
+  Fields that need to be collected assuming all volume thresholds are reached. As they become required, they appear in `currently_due` as well, and `current_deadline` becomes set.
+  """
+  eventually_due: [String]
+
+  """
+  Fields that weren't collected by `current_deadline`. These fields need to be collected to enable the account.
+  """
+  past_due: [String]
+
+  """
+  Fields that may become required depending on the results of verification or review. Will be an empty array unless an asynchronous verification is pending. If verification fails, these fields move to `eventually_due`, `currently_due`, or `past_due`.
+  """
+  pending_verification: [String]
+}
+
+type Stripe_AccountSettings {
+  bacs_debit_payments: Stripe_AccountBacsDebitPaymentsSettings
+  branding: Stripe_AccountBrandingSettings
+  card_issuing: Stripe_AccountCardIssuingSettings
+  card_payments: Stripe_AccountCardPaymentsSettings
+  dashboard: Stripe_AccountDashboardSettings
+  payments: Stripe_AccountPaymentsSettings
+  payouts: Stripe_AccountPayoutSettings
+  sepa_debit_payments: Stripe_AccountSepaDebitPaymentsSettings
+}
+
+type Stripe_AccountBacsDebitPaymentsSettings {
+  """
+  The Bacs Direct Debit Display Name for this account. For payments made with Bacs Direct Debit, this will appear on the mandate, and as the statement descriptor.
+  """
+  display_name: String
+}
+
+type Stripe_AccountBrandingSettings {
+  icon: Stripe_AccountBrandingSettingsIconProperty
+  logo: Stripe_AccountBrandingSettingsLogoProperty
+
+  """
+  A CSS hex color value representing the primary branding color for this account
+  """
+  primary_color: String
+
+  """
+  A CSS hex color value representing the secondary branding color for this account
+  """
+  secondary_color: String
+}
+
+union Stripe_AccountBrandingSettingsIconProperty = WrappedString | Stripe_File
+
+union Stripe_AccountBrandingSettingsLogoProperty = WrappedString | Stripe_File
+
+type Stripe_AccountCardIssuingSettings {
+  tos_acceptance: Stripe_CardIssuingAccountTermsOfService
+}
+
+type Stripe_CardIssuingAccountTermsOfService {
+  """
+  The Unix timestamp marking when the account representative accepted the service agreement.
+  """
+  date: Int
+
+  """
+  The IP address from which the account representative accepted the service agreement.
+  """
+  ip: String
+
+  """
+  The user agent of the browser from which the account representative accepted the service agreement.
+  """
+  user_agent: String
+}
+
+type Stripe_AccountCardPaymentsSettings {
+  decline_on: Stripe_AccountDeclineChargeOn
+
+  """
+  The default text that appears on credit card statements when a charge is made. This field prefixes any dynamic `statement_descriptor` specified on the charge. `statement_descriptor_prefix` is useful for maximizing descriptor space for the dynamic portion.
+  """
+  statement_descriptor_prefix: String
+}
+
+type Stripe_AccountDeclineChargeOn {
+  """
+  Whether Stripe automatically declines charges with an incorrect ZIP or postal code. This setting only applies when a ZIP or postal code is provided and they fail bank verification.
+  """
+  avs_failure: Boolean
+
+  """
+  Whether Stripe automatically declines charges with an incorrect CVC. This setting only applies when a CVC is provided and it fails bank verification.
+  """
+  cvc_failure: Boolean
+}
+
+type Stripe_AccountDashboardSettings {
+  """
+  The display name for this account. This is used on the Stripe Dashboard to differentiate between accounts.
+  """
+  display_name: String
+
+  """
+  The timezone used in the Stripe Dashboard for this account. A list of possible time zone values is maintained at the [IANA Time Zone Database](http://www.iana.org/time-zones).
+  """
+  timezone: String
+}
+
+type Stripe_AccountPaymentsSettings {
+  """
+  The default text that appears on credit card statements when a charge is made. This field prefixes any dynamic `statement_descriptor` specified on the charge.
+  """
+  statement_descriptor: String
+
+  """
+  The Kana variation of the default text that appears on credit card statements when a charge is made (Japan only)
+  """
+  statement_descriptor_kana: String
+
+  """
+  The Kanji variation of the default text that appears on credit card statements when a charge is made (Japan only)
+  """
+  statement_descriptor_kanji: String
+}
+
+type Stripe_AccountPayoutSettings {
+  """
+  A Boolean indicating if Stripe should try to reclaim negative balances from an attached bank account. See our [Understanding Connect Account Balances](https://stripe.com/docs/connect/account-balances) documentation for details. Default value is `true` for Express accounts and `false` for Custom accounts.
+  """
+  debit_negative_balances: Boolean
+  schedule: Stripe_TransferSchedule
+
+  """
+  The text that appears on the bank account statement for payouts. If not set, this defaults to the platform's bank descriptor as set in the Dashboard.
+  """
+  statement_descriptor: String
+}
+
+type Stripe_TransferSchedule {
+  """
+  The number of days charges for the account will be held before being paid out.
+  """
+  delay_days: Int
+
+  """
+  How frequently funds will be paid out. One of `manual` (payouts only created via API call), `daily`, `weekly`, or `monthly`.
+  """
+  interval: String
+
+  """
+  The day of the month funds will be paid out. Only shown if `interval` is monthly. Payouts scheduled between the 29th and 31st of the month are sent on the last day of shorter months.
+  """
+  monthly_anchor: Int
+
+  """
+  The day of the week funds will be paid out, of the style 'monday', 'tuesday', etc. Only shown if `interval` is weekly.
+  """
+  weekly_anchor: String
+}
+
+type Stripe_AccountSepaDebitPaymentsSettings {
+  """
+  SEPA creditor identifier that identifies the company making the payment.
+  """
+  creditor_id: String
+}
+
+type Stripe_AccountTosAcceptance {
+  """
+  The Unix timestamp marking when the account representative accepted their service agreement
+  """
+  date: Int
+
+  """
+  The IP address from which the account representative accepted their service agreement
+  """
+  ip: String
+
+  """The user's service agreement type"""
+  service_agreement: String
+
+  """
+  The user agent of the browser from which the account representative accepted their service agreement
+  """
+  user_agent: String
+}
+
+enum Stripe_AccountTypeProperty {
+  custom
+  express
+  standard
+}
+
+enum Stripe_BankAccountAvailablePayoutMethodsProperty {
+  instant
+  standard
+}
+
+union Stripe_BankAccountCustomerProperty = WrappedString | Stripe_Customer | Stripe_DeletedCustomer
+
+enum Stripe_BankAccountObjectProperty {
+  bank_account
+}
+
+type Stripe_BitcoinReceiver {
+  """
+  True when this bitcoin receiver has received a non-zero amount of bitcoin.
+  """
+  active: Boolean
+
+  """The amount of `currency` that you are collecting as payment."""
+  amount: Int
+
+  """
+  The amount of `currency` to which `bitcoin_amount_received` has been converted.
+  """
+  amount_received: Int
+
+  """
+  The amount of bitcoin that the customer should send to fill the receiver. The `bitcoin_amount` is denominated in Satoshi: there are 10^8 Satoshi in one bitcoin.
+  """
+  bitcoin_amount: Int
+
+  """
+  The amount of bitcoin that has been sent by the customer to this receiver.
+  """
+  bitcoin_amount_received: Int
+
+  """
+  This URI can be displayed to the customer as a clickable link (to activate their bitcoin client) or as a QR code (for mobile wallets).
+  """
+  bitcoin_uri: String
+
+  """
+  Time at which the object was created. Measured in seconds since the Unix epoch.
+  """
+  created: Int
+
+  """
+  Three-letter [ISO code for the currency](https://stripe.com/docs/currencies) to which the bitcoin will be converted.
+  """
+  currency: String
+
+  """The customer ID of the bitcoin receiver."""
+  customer: String
+
+  """
+  An arbitrary string attached to the object. Often useful for displaying to users.
+  """
+  description: String
+
+  """
+  The customer's email address, set by the API call that creates the receiver.
+  """
+  email: String
+
+  """
+  This flag is initially false and updates to true when the customer sends the `bitcoin_amount` to this receiver.
+  """
+  filled: Boolean
+
+  """Unique identifier for the object."""
+  id: String
+
+  """
+  A bitcoin address that is specific to this receiver. The customer can send bitcoin to this address to fill the receiver.
+  """
+  inbound_address: String
+
+  """
+  Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode.
+  """
+  livemode: Boolean
+
+  """
+  Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format.
+  """
+  metadata: JSONObject
+
+  """
+  String representing the object's type. Objects of the same type share the same value.
+  """
+  object: Stripe_BitcoinReceiverObjectProperty
+
+  """
+  The ID of the payment created from the receiver, if any. Hidden when viewing the receiver with a publishable key.
+  """
+  payment: String
+
+  """The refund address of this bitcoin receiver."""
+  refund_address: String
+
+  """
+  A list with one entry for each time that the customer sent bitcoin to the receiver. Hidden when viewing the receiver with a publishable key.
+  """
+  transactions: Stripe_BitcoinReceiverTransactionsProperty
+
+  """
+  This receiver contains uncaptured funds that can be used for a payment or refunded.
+  """
+  uncaptured_funds: Boolean
+
+  """Indicate if this source is used for payment."""
+  used_for_payment: Boolean
+}
+
+enum Stripe_BitcoinReceiverObjectProperty {
+  bitcoin_receiver
+}
+
+"""
+A list with one entry for each time that the customer sent bitcoin to the receiver. Hidden when viewing the receiver with a publishable key.
+"""
+type Stripe_BitcoinReceiverTransactionsProperty {
+  """Details about each object."""
+  data: [Stripe_BitcoinTransaction!]!
+
+  """
+  True if this list has another page of items after this one that can be fetched.
+  """
+  has_more: Boolean!
+
+  """
+  String representing the object's type. Objects of the same type share the same value. Always has the value `list`.
+  """
+  object: Stripe_BitcoinReceiverTransactionsObjectProperty!
+
+  """The URL where this list can be accessed."""
+  url: String!
+}
+
+type Stripe_BitcoinTransaction {
+  """
+  The amount of `currency` that the transaction was converted to in real-time.
+  """
+  amount: Int
+
+  """The amount of bitcoin contained in the transaction."""
+  bitcoin_amount: Int
+
+  """
+  Time at which the object was created. Measured in seconds since the Unix epoch.
+  """
+  created: Int
+
+  """
+  Three-letter [ISO code for the currency](https://stripe.com/docs/currencies) to which this transaction was converted.
+  """
+  currency: String
+
+  """Unique identifier for the object."""
+  id: String
+
+  """
+  String representing the object's type. Objects of the same type share the same value.
+  """
+  object: Stripe_BitcoinTransactionObjectProperty
+
+  """The receiver to which this transaction was sent."""
+  receiver: String
+}
+
+enum Stripe_BitcoinTransactionObjectProperty {
+  bitcoin_transaction
+}
+
+enum Stripe_BitcoinReceiverTransactionsObjectProperty {
+  list
+}
+
+type Stripe_Source {
+  ach_credit_transfer: Stripe_SourceTypeAchCreditTransfer
+  ach_debit: Stripe_SourceTypeAchDebit
+  acss_debit: Stripe_SourceTypeAcssDebit
+  alipay: Stripe_SourceTypeAlipay
+
+  """
+  A positive integer in the smallest currency unit (that is, 100 cents for $1.00, or 1 for ¥1, Japanese Yen being a zero-decimal currency) representing the total amount associated with the source. This is the amount for which the source will be chargeable once ready. Required for `single_use` sources.
+  """
+  amount: Int
+  au_becs_debit: Stripe_SourceTypeAuBecsDebit
+  bancontact: Stripe_SourceTypeBancontact
+  card: Stripe_SourceTypeCard
+  card_present: Stripe_SourceTypeCardPresent
+
+  """
+  The client secret of the source. Used for client-side retrieval using a publishable key.
+  """
+  client_secret: String
+  code_verification: Stripe_SourceCodeVerificationFlow
+
+  """
+  Time at which the object was created. Measured in seconds since the Unix epoch.
+  """
+  created: Int
+
+  """
+  Three-letter [ISO code for the currency](https://stripe.com/docs/currencies) associated with the source. This is the currency for which the source will be chargeable once ready. Required for `single_use` sources.
+  """
+  currency: String
+
+  """
+  The ID of the customer to which this source is attached. This will not be present when the source has not been attached to a customer.
+  """
+  customer: String
+  eps: Stripe_SourceTypeEps
+
+  """
+  The authentication `flow` of the source. `flow` is one of `redirect`, `receiver`, `code_verification`, `none`.
+  """
+  flow: String
+  giropay: Stripe_SourceTypeGiropay
+
+  """Unique identifier for the object."""
+  id: String
+  ideal: Stripe_SourceTypeIdeal
+  klarna: Stripe_SourceTypeKlarna
+
+  """
+  Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode.
+  """
+  livemode: Boolean
+
+  """
+  Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format.
+  """
+  metadata: JSONObject
+  multibanco: Stripe_SourceTypeMultibanco
+
+  """
+  String representing the object's type. Objects of the same type share the same value.
+  """
+  object: Stripe_SourceObjectProperty
+  owner: Stripe_SourceOwner
+  p24: Stripe_SourceTypeP24
+  receiver: Stripe_SourceReceiverFlow
+  redirect: Stripe_SourceRedirectFlow
+  sepa_debit: Stripe_SourceTypeSepaDebit
+  sofort: Stripe_SourceTypeSofort
+  source_order: Stripe_SourceOrder
+
+  """
+  Extra information about a source. This will appear on your customer's statement every time you charge the source.
+  """
+  statement_descriptor: String
+
+  """
+  The status of the source, one of `canceled`, `chargeable`, `consumed`, `failed`, or `pending`. Only `chargeable` sources can be used to create a charge.
+  """
+  status: String
+  three_d_secure: Stripe_SourceTypeThreeDSecure
+
+  """
+  The `type` of the source. The `type` is a payment method, one of `ach_credit_transfer`, `ach_debit`, `alipay`, `bancontact`, `card`, `card_present`, `eps`, `giropay`, `ideal`, `multibanco`, `klarna`, `p24`, `sepa_debit`, `sofort`, `three_d_secure`, or `wechat`. An additional hash is included on the source with a name matching this value. It contains additional information specific to the [payment method](https://stripe.com/docs/sources) used.
+  """
+  type: Stripe_SourceTypeProperty
+
+  """
+  Either `reusable` or `single_use`. Whether this source should be reusable or not. Some source types may or may not be reusable by construction, while others may leave the option at creation. If an incompatible value is passed, an error will be returned.
+  """
+  usage: String
+  wechat: Stripe_SourceTypeWechat
+}
+
+type Stripe_SourceTypeAchCreditTransfer {
+  account_number: String
+  bank_name: String
+  fingerprint: String
+  refund_account_holder_name: String
+  refund_account_holder_type: String
+  refund_routing_number: String
+  routing_number: String
+  swift_code: String
+}
+
+type Stripe_SourceTypeAchDebit {
+  bank_name: String
+  country: String
+  fingerprint: String
+  last4: String
+  routing_number: String
+  type: String
+}
+
+type Stripe_SourceTypeAcssDebit {
+  bank_address_city: String
+  bank_address_line_1: String
+  bank_address_line_2: String
+  bank_address_postal_code: String
+  bank_name: String
+  category: String
+  country: String
+  fingerprint: String
+  last4: String
+  routing_number: String
+}
+
+type Stripe_SourceTypeAlipay {
+  data_string: String
+  native_url: String
+  statement_descriptor: String
+}
+
+type Stripe_SourceTypeAuBecsDebit {
+  bsb_number: String
+  fingerprint: String
+  last4: String
+}
+
+type Stripe_SourceTypeBancontact {
+  bank_code: String
+  bank_name: String
+  bic: String
+  iban_last4: String
+  preferred_language: String
+  statement_descriptor: String
+}
+
+type Stripe_SourceTypeCard {
+  address_line1_check: String
+  address_zip_check: String
+  brand: String
+  country: String
+  cvc_check: String
+  dynamic_last4: String
+  exp_month: Int
+  exp_year: Int
+  fingerprint: String
+  funding: String
+  last4: String
+  name: String
+  three_d_secure: String
+  tokenization_method: String
+}
+
+type Stripe_SourceTypeCardPresent {
+  application_cryptogram: String
+  application_preferred_name: String
+  authorization_code: String
+  authorization_response_code: String
+  brand: String
+  country: String
+  cvm_type: String
+  data_type: String
+  dedicated_file_name: String
+  emv_auth_data: String
+  evidence_customer_signature: String
+  evidence_transaction_certificate: String
+  exp_month: Int
+  exp_year: Int
+  fingerprint: String
+  funding: String
+  last4: String
+  pos_device_id: String
+  pos_entry_mode: String
+  read_method: String
+  reader: String
+  terminal_verification_results: String
+  transaction_status_information: String
+}
+
+type Stripe_SourceCodeVerificationFlow {
+  """
+  The number of attempts remaining to authenticate the source object with a verification code.
+  """
+  attempts_remaining: Int
+
+  """
+  The status of the code verification, either `pending` (awaiting verification, `attempts_remaining` should be greater than 0), `succeeded` (successful verification) or `failed` (failed verification, cannot be verified anymore as `attempts_remaining` should be 0).
+  """
+  status: String
+}
+
+type Stripe_SourceTypeEps {
+  reference: String
+  statement_descriptor: String
+}
+
+type Stripe_SourceTypeGiropay {
+  bank_code: String
+  bank_name: String
+  bic: String
+  statement_descriptor: String
+}
+
+type Stripe_SourceTypeIdeal {
+  bank: String
+  bic: String
+  iban_last4: String
+  statement_descriptor: String
+}
+
+type Stripe_SourceTypeKlarna {
+  background_image_url: String
+  client_token: String
+  first_name: String
+  last_name: String
+  locale: String
+  logo_url: String
+  page_title: String
+  pay_later_asset_urls_descriptive: String
+  pay_later_asset_urls_standard: String
+  pay_later_name: String
+  pay_later_redirect_url: String
+  pay_now_asset_urls_descriptive: String
+  pay_now_asset_urls_standard: String
+  pay_now_name: String
+  pay_now_redirect_url: String
+  pay_over_time_asset_urls_descriptive: String
+  pay_over_time_asset_urls_standard: String
+  pay_over_time_name: String
+  pay_over_time_redirect_url: String
+  payment_method_categories: String
+  purchase_country: String
+  purchase_type: String
+  redirect_url: String
+  shipping_delay: Int
+  shipping_first_name: String
+  shipping_last_name: String
+}
+
+type Stripe_SourceTypeMultibanco {
+  entity: String
+  reference: String
+  refund_account_holder_address_city: String
+  refund_account_holder_address_country: String
+  refund_account_holder_address_line1: String
+  refund_account_holder_address_line2: String
+  refund_account_holder_address_postal_code: String
+  refund_account_holder_address_state: String
+  refund_account_holder_name: String
+  refund_iban: String
+}
+
+enum Stripe_SourceObjectProperty {
+  source
+}
+
+type Stripe_SourceOwner {
+  address: Stripe_Address
+
+  """Owner's email address."""
+  email: String
+
+  """Owner's full name."""
+  name: String
+
+  """Owner's phone number (including extension)."""
+  phone: String
+  verified_address: Stripe_Address
+
+  """
+  Verified owner's email address. Verified values are verified or provided by the payment method directly (and if supported) at the time of authorization or settlement. They cannot be set or mutated.
+  """
+  verified_email: String
+
+  """
+  Verified owner's full name. Verified values are verified or provided by the payment method directly (and if supported) at the time of authorization or settlement. They cannot be set or mutated.
+  """
+  verified_name: String
+
+  """
+  Verified owner's phone number (including extension). Verified values are verified or provided by the payment method directly (and if supported) at the time of authorization or settlement. They cannot be set or mutated.
+  """
+  verified_phone: String
+}
+
+type Stripe_SourceTypeP24 {
+  reference: String
+}
+
+type Stripe_SourceReceiverFlow {
+  """
+  The address of the receiver source. This is the value that should be communicated to the customer to send their funds to.
+  """
+  address: String
+
+  """
+  The total amount that was moved to your balance. This is almost always equal to the amount charged. In rare cases when customers deposit excess funds and we are unable to refund those, those funds get moved to your balance and show up in amount_charged as well. The amount charged is expressed in the source's currency.
+  """
+  amount_charged: Int
+
+  """
+  The total amount received by the receiver source. `amount_received = amount_returned + amount_charged` should be true for consumed sources unless customers deposit excess funds. The amount received is expressed in the source's currency.
+  """
+  amount_received: Int
+
+  """
+  The total amount that was returned to the customer. The amount returned is expressed in the source's currency.
+  """
+  amount_returned: Int
+
+  """Type of refund attribute method, one of `email`, `manual`, or `none`."""
+  refund_attributes_method: String
+
+  """
+  Type of refund attribute status, one of `missing`, `requested`, or `available`.
+  """
+  refund_attributes_status: String
+}
+
+type Stripe_SourceRedirectFlow {
+  """
+  The failure reason for the redirect, either `user_abort` (the customer aborted or dropped out of the redirect flow), `declined` (the authentication failed or the transaction was declined), or `processing_error` (the redirect failed due to a technical error). Present only if the redirect status is `failed`.
+  """
+  failure_reason: String
+
+  """
+  The URL you provide to redirect the customer to after they authenticated their payment.
+  """
+  return_url: String
+
+  """
+  The status of the redirect, either `pending` (ready to be used by your customer to authenticate the transaction), `succeeded` (succesful authentication, cannot be reused) or `not_required` (redirect should not be used) or `failed` (failed authentication, cannot be reused).
+  """
+  status: String
+
+  """
+  The URL provided to you to redirect a customer to as part of a `redirect` authentication flow.
+  """
+  url: String
+}
+
+type Stripe_SourceTypeSepaDebit {
+  bank_code: String
+  branch_code: String
+  country: String
+  fingerprint: String
+  last4: String
+  mandate_reference: String
+  mandate_url: String
+}
+
+type Stripe_SourceTypeSofort {
+  bank_code: String
+  bank_name: String
+  bic: String
+  country: String
+  iban_last4: String
+  preferred_language: String
+  statement_descriptor: String
+}
+
+type Stripe_SourceOrder {
+  """
+  A positive integer in the smallest currency unit (that is, 100 cents for $1.00, or 1 for ¥1, Japanese Yen being a zero-decimal currency) representing the total amount for the order.
+  """
+  amount: Int
+
+  """
+  Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
+  """
+  currency: String
+
+  """The email address of the customer placing the order."""
+  email: String
+
+  """List of items constituting the order."""
+  items: [Stripe_SourceOrderItem]
+  shipping: Stripe_Shipping
+}
+
+type Stripe_SourceOrderItem {
+  """The amount (price) for this order item."""
+  amount: Int
+
+  """This currency of this order item. Required when `amount` is present."""
+  currency: String
+
+  """Human-readable description for this order item."""
+  description: String
+
+  """
+  The ID of the associated object for this line item. Expandable if not null (e.g., expandable to a SKU).
+  """
+  parent: String
+
+  """
+  The quantity of this order item. When type is `sku`, this is the number of instances of the SKU to be ordered.
+  """
+  quantity: Int
+
+  """The type of this order item. Must be `sku`, `tax`, or `shipping`."""
+  type: String
+}
+
+type Stripe_Shipping {
+  address: Stripe_Address
+
+  """
+  The delivery service that shipped a physical product, such as Fedex, UPS, USPS, etc.
+  """
+  carrier: String
+
+  """Recipient name."""
+  name: String
+
+  """Recipient phone (including extension)."""
+  phone: String
+
+  """
+  The tracking number for a physical product, obtained from the delivery service. If multiple tracking numbers were generated for this purchase, please separate them with commas.
+  """
+  tracking_number: String
+}
+
+type Stripe_SourceTypeThreeDSecure {
+  address_line1_check: String
+  address_zip_check: String
+  authenticated: Boolean
+  brand: String
+  card: String
+  country: String
+  customer: String
+  cvc_check: String
+  dynamic_last4: String
+  exp_month: Int
+  exp_year: Int
+  fingerprint: String
+  funding: String
+  last4: String
+  name: String
+  three_d_secure: String
+  tokenization_method: String
+}
+
+enum Stripe_SourceTypeProperty {
+  ach_credit_transfer
+  ach_debit
+  acss_debit
+  alipay
+  au_becs_debit
+  bancontact
+  card
+  card_present
+  eps
+  giropay
+  ideal
+  klarna
+  multibanco
+  p24
+  sepa_debit
+  sofort
+  three_d_secure
+  wechat
+}
+
+type Stripe_SourceTypeWechat {
+  prepay_id: String
+  qr_code_url: String
+  statement_descriptor: String
+}
+
+type Stripe_Discount {
+  """
+  The Checkout session that this coupon is applied to, if it is applied to a particular session in payment mode. Will not be present for subscription mode.
+  """
+  checkout_session: String
+  coupon: Stripe_Coupon
+  customer: Stripe_DiscountCustomerProperty
+
+  """
+  If the coupon has a duration of `repeating`, the date that this discount will end. If the coupon has a duration of `once` or `forever`, this attribute will be null.
+  """
+  end: Int
+
+  """
+  The ID of the discount object. Discounts cannot be fetched by ID. Use `expand[]=discounts` in API calls to expand discount IDs in an array.
+  """
+  id: String
+
+  """
+  The invoice that the discount's coupon was applied to, if it was applied directly to a particular invoice.
+  """
+  invoice: String
+
+  """
+  The invoice item `id` (or invoice line item `id` for invoice line items of type='subscription') that the discount's coupon was applied to, if it was applied directly to a particular invoice item or invoice line item.
+  """
+  invoice_item: String
+
+  """
+  String representing the object's type. Objects of the same type share the same value.
+  """
+  object: Stripe_DiscountObjectProperty
+  promotion_code: Stripe_DiscountPromotionCodeProperty
+
+  """Date that the coupon was applied."""
+  start: Int
+
+  """
+  The subscription that this coupon is applied to, if it is applied to a particular subscription.
+  """
+  subscription: String
+}
+
+type Stripe_Coupon {
+  """
+  Amount (in the `currency` specified) that will be taken off the subtotal of any invoices for this customer.
+  """
+  amount_off: Int
+  applies_to: Stripe_CouponAppliesTo
+
+  """
+  Time at which the object was created. Measured in seconds since the Unix epoch.
+  """
+  created: Int
+
+  """
+  If `amount_off` has been set, the three-letter [ISO code for the currency](https://stripe.com/docs/currencies) of the amount to take off.
+  """
+  currency: String
+
+  """
+  One of `forever`, `once`, and `repeating`. Describes how long a customer who applies this coupon will get the discount.
+  """
+  duration: Stripe_CouponDurationProperty
+
+  """
+  If `duration` is `repeating`, the number of months the coupon applies. Null if coupon `duration` is `forever` or `once`.
+  """
+  duration_in_months: Int
+
+  """Unique identifier for the object."""
+  id: String
+
+  """
+  Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode.
+  """
+  livemode: Boolean
+
+  """
+  Maximum number of times this coupon can be redeemed, in total, across all customers, before it is no longer valid.
+  """
+  max_redemptions: Int
+
+  """
+  Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format.
+  """
+  metadata: JSONObject
+
+  """
+  Name of the coupon displayed to customers on for instance invoices or receipts.
+  """
+  name: String
+
+  """
+  String representing the object's type. Objects of the same type share the same value.
+  """
+  object: Stripe_CouponObjectProperty
+
+  """
+  Percent that will be taken off the subtotal of any invoices for this customer for the duration of the coupon. For example, a coupon with percent_off of 50 will make a %s100 invoice %s50 instead.
+  """
+  percent_off: Float
+
+  """Date after which the coupon can no longer be redeemed."""
+  redeem_by: Int
+
+  """Number of times this coupon has been applied to a customer."""
+  times_redeemed: Int
+
+  """
+  Taking account of the above properties, whether this coupon can still be applied to a customer.
+  """
+  valid: Boolean
+}
+
+type Stripe_CouponAppliesTo {
+  """A list of product IDs this coupon applies to"""
+  products: [String]
+}
+
+enum Stripe_CouponDurationProperty {
+  forever
+  once
+  repeating
+}
+
+enum Stripe_CouponObjectProperty {
+  coupon
+}
+
+union Stripe_DiscountCustomerProperty = WrappedString | Stripe_Customer | Stripe_DeletedCustomer
+
+enum Stripe_DiscountObjectProperty {
+  discount
+}
+
+union Stripe_DiscountPromotionCodeProperty = WrappedString | Stripe_PromotionCode
+
+type Stripe_PromotionCode {
+  """
+  Whether the promotion code is currently active. A promotion code is only active if the coupon is also valid.
+  """
+  active: Boolean
+
+  """
+  The customer-facing code. Regardless of case, this code must be unique across all active promotion codes for each customer.
+  """
+  code: String
+  coupon: Stripe_Coupon
+
+  """
+  Time at which the object was created. Measured in seconds since the Unix epoch.
+  """
+  created: Int
+  customer: Stripe_PromotionCodeCustomerProperty
+
+  """Date at which the promotion code can no longer be redeemed."""
+  expires_at: Int
+
+  """Unique identifier for the object."""
+  id: String
+
+  """
+  Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode.
+  """
+  livemode: Boolean
+
+  """Maximum number of times this promotion code can be redeemed."""
+  max_redemptions: Int
+
+  """
+  Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format.
+  """
+  metadata: JSONObject
+
+  """
+  String representing the object's type. Objects of the same type share the same value.
+  """
+  object: Stripe_PromotionCodeObjectProperty
+  restrictions: Stripe_PromotionCodesResourceRestrictions
+
+  """Number of times this promotion code has been used."""
+  times_redeemed: Int
+}
+
+union Stripe_PromotionCodeCustomerProperty = WrappedString | Stripe_Customer | Stripe_DeletedCustomer
+
+enum Stripe_PromotionCodeObjectProperty {
+  promotion_code
+}
+
+type Stripe_PromotionCodesResourceRestrictions {
+  """
+  A Boolean indicating if the Promotion Code should only be redeemed for Customers without any successful payments or invoices
+  """
+  first_time_transaction: Boolean
+
+  """
+  Minimum amount required to redeem this Promotion Code into a Coupon (e.g., a purchase must be $100 or more to work).
+  """
+  minimum_amount: Int
+
+  """
+  Three-letter [ISO code](https://stripe.com/docs/currencies) for minimum_amount
+  """
+  minimum_amount_currency: String
+}
+
+type Stripe_InvoiceSettingCustomerSetting {
+  """Default custom fields to be displayed on invoices for this customer."""
+  custom_fields: [Stripe_InvoiceSettingCustomField]
+  default_payment_method: Stripe_InvoiceSettingCustomerSettingDefaultPaymentMethodProperty
+
+  """Default footer to be displayed on invoices for this customer."""
+  footer: String
+}
+
+type Stripe_InvoiceSettingCustomField {
+  """The name of the custom field."""
+  name: String
+
+  """The value of the custom field."""
+  value: String
+}
+
+union Stripe_InvoiceSettingCustomerSettingDefaultPaymentMethodProperty = WrappedString | Stripe_PaymentMethod
+
+type Stripe_PaymentMethod {
+  acss_debit: Stripe_PaymentMethodAcssDebit
+  afterpay_clearpay: Stripe_PaymentMethodAfterpayClearpay
+  alipay: Stripe_PaymentFlowsPrivatePaymentMethodsAlipay
+  au_becs_debit: Stripe_PaymentMethodAuBecsDebit
+  bacs_debit: Stripe_PaymentMethodBacsDebit
+  bancontact: Stripe_PaymentMethodBancontact
+  billing_details: Stripe_BillingDetails
+  boleto: Stripe_PaymentMethodBoleto
+  card: Stripe_PaymentMethodCard
+  card_present: Stripe_PaymentMethodCardPresent
+
+  """
+  Time at which the object was created. Measured in seconds since the Unix epoch.
+  """
+  created: Int
+  customer: Stripe_PaymentMethodCustomerProperty
+  eps: Stripe_PaymentMethodEps
+  fpx: Stripe_PaymentMethodFpx
+  giropay: Stripe_PaymentMethodGiropay
+  grabpay: Stripe_PaymentMethodGrabpay
+
+  """Unique identifier for the object."""
+  id: String
+  ideal: Stripe_PaymentMethodIdeal
+  interac_present: Stripe_PaymentMethodInteracPresent
+
+  """
+  Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode.
+  """
+  livemode: Boolean
+
+  """
+  Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format.
+  """
+  metadata: JSONObject
+
+  """
+  String representing the object's type. Objects of the same type share the same value.
+  """
+  object: Stripe_PaymentMethodObjectProperty
+  oxxo: Stripe_PaymentMethodOxxo
+  p24: Stripe_PaymentMethodP24
+  sepa_debit: Stripe_PaymentMethodSepaDebit
+  sofort: Stripe_PaymentMethodSofort
+
+  """
+  The type of the PaymentMethod. An additional hash is included on the PaymentMethod with a name matching this value. It contains additional information specific to the PaymentMethod type.
+  """
+  type: Stripe_PaymentMethodTypeProperty
+  wechat_pay: Stripe_PaymentMethodWechatPay
+}
+
+type Stripe_PaymentMethodAcssDebit {
+  """Name of the bank associated with the bank account."""
+  bank_name: String
+
+  """
+  Uniquely identifies this particular bank account. You can use this attribute to check whether two bank accounts are the same.
+  """
+  fingerprint: String
+
+  """Institution number of the bank account."""
+  institution_number: String
+
+  """Last four digits of the bank account number."""
+  last4: String
+
+  """Transit number of the bank account."""
+  transit_number: String
+}
+
+type Stripe_PaymentMethodAfterpayClearpay {
+  result: JSONObject
+}
+
+type Stripe_PaymentFlowsPrivatePaymentMethodsAlipay {
+  result: JSONObject
+}
+
+type Stripe_PaymentMethodAuBecsDebit {
+  """
+  Six-digit number identifying bank and branch associated with this bank account.
+  """
+  bsb_number: String
+
+  """
+  Uniquely identifies this particular bank account. You can use this attribute to check whether two bank accounts are the same.
+  """
+  fingerprint: String
+
+  """Last four digits of the bank account number."""
+  last4: String
+}
+
+type Stripe_PaymentMethodBacsDebit {
+  """
+  Uniquely identifies this particular bank account. You can use this attribute to check whether two bank accounts are the same.
+  """
+  fingerprint: String
+
+  """Last four digits of the bank account number."""
+  last4: String
+
+  """Sort code of the bank account. (e.g., `10-20-30`)"""
+  sort_code: String
+}
+
+type Stripe_PaymentMethodBancontact {
+  result: JSONObject
+}
+
+type Stripe_BillingDetails {
+  address: Stripe_Address
+
+  """Email address."""
+  email: String
+
+  """Full name."""
+  name: String
+
+  """Billing phone number (including extension)."""
+  phone: String
+}
+
+type Stripe_PaymentMethodBoleto {
+  """Uniquely identifies the customer tax id (CNPJ or CPF)"""
+  tax_id: String
+}
+
+type Stripe_PaymentMethodCard {
+  """
+  Card brand. Can be `amex`, `diners`, `discover`, `jcb`, `mastercard`, `unionpay`, `visa`, or `unknown`.
+  """
+  brand: String
+  checks: Stripe_PaymentMethodCardChecks
+
+  """
+  Two-letter ISO code representing the country of the card. You could use this attribute to get a sense of the international breakdown of cards you've collected.
+  """
+  country: String
+
+  """Two-digit number representing the card's expiration month."""
+  exp_month: Int
+
+  """Four-digit number representing the card's expiration year."""
+  exp_year: Int
+
+  """
+  Uniquely identifies this particular card number. You can use this attribute to check whether two customers who’ve signed up with you are using the same card number, for example. For payment methods that tokenize card information (Apple Pay, Google Pay), the tokenized number might be provided instead of the underlying card number.
+  
+  *Starting May 1, 2021, card fingerprint in India for Connect will change to allow two fingerprints for the same card --- one for India and one for the rest of the world.*
+  """
+  fingerprint: String
+
+  """Card funding type. Can be `credit`, `debit`, `prepaid`, or `unknown`."""
+  funding: String
+  generated_from: Stripe_PaymentMethodCardGeneratedCard
+
+  """The last four digits of the card."""
+  last4: String
+  networks: Stripe_Networks
+  three_d_secure_usage: Stripe_ThreeDSecureUsage
+  wallet: Stripe_PaymentMethodCardWallet
+}
+
+type Stripe_PaymentMethodCardChecks {
+  """
+  If a address line1 was provided, results of the check, one of `pass`, `fail`, `unavailable`, or `unchecked`.
+  """
+  address_line1_check: String
+
+  """
+  If a address postal code was provided, results of the check, one of `pass`, `fail`, `unavailable`, or `unchecked`.
+  """
+  address_postal_code_check: String
+
+  """
+  If a CVC was provided, results of the check, one of `pass`, `fail`, `unavailable`, or `unchecked`.
+  """
+  cvc_check: String
+}
+
+type Stripe_PaymentMethodCardGeneratedCard {
+  """The charge that created this object."""
+  charge: String
+  payment_method_details: Stripe_CardGeneratedFromPaymentMethodDetails
+  setup_attempt: Stripe_PaymentMethodCardGeneratedCardSetupAttemptProperty
+}
+
+type Stripe_CardGeneratedFromPaymentMethodDetails {
+  card_present: Stripe_PaymentMethodDetailsCardPresent
+
+  """
+  The type of payment method transaction-specific details from the transaction that generated this `card` payment method. Always `card_present`.
+  """
+  type: String
+}
+
+type Stripe_PaymentMethodDetailsCardPresent {
+  """
+  Card brand. Can be `amex`, `diners`, `discover`, `jcb`, `mastercard`, `unionpay`, `visa`, or `unknown`.
+  """
+  brand: String
+
+  """
+  The cardholder name as read from the card, in [ISO 7813](https://en.wikipedia.org/wiki/ISO/IEC_7813) format. May include alphanumeric characters, special characters and first/last name separator (`/`).
+  """
+  cardholder_name: String
+
+  """
+  Two-letter ISO code representing the country of the card. You could use this attribute to get a sense of the international breakdown of cards you've collected.
+  """
+  country: String
+
+  """Authorization response cryptogram."""
+  emv_auth_data: String
+
+  """Two-digit number representing the card's expiration month."""
+  exp_month: Int
+
+  """Four-digit number representing the card's expiration year."""
+  exp_year: Int
+
+  """
+  Uniquely identifies this particular card number. You can use this attribute to check whether two customers who’ve signed up with you are using the same card number, for example. For payment methods that tokenize card information (Apple Pay, Google Pay), the tokenized number might be provided instead of the underlying card number.
+  
+  *Starting May 1, 2021, card fingerprint in India for Connect will change to allow two fingerprints for the same card --- one for India and one for the rest of the world.*
+  """
+  fingerprint: String
+
+  """Card funding type. Can be `credit`, `debit`, `prepaid`, or `unknown`."""
+  funding: String
+
+  """
+  ID of a card PaymentMethod generated from the card_present PaymentMethod that may be attached to a Customer for future transactions. Only present if it was possible to generate a card PaymentMethod.
+  """
+  generated_card: String
+
+  """The last four digits of the card."""
+  last4: String
+
+  """
+  Identifies which network this charge was processed on. Can be `amex`, `cartes_bancaires`, `diners`, `discover`, `interac`, `jcb`, `mastercard`, `unionpay`, `visa`, or `unknown`.
+  """
+  network: String
+
+  """How card details were read in this transaction."""
+  read_method: Stripe_PaymentMethodDetailsCardPresentReadMethodProperty
+  receipt: Stripe_PaymentMethodDetailsCardPresentReceipt
+}
+
+enum Stripe_PaymentMethodDetailsCardPresentReadMethodProperty {
+  contact_emv
+  contactless_emv
+  contactless_magstripe_mode
+  magnetic_stripe_fallback
+  magnetic_stripe_track2
+}
+
+type Stripe_PaymentMethodDetailsCardPresentReceipt {
+  """The type of account being debited or credited"""
+  account_type: Stripe_PaymentMethodDetailsCardPresentReceiptAccountTypeProperty
+
+  """EMV tag 9F26, cryptogram generated by the integrated circuit chip."""
+  application_cryptogram: String
+
+  """Mnenomic of the Application Identifier."""
+  application_preferred_name: String
+
+  """Identifier for this transaction."""
+  authorization_code: String
+
+  """EMV tag 8A. A code returned by the card issuer."""
+  authorization_response_code: String
+
+  """How the cardholder verified ownership of the card."""
+  cardholder_verification_method: String
+
+  """
+  EMV tag 84. Similar to the application identifier stored on the integrated circuit chip.
+  """
+  dedicated_file_name: String
+
+  """The outcome of a series of EMV functions performed by the card reader."""
+  terminal_verification_results: String
+
+  """
+  An indication of various EMV functions performed during the transaction.
+  """
+  transaction_status_information: String
+}
+
+enum Stripe_PaymentMethodDetailsCardPresentReceiptAccountTypeProperty {
+  checking
+  credit
+  prepaid
+  unknown
+}
+
+union Stripe_PaymentMethodCardGeneratedCardSetupAttemptProperty = WrappedString | Stripe_SetupAttempt
+
+type Stripe_SetupAttempt {
+  application: Stripe_SetupAttemptApplicationProperty
+
+  """
+  Time at which the object was created. Measured in seconds since the Unix epoch.
+  """
+  created: Int
+  customer: Stripe_SetupAttemptCustomerProperty
+
+  """Unique identifier for the object."""
+  id: String
+
+  """
+  Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode.
+  """
+  livemode: Boolean
+
+  """
+  String representing the object's type. Objects of the same type share the same value.
+  """
+  object: Stripe_SetupAttemptObjectProperty
+  on_behalf_of: Stripe_SetupAttemptOnBehalfOfProperty
+  payment_method: Stripe_SetupAttemptPaymentMethodProperty
+  payment_method_details: Stripe_SetupAttemptPaymentMethodDetails
+  setup_error: Stripe_ApiErrors
+  setup_intent: Stripe_SetupAttemptSetupIntentProperty
+
+  """
+  Status of this SetupAttempt, one of `requires_confirmation`, `requires_action`, `processing`, `succeeded`, `failed`, or `abandoned`.
+  """
+  status: String
+
+  """
+  The value of [usage](https://stripe.com/docs/api/setup_intents/object#setup_intent_object-usage) on the SetupIntent at the time of this confirmation, one of `off_session` or `on_session`.
+  """
+  usage: String
+}
+
+union Stripe_SetupAttemptApplicationProperty = WrappedString | Stripe_Application
+
+type Stripe_Application {
+  """Unique identifier for the object."""
+  id: String
+
+  """The name of the application."""
+  name: String
+
+  """
+  String representing the object's type. Objects of the same type share the same value.
+  """
+  object: Stripe_ApplicationObjectProperty
+}
+
+enum Stripe_ApplicationObjectProperty {
+  application
+}
+
+union Stripe_SetupAttemptCustomerProperty = WrappedString | Stripe_Customer | Stripe_DeletedCustomer
+
+enum Stripe_SetupAttemptObjectProperty {
+  setup_attempt
+}
+
+union Stripe_SetupAttemptOnBehalfOfProperty = WrappedString | Stripe_Account
+
+union Stripe_SetupAttemptPaymentMethodProperty = WrappedString | Stripe_PaymentMethod
+
+type Stripe_SetupAttemptPaymentMethodDetails {
+  acss_debit: Stripe_SetupAttemptPaymentMethodDetailsAcssDebit
+  au_becs_debit: Stripe_SetupAttemptPaymentMethodDetailsAuBecsDebit
+  bacs_debit: Stripe_SetupAttemptPaymentMethodDetailsBacsDebit
+  bancontact: Stripe_SetupAttemptPaymentMethodDetailsBancontact
+  card: Stripe_SetupAttemptPaymentMethodDetailsCard
+  card_present: Stripe_SetupAttemptPaymentMethodDetailsCardPresent
+  ideal: Stripe_SetupAttemptPaymentMethodDetailsIdeal
+  sepa_debit: Stripe_SetupAttemptPaymentMethodDetailsSepaDebit
+  sofort: Stripe_SetupAttemptPaymentMethodDetailsSofort
+
+  """
+  The type of the payment method used in the SetupIntent (e.g., `card`). An additional hash is included on `payment_method_details` with a name matching this value. It contains confirmation-specific information for the payment method.
+  """
+  type: String
+}
+
+type Stripe_SetupAttemptPaymentMethodDetailsAcssDebit {
+  result: JSONObject
+}
+
+type Stripe_SetupAttemptPaymentMethodDetailsAuBecsDebit {
+  result: JSONObject
+}
+
+type Stripe_SetupAttemptPaymentMethodDetailsBacsDebit {
+  result: JSONObject
+}
+
+type Stripe_SetupAttemptPaymentMethodDetailsBancontact {
+  """Bank code of bank associated with the bank account."""
+  bank_code: String
+
+  """Name of the bank associated with the bank account."""
+  bank_name: String
+
+  """Bank Identifier Code of the bank associated with the bank account."""
+  bic: String
+  generated_sepa_debit: Stripe_SetupAttemptPaymentMethodDetailsBancontactGeneratedSepaDebitProperty
+  generated_sepa_debit_mandate: Stripe_SetupAttemptPaymentMethodDetailsBancontactGeneratedSepaDebitMandateProperty
+
+  """Last four characters of the IBAN."""
+  iban_last4: String
+
+  """
+  Preferred language of the Bancontact authorization page that the customer is redirected to.
+  Can be one of `en`, `de`, `fr`, or `nl`
+  """
+  preferred_language: Stripe_SetupAttemptPaymentMethodDetailsBancontactPreferredLanguageProperty
+
+  """
+  Owner's verified full name. Values are verified or provided by Bancontact directly
+  (if supported) at the time of authorization or settlement. They cannot be set or mutated.
+  """
+  verified_name: String
+}
+
+union Stripe_SetupAttemptPaymentMethodDetailsBancontactGeneratedSepaDebitProperty = WrappedString | Stripe_PaymentMethod
+
+union Stripe_SetupAttemptPaymentMethodDetailsBancontactGeneratedSepaDebitMandateProperty = WrappedString | Stripe_Mandate
+
+type Stripe_Mandate {
+  customer_acceptance: Stripe_CustomerAcceptance
+
+  """Unique identifier for the object."""
+  id: String
+
+  """
+  Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode.
+  """
+  livemode: Boolean
+  multi_use: Stripe_MandateMultiUse
+
+  """
+  String representing the object's type. Objects of the same type share the same value.
+  """
+  object: Stripe_MandateObjectProperty
+  payment_method: Stripe_MandatePaymentMethodProperty
+  payment_method_details: Stripe_MandatePaymentMethodDetails
+  single_use: Stripe_MandateSingleUse
+
+  """
+  The status of the mandate, which indicates whether it can be used to initiate a payment.
+  """
+  status: Stripe_MandateStatusProperty
+
+  """The type of the mandate."""
+  type: Stripe_MandateTypeProperty
+}
+
+type Stripe_CustomerAcceptance {
+  """The time at which the customer accepted the Mandate."""
+  accepted_at: Int
+  offline: Stripe_OfflineAcceptance
+  online: Stripe_OnlineAcceptance
+
+  """
+  The type of customer acceptance information included with the Mandate. One of `online` or `offline`.
+  """
+  type: Stripe_CustomerAcceptanceTypeProperty
+}
+
+type Stripe_OfflineAcceptance {
+  result: JSONObject
+}
+
+type Stripe_OnlineAcceptance {
+  """The IP address from which the Mandate was accepted by the customer."""
+  ip_address: String
+
+  """
+  The user agent of the browser from which the Mandate was accepted by the customer.
+  """
+  user_agent: String
+}
+
+enum Stripe_CustomerAcceptanceTypeProperty {
+  offline
+  online
+}
+
+type Stripe_MandateMultiUse {
+  result: JSONObject
+}
+
+enum Stripe_MandateObjectProperty {
+  mandate
+}
+
+union Stripe_MandatePaymentMethodProperty = WrappedString | Stripe_PaymentMethod
+
+type Stripe_MandatePaymentMethodDetails {
+  acss_debit: Stripe_MandateAcssDebit
+  au_becs_debit: Stripe_MandateAuBecsDebit
+  bacs_debit: Stripe_MandateBacsDebit
+  card: Stripe_CardMandatePaymentMethodDetails
+  sepa_debit: Stripe_MandateSepaDebit
+
+  """
+  The type of the payment method associated with this mandate. An additional hash is included on `payment_method_details` with a name matching this value. It contains mandate information specific to the payment method.
+  """
+  type: String
+}
+
+type Stripe_MandateAcssDebit {
+  """
+  Description of the interval. Only required if 'payment_schedule' parmeter is 'interval' or 'combined'.
+  """
+  interval_description: String
+
+  """Payment schedule for the mandate."""
+  payment_schedule: Stripe_MandateAcssDebitPaymentScheduleProperty
+
+  """Transaction type of the mandate."""
+  transaction_type: Stripe_MandateAcssDebitTransactionTypeProperty
+}
+
+enum Stripe_MandateAcssDebitPaymentScheduleProperty {
+  combined
+  interval
+  sporadic
+}
+
+enum Stripe_MandateAcssDebitTransactionTypeProperty {
+  business
+  personal
+}
+
+type Stripe_MandateAuBecsDebit {
+  """
+  The URL of the mandate. This URL generally contains sensitive information about the customer and should be shared with them exclusively.
+  """
+  url: String
+}
+
+type Stripe_MandateBacsDebit {
+  """
+  The status of the mandate on the Bacs network. Can be one of `pending`, `revoked`, `refused`, or `accepted`.
+  """
+  network_status: Stripe_MandateBacsDebitNetworkStatusProperty
+
+  """The unique reference identifying the mandate on the Bacs network."""
+  reference: String
+
+  """The URL that will contain the mandate that the customer has signed."""
+  url: String
+}
+
+enum Stripe_MandateBacsDebitNetworkStatusProperty {
+  accepted
+  pending
+  refused
+  revoked
+}
+
+type Stripe_CardMandatePaymentMethodDetails {
+  result: JSONObject
+}
+
+type Stripe_MandateSepaDebit {
+  """The unique reference of the mandate."""
+  reference: String
+
+  """
+  The URL of the mandate. This URL generally contains sensitive information about the customer and should be shared with them exclusively.
+  """
+  url: String
+}
+
+type Stripe_MandateSingleUse {
+  """On a single use mandate, the amount of the payment."""
+  amount: Int
+
+  """On a single use mandate, the currency of the payment."""
+  currency: String
+}
+
+enum Stripe_MandateStatusProperty {
+  active
+  inactive
+  pending
+}
+
+enum Stripe_MandateTypeProperty {
+  multi_use
+  single_use
+}
+
+enum Stripe_SetupAttemptPaymentMethodDetailsBancontactPreferredLanguageProperty {
+  de
+  en
+  fr
+  nl
+}
+
+type Stripe_SetupAttemptPaymentMethodDetailsCard {
+  three_d_secure: Stripe_ThreeDSecureDetails
+}
+
+type Stripe_ThreeDSecureDetails {
+  """
+  For authenticated transactions: how the customer was authenticated by
+  the issuing bank.
+  """
+  authentication_flow: Stripe_ThreeDSecureDetailsAuthenticationFlowProperty
+
+  """Indicates the outcome of 3D Secure authentication."""
+  result: Stripe_ThreeDSecureDetailsResultProperty
+
+  """
+  Additional information about why 3D Secure succeeded or failed based
+  on the `result`.
+  """
+  result_reason: Stripe_ThreeDSecureDetailsResultReasonProperty
+
+  """The version of 3D Secure that was used."""
+  version: Stripe_ThreeDSecureDetailsVersionProperty
+}
+
+enum Stripe_ThreeDSecureDetailsAuthenticationFlowProperty {
+  challenge
+  frictionless
+}
+
+enum Stripe_ThreeDSecureDetailsResultProperty {
+  attempt_acknowledged
+  authenticated
+  failed
+  not_supported
+  processing_error
+}
+
+enum Stripe_ThreeDSecureDetailsResultReasonProperty {
+  abandoned
+  bypassed
+  canceled
+  card_not_enrolled
+  network_not_supported
+  protocol_error
+  rejected
+}
+
+enum Stripe_ThreeDSecureDetailsVersionProperty {
+  ONEDOT0DOT2
+  TWODOT1DOT0
+  TWODOT2DOT0
+}
+
+type Stripe_SetupAttemptPaymentMethodDetailsCardPresent {
+  generated_card: Stripe_SetupAttemptPaymentMethodDetailsCardPresentGeneratedCardProperty
+}
+
+union Stripe_SetupAttemptPaymentMethodDetailsCardPresentGeneratedCardProperty = WrappedString | Stripe_PaymentMethod
+
+type Stripe_SetupAttemptPaymentMethodDetailsIdeal {
+  """
+  The customer's bank. Can be one of `abn_amro`, `asn_bank`, `bunq`, `handelsbanken`, `ing`, `knab`, `moneyou`, `rabobank`, `regiobank`, `revolut`, `sns_bank`, `triodos_bank`, or `van_lanschot`.
+  """
+  bank: Stripe_SetupAttemptPaymentMethodDetailsIdealBankProperty
+
+  """The Bank Identifier Code of the customer's bank."""
+  bic: Stripe_SetupAttemptPaymentMethodDetailsIdealBicProperty
+  generated_sepa_debit: Stripe_SetupAttemptPaymentMethodDetailsIdealGeneratedSepaDebitProperty
+  generated_sepa_debit_mandate: Stripe_SetupAttemptPaymentMethodDetailsIdealGeneratedSepaDebitMandateProperty
+
+  """Last four characters of the IBAN."""
+  iban_last4: String
+
+  """
+  Owner's verified full name. Values are verified or provided by iDEAL directly
+  (if supported) at the time of authorization or settlement. They cannot be set or mutated.
+  """
+  verified_name: String
+}
+
+enum Stripe_SetupAttemptPaymentMethodDetailsIdealBankProperty {
+  abn_amro
+  asn_bank
+  bunq
+  handelsbanken
+  ing
+  knab
+  moneyou
+  rabobank
+  regiobank
+  revolut
+  sns_bank
+  triodos_bank
+  van_lanschot
+}
+
+enum Stripe_SetupAttemptPaymentMethodDetailsIdealBicProperty {
+  ABNANL2A
+  ASNBNL21
+  BUNQNL2A
+  FVLBNL22
+  HANDNL2A
+  INGBNL2A
+  KNABNL2H
+  MOYONL21
+  RABONL2U
+  RBRBNL21
+  REVOLT21
+  SNSBNL2A
+  TRIONL2U
+}
+
+union Stripe_SetupAttemptPaymentMethodDetailsIdealGeneratedSepaDebitProperty = WrappedString | Stripe_PaymentMethod
+
+union Stripe_SetupAttemptPaymentMethodDetailsIdealGeneratedSepaDebitMandateProperty = WrappedString | Stripe_Mandate
+
+type Stripe_SetupAttemptPaymentMethodDetailsSepaDebit {
+  result: JSONObject
+}
+
+type Stripe_SetupAttemptPaymentMethodDetailsSofort {
+  """Bank code of bank associated with the bank account."""
+  bank_code: String
+
+  """Name of the bank associated with the bank account."""
+  bank_name: String
+
+  """Bank Identifier Code of the bank associated with the bank account."""
+  bic: String
+  generated_sepa_debit: Stripe_SetupAttemptPaymentMethodDetailsSofortGeneratedSepaDebitProperty
+  generated_sepa_debit_mandate: Stripe_SetupAttemptPaymentMethodDetailsSofortGeneratedSepaDebitMandateProperty
+
+  """Last four characters of the IBAN."""
+  iban_last4: String
+
+  """
+  Preferred language of the Sofort authorization page that the customer is redirected to.
+  Can be one of `en`, `de`, `fr`, or `nl`
+  """
+  preferred_language: Stripe_SetupAttemptPaymentMethodDetailsSofortPreferredLanguageProperty
+
+  """
+  Owner's verified full name. Values are verified or provided by Sofort directly
+  (if supported) at the time of authorization or settlement. They cannot be set or mutated.
+  """
+  verified_name: String
+}
+
+union Stripe_SetupAttemptPaymentMethodDetailsSofortGeneratedSepaDebitProperty = WrappedString | Stripe_PaymentMethod
+
+union Stripe_SetupAttemptPaymentMethodDetailsSofortGeneratedSepaDebitMandateProperty = WrappedString | Stripe_Mandate
+
+enum Stripe_SetupAttemptPaymentMethodDetailsSofortPreferredLanguageProperty {
+  de
+  en
+  fr
+  nl
+}
+
+type Stripe_ApiErrors {
+  """For card errors, the ID of the failed charge."""
+  charge: String
+
+  """
+  For some errors that could be handled programmatically, a short string indicating the [error code](https://stripe.com/docs/error-codes) reported.
+  """
+  code: String
+
+  """
+  For card errors resulting from a card issuer decline, a short string indicating the [card issuer's reason for the decline](https://stripe.com/docs/declines#issuer-declines) if they provide one.
+  """
+  decline_code: String
+
+  """
+  A URL to more information about the [error code](https://stripe.com/docs/error-codes) reported.
+  """
+  doc_url: String
+
+  """
+  A human-readable message providing more details about the error. For card errors, these messages can be shown to your users.
+  """
+  message: String
+
+  """
+  If the error is parameter-specific, the parameter related to the error. For example, you can use this to display a message near the correct form field.
+  """
+  param: String
+  payment_intent: Stripe_PaymentIntent
+  payment_method: Stripe_PaymentMethod
+
+  """
+  If the error is specific to the type of payment method, the payment method type that had a problem. This field is only populated for invoice-related errors.
+  """
+  payment_method_type: String
+  setup_intent: Stripe_SetupIntent
+  source: Stripe_ApiErrorsSourceProperty
+
+  """
+  The type of error returned. One of `api_error`, `card_error`, `idempotency_error`, or `invalid_request_error`
+  """
+  type: Stripe_ApiErrorsTypeProperty
+}
+
+type Stripe_PaymentIntent {
+  """
+  Amount intended to be collected by this PaymentIntent. A positive integer representing how much to charge in the [smallest currency unit](https://stripe.com/docs/currencies#zero-decimal) (e.g., 100 cents to charge $1.00 or 100 to charge ¥100, a zero-decimal currency). The minimum amount is $0.50 US or [equivalent in charge currency](https://stripe.com/docs/currencies#minimum-and-maximum-charge-amounts). The amount value supports up to eight digits (e.g., a value of 99999999 for a USD charge of $999,999.99).
+  """
+  amount: Int
+
+  """Amount that can be captured from this PaymentIntent."""
+  amount_capturable: Int
+
+  """Amount that was collected by this PaymentIntent."""
+  amount_received: Int
+  application: Stripe_PaymentIntentApplicationProperty
+
+  """
+  The amount of the application fee (if any) that will be requested to be applied to the payment and transferred to the application owner's Stripe account. The amount of the application fee collected will be capped at the total payment amount. For more information, see the PaymentIntents [use case for connected accounts](https://stripe.com/docs/payments/connected-accounts).
+  """
+  application_fee_amount: Int
+
+  """
+  Populated when `status` is `canceled`, this is the time at which the PaymentIntent was canceled. Measured in seconds since the Unix epoch.
+  """
+  canceled_at: Int
+
+  """
+  Reason for cancellation of this PaymentIntent, either user-provided (`duplicate`, `fraudulent`, `requested_by_customer`, or `abandoned`) or generated by Stripe internally (`failed_invoice`, `void_invoice`, or `automatic`).
+  """
+  cancellation_reason: Stripe_PaymentIntentCancellationReasonProperty
+
+  """Controls when the funds will be captured from the customer's account."""
+  capture_method: Stripe_PaymentIntentCaptureMethodProperty
+
+  """Charges that were created by this PaymentIntent, if any."""
+  charges: Stripe_PaymentIntentChargesProperty
+
+  """
+  The client secret of this PaymentIntent. Used for client-side retrieval using a publishable key. 
+  
+  The client secret can be used to complete a payment from your frontend. It should not be stored, logged, embedded in URLs, or exposed to anyone other than the customer. Make sure that you have TLS enabled on any page that includes the client secret.
+  
+  Refer to our docs to [accept a payment](https://stripe.com/docs/payments/accept-a-payment?integration=elements) and learn about how `client_secret` should be handled.
+  """
+  client_secret: String
+  confirmation_method: Stripe_PaymentIntentConfirmationMethodProperty
+
+  """
+  Time at which the object was created. Measured in seconds since the Unix epoch.
+  """
+  created: Int
+
+  """
+  Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
+  """
+  currency: String
+  customer: Stripe_PaymentIntentCustomerProperty
+
+  """
+  An arbitrary string attached to the object. Often useful for displaying to users.
+  """
+  description: String
+
+  """Unique identifier for the object."""
+  id: String
+  invoice: Stripe_PaymentIntentInvoiceProperty
+  last_payment_error: Stripe_ApiErrors
+
+  """
+  Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode.
+  """
+  livemode: Boolean
+
+  """
+  Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. For more information, see the [documentation](https://stripe.com/docs/payments/payment-intents/creating-payment-intents#storing-information-in-metadata).
+  """
+  metadata: JSONObject
+  next_action: Stripe_PaymentIntentNextAction
+
+  """
+  String representing the object's type. Objects of the same type share the same value.
+  """
+  object: Stripe_PaymentIntentObjectProperty
+  on_behalf_of: Stripe_PaymentIntentOnBehalfOfProperty
+  payment_method: Stripe_PaymentIntentPaymentMethodProperty
+  payment_method_options: Stripe_PaymentIntentPaymentMethodOptions
+
+  """
+  The list of payment method types (e.g. card) that this PaymentIntent is allowed to use.
+  """
+  payment_method_types: [String]
+
+  """
+  Email address that the receipt for the resulting payment will be sent to. If `receipt_email` is specified for a payment in live mode, a receipt will be sent regardless of your [email settings](https://dashboard.stripe.com/account/emails).
+  """
+  receipt_email: String
+  review: Stripe_PaymentIntentReviewProperty
+
+  """
+  Indicates that you intend to make future payments with this PaymentIntent's payment method.
+  
+  Providing this parameter will [attach the payment method](https://stripe.com/docs/payments/save-during-payment) to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any required actions from the user are complete. If no Customer was provided, the payment method can still be [attached](https://stripe.com/docs/api/payment_methods/attach) to a Customer after the transaction completes.
+  
+  When processing card payments, Stripe also uses `setup_future_usage` to dynamically optimize your payment flow and comply with regional legislation and network rules, such as [SCA](https://stripe.com/docs/strong-customer-authentication).
+  """
+  setup_future_usage: Stripe_PaymentIntentSetupFutureUsageProperty
+  shipping: Stripe_Shipping
+
+  """
+  For non-card charges, you can use this value as the complete description that appears on your customers’ statements. Must contain at least one letter, maximum 22 characters.
+  """
+  statement_descriptor: String
+
+  """
+  Provides information about a card payment that customers see on their statements. Concatenated with the prefix (shortened descriptor) or statement descriptor that’s set on the account to form the complete statement descriptor. Maximum 22 characters for the concatenated descriptor.
+  """
+  statement_descriptor_suffix: String
+
+  """
+  Status of this PaymentIntent, one of `requires_payment_method`, `requires_confirmation`, `requires_action`, `processing`, `requires_capture`, `canceled`, or `succeeded`. Read more about each PaymentIntent [status](https://stripe.com/docs/payments/intents#intent-statuses).
+  """
+  status: Stripe_PaymentIntentStatusProperty
+  transfer_data: Stripe_TransferData
+
+  """
+  A string that identifies the resulting payment as part of a group. See the PaymentIntents [use case for connected accounts](https://stripe.com/docs/payments/connected-accounts) for details.
+  """
+  transfer_group: String
+}
+
+union Stripe_PaymentIntentApplicationProperty = WrappedString | Stripe_Application
+
+enum Stripe_PaymentIntentCancellationReasonProperty {
+  abandoned
+  automatic
+  duplicate
+  failed_invoice
+  fraudulent
+  requested_by_customer
+  void_invoice
+}
+
+enum Stripe_PaymentIntentCaptureMethodProperty {
+  automatic
+  manual
+}
+
+"""Charges that were created by this PaymentIntent, if any."""
+type Stripe_PaymentIntentChargesProperty {
+  """
+  This list only contains the latest charge, even if there were previously multiple unsuccessful charges. To view all previous charges for a PaymentIntent, you can filter the charges list using the `payment_intent` [parameter](https://stripe.com/docs/api/charges/list#list_charges-payment_intent).
+  """
+  data: [Stripe_Charge!]!
+
+  """
+  True if this list has another page of items after this one that can be fetched.
+  """
+  has_more: Boolean!
+
+  """
+  String representing the object's type. Objects of the same type share the same value. Always has the value `list`.
+  """
+  object: Stripe_PaymentIntentChargesObjectProperty!
+
+  """The URL where this list can be accessed."""
+  url: String!
+}
+
+type Stripe_Charge {
+  """
+  Amount intended to be collected by this payment. A positive integer representing how much to charge in the [smallest currency unit](https://stripe.com/docs/currencies#zero-decimal) (e.g., 100 cents to charge $1.00 or 100 to charge ¥100, a zero-decimal currency). The minimum amount is $0.50 US or [equivalent in charge currency](https://stripe.com/docs/currencies#minimum-and-maximum-charge-amounts). The amount value supports up to eight digits (e.g., a value of 99999999 for a USD charge of $999,999.99).
+  """
+  amount: Int
+
+  """
+  Amount in %s captured (can be less than the amount attribute on the charge if a partial capture was made).
+  """
+  amount_captured: Int
+
+  """
+  Amount in %s refunded (can be less than the amount attribute on the charge if a partial refund was issued).
+  """
+  amount_refunded: Int
+  application: Stripe_ChargeApplicationProperty
+  application_fee: Stripe_ChargeApplicationFeeProperty
+
+  """
+  The amount of the application fee (if any) requested for the charge. [See the Connect documentation](https://stripe.com/docs/connect/direct-charges#collecting-fees) for details.
+  """
+  application_fee_amount: Int
+  balance_transaction: Stripe_ChargeBalanceTransactionProperty
+  billing_details: Stripe_BillingDetails
+
+  """
+  The full statement descriptor that is passed to card networks, and that is displayed on your customers' credit card and bank statements. Allows you to see what the statement descriptor looks like after the static and dynamic portions are combined.
+  """
+  calculated_statement_descriptor: String
+
+  """
+  If the charge was created without capturing, this Boolean represents whether it is still uncaptured or has since been captured.
+  """
+  captured: Boolean
+
+  """
+  Time at which the object was created. Measured in seconds since the Unix epoch.
+  """
+  created: Int
+
+  """
+  Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
+  """
+  currency: String
+  customer: Stripe_ChargeCustomerProperty
+
+  """
+  An arbitrary string attached to the object. Often useful for displaying to users.
+  """
+  description: String
+
+  """Whether the charge has been disputed."""
+  disputed: Boolean
+
+  """
+  Error code explaining reason for charge failure if available (see [the errors section](https://stripe.com/docs/api#errors) for a list of codes).
+  """
+  failure_code: String
+
+  """
+  Message to user further explaining reason for charge failure if available.
+  """
+  failure_message: String
+  fraud_details: Stripe_ChargeFraudDetails
+
+  """Unique identifier for the object."""
+  id: String
+  invoice: Stripe_ChargeInvoiceProperty
+
+  """
+  Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode.
+  """
+  livemode: Boolean
+
+  """
+  Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format.
+  """
+  metadata: JSONObject
+
+  """
+  String representing the object's type. Objects of the same type share the same value.
+  """
+  object: Stripe_ChargeObjectProperty
+  on_behalf_of: Stripe_ChargeOnBehalfOfProperty
+  order: Stripe_ChargeOrderProperty
+  outcome: Stripe_ChargeOutcome
+
+  """
+  `true` if the charge succeeded, or was successfully authorized for later capture.
+  """
+  paid: Boolean
+  payment_intent: Stripe_ChargePaymentIntentProperty
+
+  """ID of the payment method used in this charge."""
+  payment_method: String
+  payment_method_details: Stripe_PaymentMethodDetails
+
+  """
+  This is the email address that the receipt for this charge was sent to.
+  """
+  receipt_email: String
+
+  """
+  This is the transaction number that appears on email receipts sent for this charge. This attribute will be `null` until a receipt has been sent.
+  """
+  receipt_number: String
+
+  """
+  This is the URL to view the receipt for this charge. The receipt is kept up-to-date to the latest state of the charge, including any refunds. If the charge is for an Invoice, the receipt will be stylized as an Invoice receipt.
+  """
+  receipt_url: String
+
+  """
+  Whether the charge has been fully refunded. If the charge is only partially refunded, this attribute will still be false.
+  """
+  refunded: Boolean
+
+  """A list of refunds that have been applied to the charge."""
+  refunds: Stripe_ChargeRefundsProperty
+  review: Stripe_ChargeReviewProperty
+  shipping: Stripe_Shipping
+  source_transfer: Stripe_ChargeSourceTransferProperty
+
+  """
+  For card charges, use `statement_descriptor_suffix` instead. Otherwise, you can use this value as the complete description of a charge on your customers’ statements. Must contain at least one letter, maximum 22 characters.
+  """
+  statement_descriptor: String
+
+  """
+  Provides information about the charge that customers see on their statements. Concatenated with the prefix (shortened descriptor) or statement descriptor that’s set on the account to form the complete statement descriptor. Maximum 22 characters for the concatenated descriptor.
+  """
+  statement_descriptor_suffix: String
+
+  """
+  The status of the payment is either `succeeded`, `pending`, or `failed`.
+  """
+  status: String
+  transfer: Stripe_ChargeTransferProperty
+  transfer_data: Stripe_ChargeTransferData
+
+  """
+  A string that identifies this transaction as part of a group. See the [Connect documentation](https://stripe.com/docs/connect/charges-transfers#transfer-options) for details.
+  """
+  transfer_group: String
+}
+
+union Stripe_ChargeApplicationProperty = WrappedString | Stripe_Application
+
+union Stripe_ChargeApplicationFeeProperty = WrappedString | Stripe_ApplicationFee
+
+type Stripe_ApplicationFee {
+  account: Stripe_ApplicationFeeAccountProperty
+
+  """Amount earned, in %s."""
+  amount: Int
+
+  """
+  Amount in %s refunded (can be less than the amount attribute on the fee if a partial refund was issued)
+  """
+  amount_refunded: Int
+  application: Stripe_ApplicationFeeApplicationProperty
+  balance_transaction: Stripe_ApplicationFeeBalanceTransactionProperty
+  charge: Stripe_ApplicationFeeChargeProperty
+
+  """
+  Time at which the object was created. Measured in seconds since the Unix epoch.
+  """
+  created: Int
+
+  """
+  Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
+  """
+  currency: String
+
+  """Unique identifier for the object."""
+  id: String
+
+  """
+  Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode.
+  """
+  livemode: Boolean
+
+  """
+  String representing the object's type. Objects of the same type share the same value.
+  """
+  object: Stripe_ApplicationFeeObjectProperty
+  originating_transaction: Stripe_ApplicationFeeOriginatingTransactionProperty
+
+  """
+  Whether the fee has been fully refunded. If the fee is only partially refunded, this attribute will still be false.
+  """
+  refunded: Boolean
+
+  """A list of refunds that have been applied to the fee."""
+  refunds: Stripe_ApplicationFeeRefundsProperty
+}
+
+union Stripe_ApplicationFeeAccountProperty = WrappedString | Stripe_Account
+
+union Stripe_ApplicationFeeApplicationProperty = WrappedString | Stripe_Application
+
+union Stripe_ApplicationFeeBalanceTransactionProperty = WrappedString | Stripe_BalanceTransaction
+
+type Stripe_BalanceTransaction {
+  """Gross amount of the transaction, in %s."""
+  amount: Int
+
+  """
+  The date the transaction's net funds will become available in the Stripe balance.
+  """
+  available_on: Int
+
+  """
+  Time at which the object was created. Measured in seconds since the Unix epoch.
+  """
+  created: Int
+
+  """
+  Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
+  """
+  currency: String
+
+  """
+  An arbitrary string attached to the object. Often useful for displaying to users.
+  """
+  description: String
+
+  """
+  The exchange rate used, if applicable, for this transaction. Specifically, if money was converted from currency A to currency B, then the `amount` in currency A, times `exchange_rate`, would be the `amount` in currency B. For example, suppose you charged a customer 10.00 EUR. Then the PaymentIntent's `amount` would be `1000` and `currency` would be `eur`. Suppose this was converted into 12.34 USD in your Stripe account. Then the BalanceTransaction's `amount` would be `1234`, `currency` would be `usd`, and `exchange_rate` would be `1.234`.
+  """
+  exchange_rate: Float
+
+  """Fees (in %s) paid for this transaction."""
+  fee: Int
+
+  """Detailed breakdown of fees (in %s) paid for this transaction."""
+  fee_details: [Stripe_Fee]
+
+  """Unique identifier for the object."""
+  id: String
+
+  """Net amount of the transaction, in %s."""
+  net: Int
+
+  """
+  String representing the object's type. Objects of the same type share the same value.
+  """
+  object: Stripe_BalanceTransactionObjectProperty
+
+  """
+  [Learn more](https://stripe.com/docs/reports/reporting-categories) about how reporting categories can help you understand balance transactions from an accounting perspective.
+  """
+  reporting_category: String
+  source: Stripe_BalanceTransactionSourceProperty
+
+  """
+  If the transaction's net funds are available in the Stripe balance yet. Either `available` or `pending`.
+  """
+  status: String
+
+  """
+  Transaction type: `adjustment`, `advance`, `advance_funding`, `anticipation_repayment`, `application_fee`, `application_fee_refund`, `charge`, `connect_collection_transfer`, `contribution`, `issuing_authorization_hold`, `issuing_authorization_release`, `issuing_dispute`, `issuing_transaction`, `payment`, `payment_failure_refund`, `payment_refund`, `payout`, `payout_cancel`, `payout_failure`, `refund`, `refund_failure`, `reserve_transaction`, `reserved_funds`, `stripe_fee`, `stripe_fx_fee`, `tax_fee`, `topup`, `topup_reversal`, `transfer`, `transfer_cancel`, `transfer_failure`, or `transfer_refund`. [Learn more](https://stripe.com/docs/reports/balance-transaction-types) about balance transaction types and what they represent. If you are looking to classify transactions for accounting purposes, you might want to consider `reporting_category` instead.
+  """
+  type: Stripe_BalanceTransactionTypeProperty
+}
+
+type Stripe_Fee {
+  """Amount of the fee, in cents."""
+  amount: Int
+
+  """ID of the Connect application that earned the fee."""
+  application: String
+
+  """
+  Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
+  """
+  currency: String
+
+  """
+  An arbitrary string attached to the object. Often useful for displaying to users.
+  """
+  description: String
+
+  """Type of the fee, one of: `application_fee`, `stripe_fee` or `tax`."""
+  type: String
+}
+
+enum Stripe_BalanceTransactionObjectProperty {
+  balance_transaction
+}
+
+union Stripe_BalanceTransactionSourceProperty = WrappedString | Stripe_ApplicationFee | Stripe_Charge | Stripe_ConnectCollectionTransfer | Stripe_Dispute | Stripe_FeeRefund | Stripe_IssuingAuthorization | Stripe_IssuingDispute | Stripe_IssuingTransaction | Stripe_Payout | Stripe_PlatformTaxFee | Stripe_Refund | Stripe_ReserveTransaction | Stripe_TaxDeductedAtSource | Stripe_Topup | Stripe_Transfer | Stripe_TransferReversal
+
+type Stripe_ConnectCollectionTransfer {
+  """Amount transferred, in %s."""
+  amount: Int
+
+  """
+  Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
+  """
+  currency: String
+  destination: Stripe_ConnectCollectionTransferDestinationProperty
+
+  """Unique identifier for the object."""
+  id: String
+
+  """
+  Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode.
+  """
+  livemode: Boolean
+
+  """
+  String representing the object's type. Objects of the same type share the same value.
+  """
+  object: Stripe_ConnectCollectionTransferObjectProperty
+}
+
+union Stripe_ConnectCollectionTransferDestinationProperty = WrappedString | Stripe_Account
+
+enum Stripe_ConnectCollectionTransferObjectProperty {
+  connect_collection_transfer
+}
+
+type Stripe_Dispute {
+  """
+  Disputed amount. Usually the amount of the charge, but can differ (usually because of currency fluctuation or because only part of the order is disputed).
+  """
+  amount: Int
+
+  """
+  List of zero, one, or two balance transactions that show funds withdrawn and reinstated to your Stripe account as a result of this dispute.
+  """
+  balance_transactions: [Stripe_BalanceTransaction]
+  charge: Stripe_DisputeChargeProperty
+
+  """
+  Time at which the object was created. Measured in seconds since the Unix epoch.
+  """
+  created: Int
+
+  """
+  Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
+  """
+  currency: String
+  evidence: Stripe_DisputeEvidence
+  evidence_details: Stripe_DisputeEvidenceDetails
+
+  """Unique identifier for the object."""
+  id: String
+
+  """
+  If true, it is still possible to refund the disputed payment. Once the payment has been fully refunded, no further funds will be withdrawn from your Stripe account as a result of this dispute.
+  """
+  is_charge_refundable: Boolean
+
+  """
+  Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode.
+  """
+  livemode: Boolean
+
+  """
+  Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format.
+  """
+  metadata: JSONObject
+
+  """
+  String representing the object's type. Objects of the same type share the same value.
+  """
+  object: Stripe_DisputeObjectProperty
+  payment_intent: Stripe_DisputePaymentIntentProperty
+
+  """
+  Reason given by cardholder for dispute. Possible values are `bank_cannot_process`, `check_returned`, `credit_not_processed`, `customer_initiated`, `debit_not_authorized`, `duplicate`, `fraudulent`, `general`, `incorrect_account_details`, `insufficient_funds`, `product_not_received`, `product_unacceptable`, `subscription_canceled`, or `unrecognized`. Read more about [dispute reasons](https://stripe.com/docs/disputes/categories).
+  """
+  reason: String
+
+  """
+  Current status of dispute. Possible values are `warning_needs_response`, `warning_under_review`, `warning_closed`, `needs_response`, `under_review`, `charge_refunded`, `won`, or `lost`.
+  """
+  status: Stripe_DisputeStatusProperty
+}
+
+union Stripe_DisputeChargeProperty = WrappedString | Stripe_Charge
+
+type Stripe_DisputeEvidence {
+  """
+  Any server or activity logs showing proof that the customer accessed or downloaded the purchased digital product. This information should include IP addresses, corresponding timestamps, and any detailed recorded activity.
+  """
+  access_activity_log: String
+
+  """The billing address provided by the customer."""
+  billing_address: String
+  cancellation_policy: Stripe_DisputeEvidenceCancellationPolicyProperty
+
+  """
+  An explanation of how and when the customer was shown your refund policy prior to purchase.
+  """
+  cancellation_policy_disclosure: String
+
+  """A justification for why the customer's subscription was not canceled."""
+  cancellation_rebuttal: String
+  customer_communication: Stripe_DisputeEvidenceCustomerCommunicationProperty
+
+  """The email address of the customer."""
+  customer_email_address: String
+
+  """The name of the customer."""
+  customer_name: String
+
+  """The IP address that the customer used when making the purchase."""
+  customer_purchase_ip: String
+  customer_signature: Stripe_DisputeEvidenceCustomerSignatureProperty
+  duplicate_charge_documentation: Stripe_DisputeEvidenceDuplicateChargeDocumentationProperty
+
+  """
+  An explanation of the difference between the disputed charge versus the prior charge that appears to be a duplicate.
+  """
+  duplicate_charge_explanation: String
+
+  """
+  The Stripe ID for the prior charge which appears to be a duplicate of the disputed charge.
+  """
+  duplicate_charge_id: String
+
+  """A description of the product or service that was sold."""
+  product_description: String
+  receipt: Stripe_DisputeEvidenceReceiptProperty
+  refund_policy: Stripe_DisputeEvidenceRefundPolicyProperty
+
+  """
+  Documentation demonstrating that the customer was shown your refund policy prior to purchase.
+  """
+  refund_policy_disclosure: String
+
+  """A justification for why the customer is not entitled to a refund."""
+  refund_refusal_explanation: String
+
+  """
+  The date on which the customer received or began receiving the purchased service, in a clear human-readable format.
+  """
+  service_date: String
+  service_documentation: Stripe_DisputeEvidenceServiceDocumentationProperty
+
+  """
+  The address to which a physical product was shipped. You should try to include as complete address information as possible.
+  """
+  shipping_address: String
+
+  """
+  The delivery service that shipped a physical product, such as Fedex, UPS, USPS, etc. If multiple carriers were used for this purchase, please separate them with commas.
+  """
+  shipping_carrier: String
+
+  """
+  The date on which a physical product began its route to the shipping address, in a clear human-readable format.
+  """
+  shipping_date: String
+  shipping_documentation: Stripe_DisputeEvidenceShippingDocumentationProperty
+
+  """
+  The tracking number for a physical product, obtained from the delivery service. If multiple tracking numbers were generated for this purchase, please separate them with commas.
+  """
+  shipping_tracking_number: String
+  uncategorized_file: Stripe_DisputeEvidenceUncategorizedFileProperty
+
+  """Any additional evidence or statements."""
+  uncategorized_text: String
+}
+
+union Stripe_DisputeEvidenceCancellationPolicyProperty = WrappedString | Stripe_File
+
+union Stripe_DisputeEvidenceCustomerCommunicationProperty = WrappedString | Stripe_File
+
+union Stripe_DisputeEvidenceCustomerSignatureProperty = WrappedString | Stripe_File
+
+union Stripe_DisputeEvidenceDuplicateChargeDocumentationProperty = WrappedString | Stripe_File
+
+union Stripe_DisputeEvidenceReceiptProperty = WrappedString | Stripe_File
+
+union Stripe_DisputeEvidenceRefundPolicyProperty = WrappedString | Stripe_File
+
+union Stripe_DisputeEvidenceServiceDocumentationProperty = WrappedString | Stripe_File
+
+union Stripe_DisputeEvidenceShippingDocumentationProperty = WrappedString | Stripe_File
+
+union Stripe_DisputeEvidenceUncategorizedFileProperty = WrappedString | Stripe_File
+
+type Stripe_DisputeEvidenceDetails {
+  """
+  Date by which evidence must be submitted in order to successfully challenge dispute. Will be null if the customer's bank or credit card company doesn't allow a response for this particular dispute.
+  """
+  due_by: Int
+
+  """Whether evidence has been staged for this dispute."""
+  has_evidence: Boolean
+
+  """
+  Whether the last evidence submission was submitted past the due date. Defaults to `false` if no evidence submissions have occurred. If `true`, then delivery of the latest evidence is *not* guaranteed.
+  """
+  past_due: Boolean
+
+  """
+  The number of times evidence has been submitted. Typically, you may only submit evidence once.
+  """
+  submission_count: Int
+}
+
+enum Stripe_DisputeObjectProperty {
+  dispute
+}
+
+union Stripe_DisputePaymentIntentProperty = WrappedString | Stripe_PaymentIntent
+
+enum Stripe_DisputeStatusProperty {
+  charge_refunded
+  lost
+  needs_response
+  under_review
+  warning_closed
+  warning_needs_response
+  warning_under_review
+  won
+}
+
+type Stripe_FeeRefund {
+  """Amount, in %s."""
+  amount: Int
+  balance_transaction: Stripe_FeeRefundBalanceTransactionProperty
+
+  """
+  Time at which the object was created. Measured in seconds since the Unix epoch.
+  """
+  created: Int
+
+  """
+  Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
+  """
+  currency: String
+  fee: Stripe_FeeRefundFeeProperty
+
+  """Unique identifier for the object."""
+  id: String
+
+  """
+  Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format.
+  """
+  metadata: JSONObject
+
+  """
+  String representing the object's type. Objects of the same type share the same value.
+  """
+  object: Stripe_FeeRefundObjectProperty
+}
+
+union Stripe_FeeRefundBalanceTransactionProperty = WrappedString | Stripe_BalanceTransaction
+
+union Stripe_FeeRefundFeeProperty = WrappedString | Stripe_ApplicationFee
+
+enum Stripe_FeeRefundObjectProperty {
+  fee_refund
+}
+
+type Stripe_IssuingAuthorization {
+  """
+  The total amount that was authorized or rejected. This amount is in the card's currency and in the [smallest currency unit](https://stripe.com/docs/currencies#zero-decimal).
+  """
+  amount: Int
+  amount_details: Stripe_IssuingAuthorizationAmountDetails
+
+  """Whether the authorization has been approved."""
+  approved: Boolean
+
+  """How the card details were provided."""
+  authorization_method: Stripe_IssuingAuthorizationAuthorizationMethodProperty
+
+  """List of balance transactions associated with this authorization."""
+  balance_transactions: [Stripe_BalanceTransaction]
+  card: Stripe_IssuingCard
+  cardholder: Stripe_IssuingAuthorizationCardholderProperty
+
+  """
+  Time at which the object was created. Measured in seconds since the Unix epoch.
+  """
+  created: Int
+
+  """
+  Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
+  """
+  currency: String
+
+  """Unique identifier for the object."""
+  id: String
+
+  """
+  Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode.
+  """
+  livemode: Boolean
+
+  """
+  The total amount that was authorized or rejected. This amount is in the `merchant_currency` and in the [smallest currency unit](https://stripe.com/docs/currencies#zero-decimal).
+  """
+  merchant_amount: Int
+
+  """
+  The currency that was presented to the cardholder for the authorization. Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
+  """
+  merchant_currency: String
+  merchant_data: Stripe_IssuingAuthorizationMerchantData
+
+  """
+  Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format.
+  """
+  metadata: JSONObject
+
+  """
+  String representing the object's type. Objects of the same type share the same value.
+  """
+  object: Stripe_IssuingAuthorizationObjectProperty
+  pending_request: Stripe_IssuingAuthorizationPendingRequest
+
+  """
+  History of every time `pending_request` was approved/denied, either by you directly or by Stripe (e.g. based on your `spending_controls`). If the merchant changes the authorization by performing an [incremental authorization](https://stripe.com/docs/issuing/purchases/authorizations), you can look at this field to see the previous requests for the authorization.
+  """
+  request_history: [Stripe_IssuingAuthorizationRequest]
+
+  """The current status of the authorization in its lifecycle."""
+  status: Stripe_IssuingAuthorizationStatusProperty
+
+  """
+  List of [transactions](https://stripe.com/docs/api/issuing/transactions) associated with this authorization.
+  """
+  transactions: [Stripe_IssuingTransaction]
+  verification_data: Stripe_IssuingAuthorizationVerificationData
+
+  """
+  The digital wallet used for this authorization. One of `apple_pay`, `google_pay`, or `samsung_pay`.
+  """
+  wallet: String
+}
+
+type Stripe_IssuingAuthorizationAmountDetails {
+  """The fee charged by the ATM for the cash withdrawal."""
+  atm_fee: Int
+}
+
+enum Stripe_IssuingAuthorizationAuthorizationMethodProperty {
+  chip
+  contactless
+  keyed_in
+  online
+  swipe
+}
+
+type Stripe_IssuingCard {
+  """The brand of the card."""
+  brand: String
+
+  """The reason why the card was canceled."""
+  cancellation_reason: Stripe_IssuingCardCancellationReasonProperty
+  cardholder: Stripe_IssuingCardholder
+
+  """
+  Time at which the object was created. Measured in seconds since the Unix epoch.
+  """
+  created: Int
+
+  """
+  Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
+  """
+  currency: String
+
+  """
+  The card's CVC. For security reasons, this is only available for virtual cards, and will be omitted unless you explicitly request it with [the `expand` parameter](https://stripe.com/docs/api/expanding_objects). Additionally, it's only available via the ["Retrieve a card" endpoint](https://stripe.com/docs/api/issuing/cards/retrieve), not via "List all cards" or any other endpoint.
+  """
+  cvc: String
+
+  """The expiration month of the card."""
+  exp_month: Int
+
+  """The expiration year of the card."""
+  exp_year: Int
+
+  """Unique identifier for the object."""
+  id: String
+
+  """The last 4 digits of the card number."""
+  last4: String
+
+  """
+  Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode.
+  """
+  livemode: Boolean
+
+  """
+  Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format.
+  """
+  metadata: JSONObject
+
+  """
+  The full unredacted card number. For security reasons, this is only available for virtual cards, and will be omitted unless you explicitly request it with [the `expand` parameter](https://stripe.com/docs/api/expanding_objects). Additionally, it's only available via the ["Retrieve a card" endpoint](https://stripe.com/docs/api/issuing/cards/retrieve), not via "List all cards" or any other endpoint.
+  """
+  number: String
+
+  """
+  String representing the object's type. Objects of the same type share the same value.
+  """
+  object: Stripe_IssuingCardObjectProperty
+  replaced_by: Stripe_IssuingCardReplacedByProperty
+  replacement_for: Stripe_IssuingCardReplacementForProperty
+
+  """The reason why the previous card needed to be replaced."""
+  replacement_reason: Stripe_IssuingCardReplacementReasonProperty
+  shipping: Stripe_IssuingCardShipping
+  spending_controls: Stripe_IssuingCardAuthorizationControls
+
+  """Whether authorizations can be approved on this card."""
+  status: Stripe_IssuingCardStatusProperty
+
+  """The type of the card."""
+  type: Stripe_IssuingCardTypeProperty
+}
+
+enum Stripe_IssuingCardCancellationReasonProperty {
+  lost
+  stolen
+}
+
+type Stripe_IssuingCardholder {
+  billing: Stripe_IssuingCardholderAddress
+  company: Stripe_IssuingCardholderCompany
+
+  """
+  Time at which the object was created. Measured in seconds since the Unix epoch.
+  """
+  created: Int
+
+  """The cardholder's email address."""
+  email: String
+
+  """Unique identifier for the object."""
+  id: String
+  individual: Stripe_IssuingCardholderIndividual
+
+  """
+  Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode.
+  """
+  livemode: Boolean
+
+  """
+  Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format.
+  """
+  metadata: JSONObject
+
+  """The cardholder's name. This will be printed on cards issued to them."""
+  name: String
+
+  """
+  String representing the object's type. Objects of the same type share the same value.
+  """
+  object: Stripe_IssuingCardholderObjectProperty
+
+  """The cardholder's phone number."""
+  phone_number: String
+  requirements: Stripe_IssuingCardholderRequirements
+  spending_controls: Stripe_IssuingCardholderAuthorizationControls
+
+  """Specifies whether to permit authorizations on this cardholder's cards."""
+  status: Stripe_IssuingCardholderStatusProperty
+
+  """One of `individual` or `company`."""
+  type: Stripe_IssuingCardholderTypeProperty
+}
+
+type Stripe_IssuingCardholderAddress {
+  address: Stripe_Address
+}
+
+type Stripe_IssuingCardholderCompany {
+  """Whether the company's business ID number was provided."""
+  tax_id_provided: Boolean
+}
+
+type Stripe_IssuingCardholderIndividual {
+  dob: Stripe_IssuingCardholderIndividualDob
+
+  """The first name of this cardholder."""
+  first_name: String
+
+  """The last name of this cardholder."""
+  last_name: String
+  verification: Stripe_IssuingCardholderVerification
+}
+
+type Stripe_IssuingCardholderIndividualDob {
+  """The day of birth, between 1 and 31."""
+  day: Int
+
+  """The month of birth, between 1 and 12."""
+  month: Int
+
+  """The four-digit year of birth."""
+  year: Int
+}
+
+type Stripe_IssuingCardholderVerification {
+  document: Stripe_IssuingCardholderIdDocument
+}
+
+type Stripe_IssuingCardholderIdDocument {
+  back: Stripe_IssuingCardholderIdDocumentBackProperty
+  front: Stripe_IssuingCardholderIdDocumentFrontProperty
+}
+
+union Stripe_IssuingCardholderIdDocumentBackProperty = WrappedString | Stripe_File
+
+union Stripe_IssuingCardholderIdDocumentFrontProperty = WrappedString | Stripe_File
+
+enum Stripe_IssuingCardholderObjectProperty {
+  issuingDOTcardholder
+}
+
+type Stripe_IssuingCardholderRequirements {
+  """
+  If `disabled_reason` is present, all cards will decline authorizations with `cardholder_verification_required` reason.
+  """
+  disabled_reason: Stripe_IssuingCardholderRequirementsDisabledReasonProperty
+
+  """
+  Array of fields that need to be collected in order to verify and re-enable the cardholder.
+  """
+  past_due: [Stripe_IssuingCardholderRequirementsPastDueProperty]
+}
+
+enum Stripe_IssuingCardholderRequirementsDisabledReasonProperty {
+  listed
+  rejectedDOTlisted
+  under_review
+}
+
+enum Stripe_IssuingCardholderRequirementsPastDueProperty {
+  companyDOTtax_id
+  individualDOTdobDOTday
+  individualDOTdobDOTmonth
+  individualDOTdobDOTyear
+  individualDOTfirst_name
+  individualDOTlast_name
+  individualDOTverificationDOTdocument
+}
+
+type Stripe_IssuingCardholderAuthorizationControls {
+  """
+  Array of strings containing [categories](https://stripe.com/docs/api#issuing_authorization_object-merchant_data-category) of authorizations to allow. All other categories will be blocked. Cannot be set with `blocked_categories`.
+  """
+  allowed_categories: [Stripe_IssuingCardholderAuthorizationControlsAllowedCategoriesProperty]
+
+  """
+  Array of strings containing [categories](https://stripe.com/docs/api#issuing_authorization_object-merchant_data-category) of authorizations to decline. All other categories will be allowed. Cannot be set with `allowed_categories`.
+  """
+  blocked_categories: [Stripe_IssuingCardholderAuthorizationControlsBlockedCategoriesProperty]
+
+  """
+  Limit spending with amount-based rules that apply across this cardholder's cards.
+  """
+  spending_limits: [Stripe_IssuingCardholderSpendingLimit]
+
+  """Currency of the amounts within `spending_limits`."""
+  spending_limits_currency: String
+}
+
+enum Stripe_IssuingCardholderAuthorizationControlsAllowedCategoriesProperty {
+  ac_refrigeration_repair
+  accounting_bookkeeping_services
+  advertising_services
+  agricultural_cooperative
+  airlines_air_carriers
+  airports_flying_fields
+  ambulance_services
+  amusement_parks_carnivals
+  antique_reproductions
+  antique_shops
+  aquariums
+  architectural_surveying_services
+  art_dealers_and_galleries
+  artists_supply_and_craft_shops
+  auto_and_home_supply_stores
+  auto_body_repair_shops
+  auto_paint_shops
+  auto_service_shops
+  automated_cash_disburse
+  automated_fuel_dispensers
+  automobile_associations
+  automotive_parts_and_accessories_stores
+  automotive_tire_stores
+  bail_and_bond_payments
+  bakeries
+  bands_orchestras
+  barber_and_beauty_shops
+  betting_casino_gambling
+  bicycle_shops
+  billiard_pool_establishments
+  boat_dealers
+  boat_rentals_and_leases
+  book_stores
+  books_periodicals_and_newspapers
+  bowling_alleys
+  bus_lines
+  business_secretarial_schools
+  buying_shopping_services
+  cable_satellite_and_other_pay_television_and_radio
+  camera_and_photographic_supply_stores
+  candy_nut_and_confectionery_stores
+  car_and_truck_dealers_new_used
+  car_and_truck_dealers_used_only
+  car_rental_agencies
+  car_washes
+  carpentry_services
+  carpet_upholstery_cleaning
+  caterers
+  charitable_and_social_service_organizations_fundraising
+  chemicals_and_allied_products
+  child_care_services
+  childrens_and_infants_wear_stores
+  chiropodists_podiatrists
+  chiropractors
+  cigar_stores_and_stands
+  civic_social_fraternal_associations
+  cleaning_and_maintenance
+  clothing_rental
+  colleges_universities
+  commercial_equipment
+  commercial_footwear
+  commercial_photography_art_and_graphics
+  commuter_transport_and_ferries
+  computer_network_services
+  computer_programming
+  computer_repair
+  computer_software_stores
+  computers_peripherals_and_software
+  concrete_work_services
+  construction_materials
+  consulting_public_relations
+  correspondence_schools
+  cosmetic_stores
+  counseling_services
+  country_clubs
+  courier_services
+  court_costs
+  credit_reporting_agencies
+  cruise_lines
+  dairy_products_stores
+  dance_hall_studios_schools
+  dating_escort_services
+  dentists_orthodontists
+  department_stores
+  detective_agencies
+  digital_goods_applications
+  digital_goods_games
+  digital_goods_large_volume
+  digital_goods_media
+  direct_marketing_catalog_merchant
+  direct_marketing_combination_catalog_and_retail_merchant
+  direct_marketing_inbound_telemarketing
+  direct_marketing_insurance_services
+  direct_marketing_other
+  direct_marketing_outbound_telemarketing
+  direct_marketing_subscription
+  direct_marketing_travel
+  discount_stores
+  doctors
+  door_to_door_sales
+  drapery_window_covering_and_upholstery_stores
+  drinking_places
+  drug_stores_and_pharmacies
+  drugs_drug_proprietaries_and_druggist_sundries
+  dry_cleaners
+  durable_goods
+  duty_free_stores
+  eating_places_restaurants
+  educational_services
+  electric_razor_stores
+  electrical_parts_and_equipment
+  electrical_services
+  electronics_repair_shops
+  electronics_stores
+  elementary_secondary_schools
+  employment_temp_agencies
+  equipment_rental
+  exterminating_services
+  family_clothing_stores
+  fast_food_restaurants
+  financial_institutions
+  fines_government_administrative_entities
+  fireplace_fireplace_screens_and_accessories_stores
+  floor_covering_stores
+  florists
+  florists_supplies_nursery_stock_and_flowers
+  freezer_and_locker_meat_provisioners
+  fuel_dealers_non_automotive
+  funeral_services_crematories
+  furniture_home_furnishings_and_equipment_stores_except_appliances
+  furniture_repair_refinishing
+  furriers_and_fur_shops
+  general_services
+  gift_card_novelty_and_souvenir_shops
+  glass_paint_and_wallpaper_stores
+  glassware_crystal_stores
+  golf_courses_public
+  government_services
+  grocery_stores_supermarkets
+  hardware_equipment_and_supplies
+  hardware_stores
+  health_and_beauty_spas
+  hearing_aids_sales_and_supplies
+  heating_plumbing_a_c
+  hobby_toy_and_game_shops
+  home_supply_warehouse_stores
+  hospitals
+  hotels_motels_and_resorts
+  household_appliance_stores
+  industrial_supplies
+  information_retrieval_services
+  insurance_default
+  insurance_underwriting_premiums
+  intra_company_purchases
+  jewelry_stores_watches_clocks_and_silverware_stores
+  landscaping_services
+  laundries
+  laundry_cleaning_services
+  legal_services_attorneys
+  luggage_and_leather_goods_stores
+  lumber_building_materials_stores
+  manual_cash_disburse
+  marinas_service_and_supplies
+  masonry_stonework_and_plaster
+  massage_parlors
+  medical_and_dental_labs
+  medical_dental_ophthalmic_and_hospital_equipment_and_supplies
+  medical_services
+  membership_organizations
+  mens_and_boys_clothing_and_accessories_stores
+  mens_womens_clothing_stores
+  metal_service_centers
+  miscellaneous
+  miscellaneous_apparel_and_accessory_shops
+  miscellaneous_auto_dealers
+  miscellaneous_business_services
+  miscellaneous_food_stores
+  miscellaneous_general_merchandise
+  miscellaneous_general_services
+  miscellaneous_home_furnishing_specialty_stores
+  miscellaneous_publishing_and_printing
+  miscellaneous_recreation_services
+  miscellaneous_repair_shops
+  miscellaneous_specialty_retail
+  mobile_home_dealers
+  motion_picture_theaters
+  motor_freight_carriers_and_trucking
+  motor_homes_dealers
+  motor_vehicle_supplies_and_new_parts
+  motorcycle_shops_and_dealers
+  motorcycle_shops_dealers
+  music_stores_musical_instruments_pianos_and_sheet_music
+  news_dealers_and_newsstands
+  non_fi_money_orders
+  non_fi_stored_value_card_purchase_load
+  nondurable_goods
+  nurseries_lawn_and_garden_supply_stores
+  nursing_personal_care
+  office_and_commercial_furniture
+  opticians_eyeglasses
+  optometrists_ophthalmologist
+  orthopedic_goods_prosthetic_devices
+  osteopaths
+  package_stores_beer_wine_and_liquor
+  paints_varnishes_and_supplies
+  parking_lots_garages
+  passenger_railways
+  pawn_shops
+  pet_shops_pet_food_and_supplies
+  petroleum_and_petroleum_products
+  photo_developing
+  photographic_photocopy_microfilm_equipment_and_supplies
+  photographic_studios
+  picture_video_production
+  piece_goods_notions_and_other_dry_goods
+  plumbing_heating_equipment_and_supplies
+  political_organizations
+  postal_services_government_only
+  precious_stones_and_metals_watches_and_jewelry
+  professional_services
+  public_warehousing_and_storage
+  quick_copy_repro_and_blueprint
+  railroads
+  real_estate_agents_and_managers_rentals
+  record_stores
+  recreational_vehicle_rentals
+  religious_goods_stores
+  religious_organizations
+  roofing_siding_sheet_metal
+  secretarial_support_services
+  security_brokers_dealers
+  service_stations
+  sewing_needlework_fabric_and_piece_goods_stores
+  shoe_repair_hat_cleaning
+  shoe_stores
+  small_appliance_repair
+  snowmobile_dealers
+  special_trade_services
+  specialty_cleaning
+  sporting_goods_stores
+  sporting_recreation_camps
+  sports_and_riding_apparel_stores
+  sports_clubs_fields
+  stamp_and_coin_stores
+  stationary_office_supplies_printing_and_writing_paper
+  stationery_stores_office_and_school_supply_stores
+  swimming_pools_sales
+  t_ui_travel_germany
+  tailors_alterations
+  tax_payments_government_agencies
+  tax_preparation_services
+  taxicabs_limousines
+  telecommunication_equipment_and_telephone_sales
+  telecommunication_services
+  telegraph_services
+  tent_and_awning_shops
+  testing_laboratories
+  theatrical_ticket_agencies
+  timeshares
+  tire_retreading_and_repair
+  tolls_bridge_fees
+  tourist_attractions_and_exhibits
+  towing_services
+  trailer_parks_campgrounds
+  transportation_services
+  travel_agencies_tour_operators
+  truck_stop_iteration
+  truck_utility_trailer_rentals
+  typesetting_plate_making_and_related_services
+  typewriter_stores
+  u_s_federal_government_agencies_or_departments
+  uniforms_commercial_clothing
+  used_merchandise_and_secondhand_stores
+  utilities
+  variety_stores
+  veterinary_services
+  video_amusement_game_supplies
+  video_game_arcades
+  video_tape_rental_stores
+  vocational_trade_schools
+  watch_jewelry_repair
+  welding_repair
+  wholesale_clubs
+  wig_and_toupee_stores
+  wires_money_orders
+  womens_accessory_and_specialty_shops
+  womens_ready_to_wear_stores
+  wrecking_and_salvage_yards
+}
+
+enum Stripe_IssuingCardholderAuthorizationControlsBlockedCategoriesProperty {
+  ac_refrigeration_repair
+  accounting_bookkeeping_services
+  advertising_services
+  agricultural_cooperative
+  airlines_air_carriers
+  airports_flying_fields
+  ambulance_services
+  amusement_parks_carnivals
+  antique_reproductions
+  antique_shops
+  aquariums
+  architectural_surveying_services
+  art_dealers_and_galleries
+  artists_supply_and_craft_shops
+  auto_and_home_supply_stores
+  auto_body_repair_shops
+  auto_paint_shops
+  auto_service_shops
+  automated_cash_disburse
+  automated_fuel_dispensers
+  automobile_associations
+  automotive_parts_and_accessories_stores
+  automotive_tire_stores
+  bail_and_bond_payments
+  bakeries
+  bands_orchestras
+  barber_and_beauty_shops
+  betting_casino_gambling
+  bicycle_shops
+  billiard_pool_establishments
+  boat_dealers
+  boat_rentals_and_leases
+  book_stores
+  books_periodicals_and_newspapers
+  bowling_alleys
+  bus_lines
+  business_secretarial_schools
+  buying_shopping_services
+  cable_satellite_and_other_pay_television_and_radio
+  camera_and_photographic_supply_stores
+  candy_nut_and_confectionery_stores
+  car_and_truck_dealers_new_used
+  car_and_truck_dealers_used_only
+  car_rental_agencies
+  car_washes
+  carpentry_services
+  carpet_upholstery_cleaning
+  caterers
+  charitable_and_social_service_organizations_fundraising
+  chemicals_and_allied_products
+  child_care_services
+  childrens_and_infants_wear_stores
+  chiropodists_podiatrists
+  chiropractors
+  cigar_stores_and_stands
+  civic_social_fraternal_associations
+  cleaning_and_maintenance
+  clothing_rental
+  colleges_universities
+  commercial_equipment
+  commercial_footwear
+  commercial_photography_art_and_graphics
+  commuter_transport_and_ferries
+  computer_network_services
+  computer_programming
+  computer_repair
+  computer_software_stores
+  computers_peripherals_and_software
+  concrete_work_services
+  construction_materials
+  consulting_public_relations
+  correspondence_schools
+  cosmetic_stores
+  counseling_services
+  country_clubs
+  courier_services
+  court_costs
+  credit_reporting_agencies
+  cruise_lines
+  dairy_products_stores
+  dance_hall_studios_schools
+  dating_escort_services
+  dentists_orthodontists
+  department_stores
+  detective_agencies
+  digital_goods_applications
+  digital_goods_games
+  digital_goods_large_volume
+  digital_goods_media
+  direct_marketing_catalog_merchant
+  direct_marketing_combination_catalog_and_retail_merchant
+  direct_marketing_inbound_telemarketing
+  direct_marketing_insurance_services
+  direct_marketing_other
+  direct_marketing_outbound_telemarketing
+  direct_marketing_subscription
+  direct_marketing_travel
+  discount_stores
+  doctors
+  door_to_door_sales
+  drapery_window_covering_and_upholstery_stores
+  drinking_places
+  drug_stores_and_pharmacies
+  drugs_drug_proprietaries_and_druggist_sundries
+  dry_cleaners
+  durable_goods
+  duty_free_stores
+  eating_places_restaurants
+  educational_services
+  electric_razor_stores
+  electrical_parts_and_equipment
+  electrical_services
+  electronics_repair_shops
+  electronics_stores
+  elementary_secondary_schools
+  employment_temp_agencies
+  equipment_rental
+  exterminating_services
+  family_clothing_stores
+  fast_food_restaurants
+  financial_institutions
+  fines_government_administrative_entities
+  fireplace_fireplace_screens_and_accessories_stores
+  floor_covering_stores
+  florists
+  florists_supplies_nursery_stock_and_flowers
+  freezer_and_locker_meat_provisioners
+  fuel_dealers_non_automotive
+  funeral_services_crematories
+  furniture_home_furnishings_and_equipment_stores_except_appliances
+  furniture_repair_refinishing
+  furriers_and_fur_shops
+  general_services
+  gift_card_novelty_and_souvenir_shops
+  glass_paint_and_wallpaper_stores
+  glassware_crystal_stores
+  golf_courses_public
+  government_services
+  grocery_stores_supermarkets
+  hardware_equipment_and_supplies
+  hardware_stores
+  health_and_beauty_spas
+  hearing_aids_sales_and_supplies
+  heating_plumbing_a_c
+  hobby_toy_and_game_shops
+  home_supply_warehouse_stores
+  hospitals
+  hotels_motels_and_resorts
+  household_appliance_stores
+  industrial_supplies
+  information_retrieval_services
+  insurance_default
+  insurance_underwriting_premiums
+  intra_company_purchases
+  jewelry_stores_watches_clocks_and_silverware_stores
+  landscaping_services
+  laundries
+  laundry_cleaning_services
+  legal_services_attorneys
+  luggage_and_leather_goods_stores
+  lumber_building_materials_stores
+  manual_cash_disburse
+  marinas_service_and_supplies
+  masonry_stonework_and_plaster
+  massage_parlors
+  medical_and_dental_labs
+  medical_dental_ophthalmic_and_hospital_equipment_and_supplies
+  medical_services
+  membership_organizations
+  mens_and_boys_clothing_and_accessories_stores
+  mens_womens_clothing_stores
+  metal_service_centers
+  miscellaneous
+  miscellaneous_apparel_and_accessory_shops
+  miscellaneous_auto_dealers
+  miscellaneous_business_services
+  miscellaneous_food_stores
+  miscellaneous_general_merchandise
+  miscellaneous_general_services
+  miscellaneous_home_furnishing_specialty_stores
+  miscellaneous_publishing_and_printing
+  miscellaneous_recreation_services
+  miscellaneous_repair_shops
+  miscellaneous_specialty_retail
+  mobile_home_dealers
+  motion_picture_theaters
+  motor_freight_carriers_and_trucking
+  motor_homes_dealers
+  motor_vehicle_supplies_and_new_parts
+  motorcycle_shops_and_dealers
+  motorcycle_shops_dealers
+  music_stores_musical_instruments_pianos_and_sheet_music
+  news_dealers_and_newsstands
+  non_fi_money_orders
+  non_fi_stored_value_card_purchase_load
+  nondurable_goods
+  nurseries_lawn_and_garden_supply_stores
+  nursing_personal_care
+  office_and_commercial_furniture
+  opticians_eyeglasses
+  optometrists_ophthalmologist
+  orthopedic_goods_prosthetic_devices
+  osteopaths
+  package_stores_beer_wine_and_liquor
+  paints_varnishes_and_supplies
+  parking_lots_garages
+  passenger_railways
+  pawn_shops
+  pet_shops_pet_food_and_supplies
+  petroleum_and_petroleum_products
+  photo_developing
+  photographic_photocopy_microfilm_equipment_and_supplies
+  photographic_studios
+  picture_video_production
+  piece_goods_notions_and_other_dry_goods
+  plumbing_heating_equipment_and_supplies
+  political_organizations
+  postal_services_government_only
+  precious_stones_and_metals_watches_and_jewelry
+  professional_services
+  public_warehousing_and_storage
+  quick_copy_repro_and_blueprint
+  railroads
+  real_estate_agents_and_managers_rentals
+  record_stores
+  recreational_vehicle_rentals
+  religious_goods_stores
+  religious_organizations
+  roofing_siding_sheet_metal
+  secretarial_support_services
+  security_brokers_dealers
+  service_stations
+  sewing_needlework_fabric_and_piece_goods_stores
+  shoe_repair_hat_cleaning
+  shoe_stores
+  small_appliance_repair
+  snowmobile_dealers
+  special_trade_services
+  specialty_cleaning
+  sporting_goods_stores
+  sporting_recreation_camps
+  sports_and_riding_apparel_stores
+  sports_clubs_fields
+  stamp_and_coin_stores
+  stationary_office_supplies_printing_and_writing_paper
+  stationery_stores_office_and_school_supply_stores
+  swimming_pools_sales
+  t_ui_travel_germany
+  tailors_alterations
+  tax_payments_government_agencies
+  tax_preparation_services
+  taxicabs_limousines
+  telecommunication_equipment_and_telephone_sales
+  telecommunication_services
+  telegraph_services
+  tent_and_awning_shops
+  testing_laboratories
+  theatrical_ticket_agencies
+  timeshares
+  tire_retreading_and_repair
+  tolls_bridge_fees
+  tourist_attractions_and_exhibits
+  towing_services
+  trailer_parks_campgrounds
+  transportation_services
+  travel_agencies_tour_operators
+  truck_stop_iteration
+  truck_utility_trailer_rentals
+  typesetting_plate_making_and_related_services
+  typewriter_stores
+  u_s_federal_government_agencies_or_departments
+  uniforms_commercial_clothing
+  used_merchandise_and_secondhand_stores
+  utilities
+  variety_stores
+  veterinary_services
+  video_amusement_game_supplies
+  video_game_arcades
+  video_tape_rental_stores
+  vocational_trade_schools
+  watch_jewelry_repair
+  welding_repair
+  wholesale_clubs
+  wig_and_toupee_stores
+  wires_money_orders
+  womens_accessory_and_specialty_shops
+  womens_ready_to_wear_stores
+  wrecking_and_salvage_yards
+}
+
+type Stripe_IssuingCardholderSpendingLimit {
+  """Maximum amount allowed to spend per interval."""
+  amount: Int
+
+  """
+  Array of strings containing [categories](https://stripe.com/docs/api#issuing_authorization_object-merchant_data-category) this limit applies to. Omitting this field will apply the limit to all categories.
+  """
+  categories: [Stripe_IssuingCardholderSpendingLimitCategoriesProperty]
+
+  """Interval (or event) to which the amount applies."""
+  interval: Stripe_IssuingCardholderSpendingLimitIntervalProperty
+}
+
+enum Stripe_IssuingCardholderSpendingLimitCategoriesProperty {
+  ac_refrigeration_repair
+  accounting_bookkeeping_services
+  advertising_services
+  agricultural_cooperative
+  airlines_air_carriers
+  airports_flying_fields
+  ambulance_services
+  amusement_parks_carnivals
+  antique_reproductions
+  antique_shops
+  aquariums
+  architectural_surveying_services
+  art_dealers_and_galleries
+  artists_supply_and_craft_shops
+  auto_and_home_supply_stores
+  auto_body_repair_shops
+  auto_paint_shops
+  auto_service_shops
+  automated_cash_disburse
+  automated_fuel_dispensers
+  automobile_associations
+  automotive_parts_and_accessories_stores
+  automotive_tire_stores
+  bail_and_bond_payments
+  bakeries
+  bands_orchestras
+  barber_and_beauty_shops
+  betting_casino_gambling
+  bicycle_shops
+  billiard_pool_establishments
+  boat_dealers
+  boat_rentals_and_leases
+  book_stores
+  books_periodicals_and_newspapers
+  bowling_alleys
+  bus_lines
+  business_secretarial_schools
+  buying_shopping_services
+  cable_satellite_and_other_pay_television_and_radio
+  camera_and_photographic_supply_stores
+  candy_nut_and_confectionery_stores
+  car_and_truck_dealers_new_used
+  car_and_truck_dealers_used_only
+  car_rental_agencies
+  car_washes
+  carpentry_services
+  carpet_upholstery_cleaning
+  caterers
+  charitable_and_social_service_organizations_fundraising
+  chemicals_and_allied_products
+  child_care_services
+  childrens_and_infants_wear_stores
+  chiropodists_podiatrists
+  chiropractors
+  cigar_stores_and_stands
+  civic_social_fraternal_associations
+  cleaning_and_maintenance
+  clothing_rental
+  colleges_universities
+  commercial_equipment
+  commercial_footwear
+  commercial_photography_art_and_graphics
+  commuter_transport_and_ferries
+  computer_network_services
+  computer_programming
+  computer_repair
+  computer_software_stores
+  computers_peripherals_and_software
+  concrete_work_services
+  construction_materials
+  consulting_public_relations
+  correspondence_schools
+  cosmetic_stores
+  counseling_services
+  country_clubs
+  courier_services
+  court_costs
+  credit_reporting_agencies
+  cruise_lines
+  dairy_products_stores
+  dance_hall_studios_schools
+  dating_escort_services
+  dentists_orthodontists
+  department_stores
+  detective_agencies
+  digital_goods_applications
+  digital_goods_games
+  digital_goods_large_volume
+  digital_goods_media
+  direct_marketing_catalog_merchant
+  direct_marketing_combination_catalog_and_retail_merchant
+  direct_marketing_inbound_telemarketing
+  direct_marketing_insurance_services
+  direct_marketing_other
+  direct_marketing_outbound_telemarketing
+  direct_marketing_subscription
+  direct_marketing_travel
+  discount_stores
+  doctors
+  door_to_door_sales
+  drapery_window_covering_and_upholstery_stores
+  drinking_places
+  drug_stores_and_pharmacies
+  drugs_drug_proprietaries_and_druggist_sundries
+  dry_cleaners
+  durable_goods
+  duty_free_stores
+  eating_places_restaurants
+  educational_services
+  electric_razor_stores
+  electrical_parts_and_equipment
+  electrical_services
+  electronics_repair_shops
+  electronics_stores
+  elementary_secondary_schools
+  employment_temp_agencies
+  equipment_rental
+  exterminating_services
+  family_clothing_stores
+  fast_food_restaurants
+  financial_institutions
+  fines_government_administrative_entities
+  fireplace_fireplace_screens_and_accessories_stores
+  floor_covering_stores
+  florists
+  florists_supplies_nursery_stock_and_flowers
+  freezer_and_locker_meat_provisioners
+  fuel_dealers_non_automotive
+  funeral_services_crematories
+  furniture_home_furnishings_and_equipment_stores_except_appliances
+  furniture_repair_refinishing
+  furriers_and_fur_shops
+  general_services
+  gift_card_novelty_and_souvenir_shops
+  glass_paint_and_wallpaper_stores
+  glassware_crystal_stores
+  golf_courses_public
+  government_services
+  grocery_stores_supermarkets
+  hardware_equipment_and_supplies
+  hardware_stores
+  health_and_beauty_spas
+  hearing_aids_sales_and_supplies
+  heating_plumbing_a_c
+  hobby_toy_and_game_shops
+  home_supply_warehouse_stores
+  hospitals
+  hotels_motels_and_resorts
+  household_appliance_stores
+  industrial_supplies
+  information_retrieval_services
+  insurance_default
+  insurance_underwriting_premiums
+  intra_company_purchases
+  jewelry_stores_watches_clocks_and_silverware_stores
+  landscaping_services
+  laundries
+  laundry_cleaning_services
+  legal_services_attorneys
+  luggage_and_leather_goods_stores
+  lumber_building_materials_stores
+  manual_cash_disburse
+  marinas_service_and_supplies
+  masonry_stonework_and_plaster
+  massage_parlors
+  medical_and_dental_labs
+  medical_dental_ophthalmic_and_hospital_equipment_and_supplies
+  medical_services
+  membership_organizations
+  mens_and_boys_clothing_and_accessories_stores
+  mens_womens_clothing_stores
+  metal_service_centers
+  miscellaneous
+  miscellaneous_apparel_and_accessory_shops
+  miscellaneous_auto_dealers
+  miscellaneous_business_services
+  miscellaneous_food_stores
+  miscellaneous_general_merchandise
+  miscellaneous_general_services
+  miscellaneous_home_furnishing_specialty_stores
+  miscellaneous_publishing_and_printing
+  miscellaneous_recreation_services
+  miscellaneous_repair_shops
+  miscellaneous_specialty_retail
+  mobile_home_dealers
+  motion_picture_theaters
+  motor_freight_carriers_and_trucking
+  motor_homes_dealers
+  motor_vehicle_supplies_and_new_parts
+  motorcycle_shops_and_dealers
+  motorcycle_shops_dealers
+  music_stores_musical_instruments_pianos_and_sheet_music
+  news_dealers_and_newsstands
+  non_fi_money_orders
+  non_fi_stored_value_card_purchase_load
+  nondurable_goods
+  nurseries_lawn_and_garden_supply_stores
+  nursing_personal_care
+  office_and_commercial_furniture
+  opticians_eyeglasses
+  optometrists_ophthalmologist
+  orthopedic_goods_prosthetic_devices
+  osteopaths
+  package_stores_beer_wine_and_liquor
+  paints_varnishes_and_supplies
+  parking_lots_garages
+  passenger_railways
+  pawn_shops
+  pet_shops_pet_food_and_supplies
+  petroleum_and_petroleum_products
+  photo_developing
+  photographic_photocopy_microfilm_equipment_and_supplies
+  photographic_studios
+  picture_video_production
+  piece_goods_notions_and_other_dry_goods
+  plumbing_heating_equipment_and_supplies
+  political_organizations
+  postal_services_government_only
+  precious_stones_and_metals_watches_and_jewelry
+  professional_services
+  public_warehousing_and_storage
+  quick_copy_repro_and_blueprint
+  railroads
+  real_estate_agents_and_managers_rentals
+  record_stores
+  recreational_vehicle_rentals
+  religious_goods_stores
+  religious_organizations
+  roofing_siding_sheet_metal
+  secretarial_support_services
+  security_brokers_dealers
+  service_stations
+  sewing_needlework_fabric_and_piece_goods_stores
+  shoe_repair_hat_cleaning
+  shoe_stores
+  small_appliance_repair
+  snowmobile_dealers
+  special_trade_services
+  specialty_cleaning
+  sporting_goods_stores
+  sporting_recreation_camps
+  sports_and_riding_apparel_stores
+  sports_clubs_fields
+  stamp_and_coin_stores
+  stationary_office_supplies_printing_and_writing_paper
+  stationery_stores_office_and_school_supply_stores
+  swimming_pools_sales
+  t_ui_travel_germany
+  tailors_alterations
+  tax_payments_government_agencies
+  tax_preparation_services
+  taxicabs_limousines
+  telecommunication_equipment_and_telephone_sales
+  telecommunication_services
+  telegraph_services
+  tent_and_awning_shops
+  testing_laboratories
+  theatrical_ticket_agencies
+  timeshares
+  tire_retreading_and_repair
+  tolls_bridge_fees
+  tourist_attractions_and_exhibits
+  towing_services
+  trailer_parks_campgrounds
+  transportation_services
+  travel_agencies_tour_operators
+  truck_stop_iteration
+  truck_utility_trailer_rentals
+  typesetting_plate_making_and_related_services
+  typewriter_stores
+  u_s_federal_government_agencies_or_departments
+  uniforms_commercial_clothing
+  used_merchandise_and_secondhand_stores
+  utilities
+  variety_stores
+  veterinary_services
+  video_amusement_game_supplies
+  video_game_arcades
+  video_tape_rental_stores
+  vocational_trade_schools
+  watch_jewelry_repair
+  welding_repair
+  wholesale_clubs
+  wig_and_toupee_stores
+  wires_money_orders
+  womens_accessory_and_specialty_shops
+  womens_ready_to_wear_stores
+  wrecking_and_salvage_yards
+}
+
+enum Stripe_IssuingCardholderSpendingLimitIntervalProperty {
+  all_time
+  daily
+  monthly
+  per_authorization
+  weekly
+  yearly
+}
+
+enum Stripe_IssuingCardholderStatusProperty {
+  active
+  blocked
+  inactive
+}
+
+enum Stripe_IssuingCardholderTypeProperty {
+  company
+  individual
+}
+
+enum Stripe_IssuingCardObjectProperty {
+  issuingDOTcard
+}
+
+union Stripe_IssuingCardReplacedByProperty = WrappedString | Stripe_IssuingCard
+
+union Stripe_IssuingCardReplacementForProperty = WrappedString | Stripe_IssuingCard
+
+enum Stripe_IssuingCardReplacementReasonProperty {
+  damaged
+  expired
+  lost
+  stolen
+}
+
+type Stripe_IssuingCardShipping {
+  address: Stripe_Address
+
+  """The delivery company that shipped a card."""
+  carrier: Stripe_IssuingCardShippingCarrierProperty
+
+  """
+  A unix timestamp representing a best estimate of when the card will be delivered.
+  """
+  eta: Int
+
+  """Recipient name."""
+  name: String
+
+  """Shipment service, such as `standard` or `express`."""
+  service: Stripe_IssuingCardShippingServiceProperty
+
+  """The delivery status of the card."""
+  status: Stripe_IssuingCardShippingStatusProperty
+
+  """A tracking number for a card shipment."""
+  tracking_number: String
+
+  """
+  A link to the shipping carrier's site where you can view detailed information about a card shipment.
+  """
+  tracking_url: String
+
+  """Packaging options."""
+  type: Stripe_IssuingCardShippingTypeProperty
+}
+
+enum Stripe_IssuingCardShippingCarrierProperty {
+  dhl
+  fedex
+  royal_mail
+  usps
+}
+
+enum Stripe_IssuingCardShippingServiceProperty {
+  express
+  priority
+  standard
+}
+
+enum Stripe_IssuingCardShippingStatusProperty {
+  canceled
+  delivered
+  failure
+  pending
+  returned
+  shipped
+}
+
+enum Stripe_IssuingCardShippingTypeProperty {
+  bulk
+  individual
+}
+
+type Stripe_IssuingCardAuthorizationControls {
+  """
+  Array of strings containing [categories](https://stripe.com/docs/api#issuing_authorization_object-merchant_data-category) of authorizations to allow. All other categories will be blocked. Cannot be set with `blocked_categories`.
+  """
+  allowed_categories: [Stripe_IssuingCardAuthorizationControlsAllowedCategoriesProperty]
+
+  """
+  Array of strings containing [categories](https://stripe.com/docs/api#issuing_authorization_object-merchant_data-category) of authorizations to decline. All other categories will be allowed. Cannot be set with `allowed_categories`.
+  """
+  blocked_categories: [Stripe_IssuingCardAuthorizationControlsBlockedCategoriesProperty]
+
+  """
+  Limit spending with amount-based rules that apply across any cards this card replaced (i.e., its `replacement_for` card and _that_ card's `replacement_for` card, up the chain).
+  """
+  spending_limits: [Stripe_IssuingCardSpendingLimit]
+
+  """
+  Currency of the amounts within `spending_limits`. Always the same as the currency of the card.
+  """
+  spending_limits_currency: String
+}
+
+enum Stripe_IssuingCardAuthorizationControlsAllowedCategoriesProperty {
+  ac_refrigeration_repair
+  accounting_bookkeeping_services
+  advertising_services
+  agricultural_cooperative
+  airlines_air_carriers
+  airports_flying_fields
+  ambulance_services
+  amusement_parks_carnivals
+  antique_reproductions
+  antique_shops
+  aquariums
+  architectural_surveying_services
+  art_dealers_and_galleries
+  artists_supply_and_craft_shops
+  auto_and_home_supply_stores
+  auto_body_repair_shops
+  auto_paint_shops
+  auto_service_shops
+  automated_cash_disburse
+  automated_fuel_dispensers
+  automobile_associations
+  automotive_parts_and_accessories_stores
+  automotive_tire_stores
+  bail_and_bond_payments
+  bakeries
+  bands_orchestras
+  barber_and_beauty_shops
+  betting_casino_gambling
+  bicycle_shops
+  billiard_pool_establishments
+  boat_dealers
+  boat_rentals_and_leases
+  book_stores
+  books_periodicals_and_newspapers
+  bowling_alleys
+  bus_lines
+  business_secretarial_schools
+  buying_shopping_services
+  cable_satellite_and_other_pay_television_and_radio
+  camera_and_photographic_supply_stores
+  candy_nut_and_confectionery_stores
+  car_and_truck_dealers_new_used
+  car_and_truck_dealers_used_only
+  car_rental_agencies
+  car_washes
+  carpentry_services
+  carpet_upholstery_cleaning
+  caterers
+  charitable_and_social_service_organizations_fundraising
+  chemicals_and_allied_products
+  child_care_services
+  childrens_and_infants_wear_stores
+  chiropodists_podiatrists
+  chiropractors
+  cigar_stores_and_stands
+  civic_social_fraternal_associations
+  cleaning_and_maintenance
+  clothing_rental
+  colleges_universities
+  commercial_equipment
+  commercial_footwear
+  commercial_photography_art_and_graphics
+  commuter_transport_and_ferries
+  computer_network_services
+  computer_programming
+  computer_repair
+  computer_software_stores
+  computers_peripherals_and_software
+  concrete_work_services
+  construction_materials
+  consulting_public_relations
+  correspondence_schools
+  cosmetic_stores
+  counseling_services
+  country_clubs
+  courier_services
+  court_costs
+  credit_reporting_agencies
+  cruise_lines
+  dairy_products_stores
+  dance_hall_studios_schools
+  dating_escort_services
+  dentists_orthodontists
+  department_stores
+  detective_agencies
+  digital_goods_applications
+  digital_goods_games
+  digital_goods_large_volume
+  digital_goods_media
+  direct_marketing_catalog_merchant
+  direct_marketing_combination_catalog_and_retail_merchant
+  direct_marketing_inbound_telemarketing
+  direct_marketing_insurance_services
+  direct_marketing_other
+  direct_marketing_outbound_telemarketing
+  direct_marketing_subscription
+  direct_marketing_travel
+  discount_stores
+  doctors
+  door_to_door_sales
+  drapery_window_covering_and_upholstery_stores
+  drinking_places
+  drug_stores_and_pharmacies
+  drugs_drug_proprietaries_and_druggist_sundries
+  dry_cleaners
+  durable_goods
+  duty_free_stores
+  eating_places_restaurants
+  educational_services
+  electric_razor_stores
+  electrical_parts_and_equipment
+  electrical_services
+  electronics_repair_shops
+  electronics_stores
+  elementary_secondary_schools
+  employment_temp_agencies
+  equipment_rental
+  exterminating_services
+  family_clothing_stores
+  fast_food_restaurants
+  financial_institutions
+  fines_government_administrative_entities
+  fireplace_fireplace_screens_and_accessories_stores
+  floor_covering_stores
+  florists
+  florists_supplies_nursery_stock_and_flowers
+  freezer_and_locker_meat_provisioners
+  fuel_dealers_non_automotive
+  funeral_services_crematories
+  furniture_home_furnishings_and_equipment_stores_except_appliances
+  furniture_repair_refinishing
+  furriers_and_fur_shops
+  general_services
+  gift_card_novelty_and_souvenir_shops
+  glass_paint_and_wallpaper_stores
+  glassware_crystal_stores
+  golf_courses_public
+  government_services
+  grocery_stores_supermarkets
+  hardware_equipment_and_supplies
+  hardware_stores
+  health_and_beauty_spas
+  hearing_aids_sales_and_supplies
+  heating_plumbing_a_c
+  hobby_toy_and_game_shops
+  home_supply_warehouse_stores
+  hospitals
+  hotels_motels_and_resorts
+  household_appliance_stores
+  industrial_supplies
+  information_retrieval_services
+  insurance_default
+  insurance_underwriting_premiums
+  intra_company_purchases
+  jewelry_stores_watches_clocks_and_silverware_stores
+  landscaping_services
+  laundries
+  laundry_cleaning_services
+  legal_services_attorneys
+  luggage_and_leather_goods_stores
+  lumber_building_materials_stores
+  manual_cash_disburse
+  marinas_service_and_supplies
+  masonry_stonework_and_plaster
+  massage_parlors
+  medical_and_dental_labs
+  medical_dental_ophthalmic_and_hospital_equipment_and_supplies
+  medical_services
+  membership_organizations
+  mens_and_boys_clothing_and_accessories_stores
+  mens_womens_clothing_stores
+  metal_service_centers
+  miscellaneous
+  miscellaneous_apparel_and_accessory_shops
+  miscellaneous_auto_dealers
+  miscellaneous_business_services
+  miscellaneous_food_stores
+  miscellaneous_general_merchandise
+  miscellaneous_general_services
+  miscellaneous_home_furnishing_specialty_stores
+  miscellaneous_publishing_and_printing
+  miscellaneous_recreation_services
+  miscellaneous_repair_shops
+  miscellaneous_specialty_retail
+  mobile_home_dealers
+  motion_picture_theaters
+  motor_freight_carriers_and_trucking
+  motor_homes_dealers
+  motor_vehicle_supplies_and_new_parts
+  motorcycle_shops_and_dealers
+  motorcycle_shops_dealers
+  music_stores_musical_instruments_pianos_and_sheet_music
+  news_dealers_and_newsstands
+  non_fi_money_orders
+  non_fi_stored_value_card_purchase_load
+  nondurable_goods
+  nurseries_lawn_and_garden_supply_stores
+  nursing_personal_care
+  office_and_commercial_furniture
+  opticians_eyeglasses
+  optometrists_ophthalmologist
+  orthopedic_goods_prosthetic_devices
+  osteopaths
+  package_stores_beer_wine_and_liquor
+  paints_varnishes_and_supplies
+  parking_lots_garages
+  passenger_railways
+  pawn_shops
+  pet_shops_pet_food_and_supplies
+  petroleum_and_petroleum_products
+  photo_developing
+  photographic_photocopy_microfilm_equipment_and_supplies
+  photographic_studios
+  picture_video_production
+  piece_goods_notions_and_other_dry_goods
+  plumbing_heating_equipment_and_supplies
+  political_organizations
+  postal_services_government_only
+  precious_stones_and_metals_watches_and_jewelry
+  professional_services
+  public_warehousing_and_storage
+  quick_copy_repro_and_blueprint
+  railroads
+  real_estate_agents_and_managers_rentals
+  record_stores
+  recreational_vehicle_rentals
+  religious_goods_stores
+  religious_organizations
+  roofing_siding_sheet_metal
+  secretarial_support_services
+  security_brokers_dealers
+  service_stations
+  sewing_needlework_fabric_and_piece_goods_stores
+  shoe_repair_hat_cleaning
+  shoe_stores
+  small_appliance_repair
+  snowmobile_dealers
+  special_trade_services
+  specialty_cleaning
+  sporting_goods_stores
+  sporting_recreation_camps
+  sports_and_riding_apparel_stores
+  sports_clubs_fields
+  stamp_and_coin_stores
+  stationary_office_supplies_printing_and_writing_paper
+  stationery_stores_office_and_school_supply_stores
+  swimming_pools_sales
+  t_ui_travel_germany
+  tailors_alterations
+  tax_payments_government_agencies
+  tax_preparation_services
+  taxicabs_limousines
+  telecommunication_equipment_and_telephone_sales
+  telecommunication_services
+  telegraph_services
+  tent_and_awning_shops
+  testing_laboratories
+  theatrical_ticket_agencies
+  timeshares
+  tire_retreading_and_repair
+  tolls_bridge_fees
+  tourist_attractions_and_exhibits
+  towing_services
+  trailer_parks_campgrounds
+  transportation_services
+  travel_agencies_tour_operators
+  truck_stop_iteration
+  truck_utility_trailer_rentals
+  typesetting_plate_making_and_related_services
+  typewriter_stores
+  u_s_federal_government_agencies_or_departments
+  uniforms_commercial_clothing
+  used_merchandise_and_secondhand_stores
+  utilities
+  variety_stores
+  veterinary_services
+  video_amusement_game_supplies
+  video_game_arcades
+  video_tape_rental_stores
+  vocational_trade_schools
+  watch_jewelry_repair
+  welding_repair
+  wholesale_clubs
+  wig_and_toupee_stores
+  wires_money_orders
+  womens_accessory_and_specialty_shops
+  womens_ready_to_wear_stores
+  wrecking_and_salvage_yards
+}
+
+enum Stripe_IssuingCardAuthorizationControlsBlockedCategoriesProperty {
+  ac_refrigeration_repair
+  accounting_bookkeeping_services
+  advertising_services
+  agricultural_cooperative
+  airlines_air_carriers
+  airports_flying_fields
+  ambulance_services
+  amusement_parks_carnivals
+  antique_reproductions
+  antique_shops
+  aquariums
+  architectural_surveying_services
+  art_dealers_and_galleries
+  artists_supply_and_craft_shops
+  auto_and_home_supply_stores
+  auto_body_repair_shops
+  auto_paint_shops
+  auto_service_shops
+  automated_cash_disburse
+  automated_fuel_dispensers
+  automobile_associations
+  automotive_parts_and_accessories_stores
+  automotive_tire_stores
+  bail_and_bond_payments
+  bakeries
+  bands_orchestras
+  barber_and_beauty_shops
+  betting_casino_gambling
+  bicycle_shops
+  billiard_pool_establishments
+  boat_dealers
+  boat_rentals_and_leases
+  book_stores
+  books_periodicals_and_newspapers
+  bowling_alleys
+  bus_lines
+  business_secretarial_schools
+  buying_shopping_services
+  cable_satellite_and_other_pay_television_and_radio
+  camera_and_photographic_supply_stores
+  candy_nut_and_confectionery_stores
+  car_and_truck_dealers_new_used
+  car_and_truck_dealers_used_only
+  car_rental_agencies
+  car_washes
+  carpentry_services
+  carpet_upholstery_cleaning
+  caterers
+  charitable_and_social_service_organizations_fundraising
+  chemicals_and_allied_products
+  child_care_services
+  childrens_and_infants_wear_stores
+  chiropodists_podiatrists
+  chiropractors
+  cigar_stores_and_stands
+  civic_social_fraternal_associations
+  cleaning_and_maintenance
+  clothing_rental
+  colleges_universities
+  commercial_equipment
+  commercial_footwear
+  commercial_photography_art_and_graphics
+  commuter_transport_and_ferries
+  computer_network_services
+  computer_programming
+  computer_repair
+  computer_software_stores
+  computers_peripherals_and_software
+  concrete_work_services
+  construction_materials
+  consulting_public_relations
+  correspondence_schools
+  cosmetic_stores
+  counseling_services
+  country_clubs
+  courier_services
+  court_costs
+  credit_reporting_agencies
+  cruise_lines
+  dairy_products_stores
+  dance_hall_studios_schools
+  dating_escort_services
+  dentists_orthodontists
+  department_stores
+  detective_agencies
+  digital_goods_applications
+  digital_goods_games
+  digital_goods_large_volume
+  digital_goods_media
+  direct_marketing_catalog_merchant
+  direct_marketing_combination_catalog_and_retail_merchant
+  direct_marketing_inbound_telemarketing
+  direct_marketing_insurance_services
+  direct_marketing_other
+  direct_marketing_outbound_telemarketing
+  direct_marketing_subscription
+  direct_marketing_travel
+  discount_stores
+  doctors
+  door_to_door_sales
+  drapery_window_covering_and_upholstery_stores
+  drinking_places
+  drug_stores_and_pharmacies
+  drugs_drug_proprietaries_and_druggist_sundries
+  dry_cleaners
+  durable_goods
+  duty_free_stores
+  eating_places_restaurants
+  educational_services
+  electric_razor_stores
+  electrical_parts_and_equipment
+  electrical_services
+  electronics_repair_shops
+  electronics_stores
+  elementary_secondary_schools
+  employment_temp_agencies
+  equipment_rental
+  exterminating_services
+  family_clothing_stores
+  fast_food_restaurants
+  financial_institutions
+  fines_government_administrative_entities
+  fireplace_fireplace_screens_and_accessories_stores
+  floor_covering_stores
+  florists
+  florists_supplies_nursery_stock_and_flowers
+  freezer_and_locker_meat_provisioners
+  fuel_dealers_non_automotive
+  funeral_services_crematories
+  furniture_home_furnishings_and_equipment_stores_except_appliances
+  furniture_repair_refinishing
+  furriers_and_fur_shops
+  general_services
+  gift_card_novelty_and_souvenir_shops
+  glass_paint_and_wallpaper_stores
+  glassware_crystal_stores
+  golf_courses_public
+  government_services
+  grocery_stores_supermarkets
+  hardware_equipment_and_supplies
+  hardware_stores
+  health_and_beauty_spas
+  hearing_aids_sales_and_supplies
+  heating_plumbing_a_c
+  hobby_toy_and_game_shops
+  home_supply_warehouse_stores
+  hospitals
+  hotels_motels_and_resorts
+  household_appliance_stores
+  industrial_supplies
+  information_retrieval_services
+  insurance_default
+  insurance_underwriting_premiums
+  intra_company_purchases
+  jewelry_stores_watches_clocks_and_silverware_stores
+  landscaping_services
+  laundries
+  laundry_cleaning_services
+  legal_services_attorneys
+  luggage_and_leather_goods_stores
+  lumber_building_materials_stores
+  manual_cash_disburse
+  marinas_service_and_supplies
+  masonry_stonework_and_plaster
+  massage_parlors
+  medical_and_dental_labs
+  medical_dental_ophthalmic_and_hospital_equipment_and_supplies
+  medical_services
+  membership_organizations
+  mens_and_boys_clothing_and_accessories_stores
+  mens_womens_clothing_stores
+  metal_service_centers
+  miscellaneous
+  miscellaneous_apparel_and_accessory_shops
+  miscellaneous_auto_dealers
+  miscellaneous_business_services
+  miscellaneous_food_stores
+  miscellaneous_general_merchandise
+  miscellaneous_general_services
+  miscellaneous_home_furnishing_specialty_stores
+  miscellaneous_publishing_and_printing
+  miscellaneous_recreation_services
+  miscellaneous_repair_shops
+  miscellaneous_specialty_retail
+  mobile_home_dealers
+  motion_picture_theaters
+  motor_freight_carriers_and_trucking
+  motor_homes_dealers
+  motor_vehicle_supplies_and_new_parts
+  motorcycle_shops_and_dealers
+  motorcycle_shops_dealers
+  music_stores_musical_instruments_pianos_and_sheet_music
+  news_dealers_and_newsstands
+  non_fi_money_orders
+  non_fi_stored_value_card_purchase_load
+  nondurable_goods
+  nurseries_lawn_and_garden_supply_stores
+  nursing_personal_care
+  office_and_commercial_furniture
+  opticians_eyeglasses
+  optometrists_ophthalmologist
+  orthopedic_goods_prosthetic_devices
+  osteopaths
+  package_stores_beer_wine_and_liquor
+  paints_varnishes_and_supplies
+  parking_lots_garages
+  passenger_railways
+  pawn_shops
+  pet_shops_pet_food_and_supplies
+  petroleum_and_petroleum_products
+  photo_developing
+  photographic_photocopy_microfilm_equipment_and_supplies
+  photographic_studios
+  picture_video_production
+  piece_goods_notions_and_other_dry_goods
+  plumbing_heating_equipment_and_supplies
+  political_organizations
+  postal_services_government_only
+  precious_stones_and_metals_watches_and_jewelry
+  professional_services
+  public_warehousing_and_storage
+  quick_copy_repro_and_blueprint
+  railroads
+  real_estate_agents_and_managers_rentals
+  record_stores
+  recreational_vehicle_rentals
+  religious_goods_stores
+  religious_organizations
+  roofing_siding_sheet_metal
+  secretarial_support_services
+  security_brokers_dealers
+  service_stations
+  sewing_needlework_fabric_and_piece_goods_stores
+  shoe_repair_hat_cleaning
+  shoe_stores
+  small_appliance_repair
+  snowmobile_dealers
+  special_trade_services
+  specialty_cleaning
+  sporting_goods_stores
+  sporting_recreation_camps
+  sports_and_riding_apparel_stores
+  sports_clubs_fields
+  stamp_and_coin_stores
+  stationary_office_supplies_printing_and_writing_paper
+  stationery_stores_office_and_school_supply_stores
+  swimming_pools_sales
+  t_ui_travel_germany
+  tailors_alterations
+  tax_payments_government_agencies
+  tax_preparation_services
+  taxicabs_limousines
+  telecommunication_equipment_and_telephone_sales
+  telecommunication_services
+  telegraph_services
+  tent_and_awning_shops
+  testing_laboratories
+  theatrical_ticket_agencies
+  timeshares
+  tire_retreading_and_repair
+  tolls_bridge_fees
+  tourist_attractions_and_exhibits
+  towing_services
+  trailer_parks_campgrounds
+  transportation_services
+  travel_agencies_tour_operators
+  truck_stop_iteration
+  truck_utility_trailer_rentals
+  typesetting_plate_making_and_related_services
+  typewriter_stores
+  u_s_federal_government_agencies_or_departments
+  uniforms_commercial_clothing
+  used_merchandise_and_secondhand_stores
+  utilities
+  variety_stores
+  veterinary_services
+  video_amusement_game_supplies
+  video_game_arcades
+  video_tape_rental_stores
+  vocational_trade_schools
+  watch_jewelry_repair
+  welding_repair
+  wholesale_clubs
+  wig_and_toupee_stores
+  wires_money_orders
+  womens_accessory_and_specialty_shops
+  womens_ready_to_wear_stores
+  wrecking_and_salvage_yards
+}
+
+type Stripe_IssuingCardSpendingLimit {
+  """Maximum amount allowed to spend per interval."""
+  amount: Int
+
+  """
+  Array of strings containing [categories](https://stripe.com/docs/api#issuing_authorization_object-merchant_data-category) this limit applies to. Omitting this field will apply the limit to all categories.
+  """
+  categories: [Stripe_IssuingCardSpendingLimitCategoriesProperty]
+
+  """Interval (or event) to which the amount applies."""
+  interval: Stripe_IssuingCardSpendingLimitIntervalProperty
+}
+
+enum Stripe_IssuingCardSpendingLimitCategoriesProperty {
+  ac_refrigeration_repair
+  accounting_bookkeeping_services
+  advertising_services
+  agricultural_cooperative
+  airlines_air_carriers
+  airports_flying_fields
+  ambulance_services
+  amusement_parks_carnivals
+  antique_reproductions
+  antique_shops
+  aquariums
+  architectural_surveying_services
+  art_dealers_and_galleries
+  artists_supply_and_craft_shops
+  auto_and_home_supply_stores
+  auto_body_repair_shops
+  auto_paint_shops
+  auto_service_shops
+  automated_cash_disburse
+  automated_fuel_dispensers
+  automobile_associations
+  automotive_parts_and_accessories_stores
+  automotive_tire_stores
+  bail_and_bond_payments
+  bakeries
+  bands_orchestras
+  barber_and_beauty_shops
+  betting_casino_gambling
+  bicycle_shops
+  billiard_pool_establishments
+  boat_dealers
+  boat_rentals_and_leases
+  book_stores
+  books_periodicals_and_newspapers
+  bowling_alleys
+  bus_lines
+  business_secretarial_schools
+  buying_shopping_services
+  cable_satellite_and_other_pay_television_and_radio
+  camera_and_photographic_supply_stores
+  candy_nut_and_confectionery_stores
+  car_and_truck_dealers_new_used
+  car_and_truck_dealers_used_only
+  car_rental_agencies
+  car_washes
+  carpentry_services
+  carpet_upholstery_cleaning
+  caterers
+  charitable_and_social_service_organizations_fundraising
+  chemicals_and_allied_products
+  child_care_services
+  childrens_and_infants_wear_stores
+  chiropodists_podiatrists
+  chiropractors
+  cigar_stores_and_stands
+  civic_social_fraternal_associations
+  cleaning_and_maintenance
+  clothing_rental
+  colleges_universities
+  commercial_equipment
+  commercial_footwear
+  commercial_photography_art_and_graphics
+  commuter_transport_and_ferries
+  computer_network_services
+  computer_programming
+  computer_repair
+  computer_software_stores
+  computers_peripherals_and_software
+  concrete_work_services
+  construction_materials
+  consulting_public_relations
+  correspondence_schools
+  cosmetic_stores
+  counseling_services
+  country_clubs
+  courier_services
+  court_costs
+  credit_reporting_agencies
+  cruise_lines
+  dairy_products_stores
+  dance_hall_studios_schools
+  dating_escort_services
+  dentists_orthodontists
+  department_stores
+  detective_agencies
+  digital_goods_applications
+  digital_goods_games
+  digital_goods_large_volume
+  digital_goods_media
+  direct_marketing_catalog_merchant
+  direct_marketing_combination_catalog_and_retail_merchant
+  direct_marketing_inbound_telemarketing
+  direct_marketing_insurance_services
+  direct_marketing_other
+  direct_marketing_outbound_telemarketing
+  direct_marketing_subscription
+  direct_marketing_travel
+  discount_stores
+  doctors
+  door_to_door_sales
+  drapery_window_covering_and_upholstery_stores
+  drinking_places
+  drug_stores_and_pharmacies
+  drugs_drug_proprietaries_and_druggist_sundries
+  dry_cleaners
+  durable_goods
+  duty_free_stores
+  eating_places_restaurants
+  educational_services
+  electric_razor_stores
+  electrical_parts_and_equipment
+  electrical_services
+  electronics_repair_shops
+  electronics_stores
+  elementary_secondary_schools
+  employment_temp_agencies
+  equipment_rental
+  exterminating_services
+  family_clothing_stores
+  fast_food_restaurants
+  financial_institutions
+  fines_government_administrative_entities
+  fireplace_fireplace_screens_and_accessories_stores
+  floor_covering_stores
+  florists
+  florists_supplies_nursery_stock_and_flowers
+  freezer_and_locker_meat_provisioners
+  fuel_dealers_non_automotive
+  funeral_services_crematories
+  furniture_home_furnishings_and_equipment_stores_except_appliances
+  furniture_repair_refinishing
+  furriers_and_fur_shops
+  general_services
+  gift_card_novelty_and_souvenir_shops
+  glass_paint_and_wallpaper_stores
+  glassware_crystal_stores
+  golf_courses_public
+  government_services
+  grocery_stores_supermarkets
+  hardware_equipment_and_supplies
+  hardware_stores
+  health_and_beauty_spas
+  hearing_aids_sales_and_supplies
+  heating_plumbing_a_c
+  hobby_toy_and_game_shops
+  home_supply_warehouse_stores
+  hospitals
+  hotels_motels_and_resorts
+  household_appliance_stores
+  industrial_supplies
+  information_retrieval_services
+  insurance_default
+  insurance_underwriting_premiums
+  intra_company_purchases
+  jewelry_stores_watches_clocks_and_silverware_stores
+  landscaping_services
+  laundries
+  laundry_cleaning_services
+  legal_services_attorneys
+  luggage_and_leather_goods_stores
+  lumber_building_materials_stores
+  manual_cash_disburse
+  marinas_service_and_supplies
+  masonry_stonework_and_plaster
+  massage_parlors
+  medical_and_dental_labs
+  medical_dental_ophthalmic_and_hospital_equipment_and_supplies
+  medical_services
+  membership_organizations
+  mens_and_boys_clothing_and_accessories_stores
+  mens_womens_clothing_stores
+  metal_service_centers
+  miscellaneous
+  miscellaneous_apparel_and_accessory_shops
+  miscellaneous_auto_dealers
+  miscellaneous_business_services
+  miscellaneous_food_stores
+  miscellaneous_general_merchandise
+  miscellaneous_general_services
+  miscellaneous_home_furnishing_specialty_stores
+  miscellaneous_publishing_and_printing
+  miscellaneous_recreation_services
+  miscellaneous_repair_shops
+  miscellaneous_specialty_retail
+  mobile_home_dealers
+  motion_picture_theaters
+  motor_freight_carriers_and_trucking
+  motor_homes_dealers
+  motor_vehicle_supplies_and_new_parts
+  motorcycle_shops_and_dealers
+  motorcycle_shops_dealers
+  music_stores_musical_instruments_pianos_and_sheet_music
+  news_dealers_and_newsstands
+  non_fi_money_orders
+  non_fi_stored_value_card_purchase_load
+  nondurable_goods
+  nurseries_lawn_and_garden_supply_stores
+  nursing_personal_care
+  office_and_commercial_furniture
+  opticians_eyeglasses
+  optometrists_ophthalmologist
+  orthopedic_goods_prosthetic_devices
+  osteopaths
+  package_stores_beer_wine_and_liquor
+  paints_varnishes_and_supplies
+  parking_lots_garages
+  passenger_railways
+  pawn_shops
+  pet_shops_pet_food_and_supplies
+  petroleum_and_petroleum_products
+  photo_developing
+  photographic_photocopy_microfilm_equipment_and_supplies
+  photographic_studios
+  picture_video_production
+  piece_goods_notions_and_other_dry_goods
+  plumbing_heating_equipment_and_supplies
+  political_organizations
+  postal_services_government_only
+  precious_stones_and_metals_watches_and_jewelry
+  professional_services
+  public_warehousing_and_storage
+  quick_copy_repro_and_blueprint
+  railroads
+  real_estate_agents_and_managers_rentals
+  record_stores
+  recreational_vehicle_rentals
+  religious_goods_stores
+  religious_organizations
+  roofing_siding_sheet_metal
+  secretarial_support_services
+  security_brokers_dealers
+  service_stations
+  sewing_needlework_fabric_and_piece_goods_stores
+  shoe_repair_hat_cleaning
+  shoe_stores
+  small_appliance_repair
+  snowmobile_dealers
+  special_trade_services
+  specialty_cleaning
+  sporting_goods_stores
+  sporting_recreation_camps
+  sports_and_riding_apparel_stores
+  sports_clubs_fields
+  stamp_and_coin_stores
+  stationary_office_supplies_printing_and_writing_paper
+  stationery_stores_office_and_school_supply_stores
+  swimming_pools_sales
+  t_ui_travel_germany
+  tailors_alterations
+  tax_payments_government_agencies
+  tax_preparation_services
+  taxicabs_limousines
+  telecommunication_equipment_and_telephone_sales
+  telecommunication_services
+  telegraph_services
+  tent_and_awning_shops
+  testing_laboratories
+  theatrical_ticket_agencies
+  timeshares
+  tire_retreading_and_repair
+  tolls_bridge_fees
+  tourist_attractions_and_exhibits
+  towing_services
+  trailer_parks_campgrounds
+  transportation_services
+  travel_agencies_tour_operators
+  truck_stop_iteration
+  truck_utility_trailer_rentals
+  typesetting_plate_making_and_related_services
+  typewriter_stores
+  u_s_federal_government_agencies_or_departments
+  uniforms_commercial_clothing
+  used_merchandise_and_secondhand_stores
+  utilities
+  variety_stores
+  veterinary_services
+  video_amusement_game_supplies
+  video_game_arcades
+  video_tape_rental_stores
+  vocational_trade_schools
+  watch_jewelry_repair
+  welding_repair
+  wholesale_clubs
+  wig_and_toupee_stores
+  wires_money_orders
+  womens_accessory_and_specialty_shops
+  womens_ready_to_wear_stores
+  wrecking_and_salvage_yards
+}
+
+enum Stripe_IssuingCardSpendingLimitIntervalProperty {
+  all_time
+  daily
+  monthly
+  per_authorization
+  weekly
+  yearly
+}
+
+enum Stripe_IssuingCardStatusProperty {
+  active
+  canceled
+  inactive
+}
+
+enum Stripe_IssuingCardTypeProperty {
+  physical
+  virtual
+}
+
+union Stripe_IssuingAuthorizationCardholderProperty = WrappedString | Stripe_IssuingCardholder
+
+type Stripe_IssuingAuthorizationMerchantData {
+  """
+  A categorization of the seller's type of business. See our [merchant categories guide](https://stripe.com/docs/issuing/merchant-categories) for a list of possible values.
+  """
+  category: String
+
+  """City where the seller is located"""
+  city: String
+
+  """Country where the seller is located"""
+  country: String
+
+  """Name of the seller"""
+  name: String
+
+  """Identifier assigned to the seller by the card brand"""
+  network_id: String
+
+  """Postal code where the seller is located"""
+  postal_code: String
+
+  """State where the seller is located"""
+  state: String
+}
+
+enum Stripe_IssuingAuthorizationObjectProperty {
+  issuingDOTauthorization
+}
+
+type Stripe_IssuingAuthorizationPendingRequest {
+  """
+  The additional amount Stripe will hold if the authorization is approved, in the card's [currency](https://stripe.com/docs/api#issuing_authorization_object-pending-request-currency) and in the [smallest currency unit](https://stripe.com/docs/currencies#zero-decimal).
+  """
+  amount: Int
+  amount_details: Stripe_IssuingAuthorizationAmountDetails
+
+  """
+  Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
+  """
+  currency: String
+
+  """
+  If set `true`, you may provide [amount](https://stripe.com/docs/api/issuing/authorizations/approve#approve_issuing_authorization-amount) to control how much to hold for the authorization.
+  """
+  is_amount_controllable: Boolean
+
+  """
+  The amount the merchant is requesting to be authorized in the `merchant_currency`. The amount is in the [smallest currency unit](https://stripe.com/docs/currencies#zero-decimal).
+  """
+  merchant_amount: Int
+
+  """The local currency the merchant is requesting to authorize."""
+  merchant_currency: String
+}
+
+type Stripe_IssuingAuthorizationRequest {
+  """
+  The `pending_request.amount` at the time of the request, presented in your card's currency and in the [smallest currency unit](https://stripe.com/docs/currencies#zero-decimal). Stripe held this amount from your account to fund the authorization if the request was approved.
+  """
+  amount: Int
+  amount_details: Stripe_IssuingAuthorizationAmountDetails
+
+  """Whether this request was approved."""
+  approved: Boolean
+
+  """
+  Time at which the object was created. Measured in seconds since the Unix epoch.
+  """
+  created: Int
+
+  """
+  Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
+  """
+  currency: String
+
+  """
+  The `pending_request.merchant_amount` at the time of the request, presented in the `merchant_currency` and in the [smallest currency unit](https://stripe.com/docs/currencies#zero-decimal).
+  """
+  merchant_amount: Int
+
+  """
+  The currency that was collected by the merchant and presented to the cardholder for the authorization. Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
+  """
+  merchant_currency: String
+
+  """The reason for the approval or decline."""
+  reason: Stripe_IssuingAuthorizationRequestReasonProperty
+}
+
+enum Stripe_IssuingAuthorizationRequestReasonProperty {
+  account_disabled
+  card_active
+  card_inactive
+  cardholder_inactive
+  cardholder_verification_required
+  insufficient_funds
+  not_allowed
+  spending_controls
+  suspected_fraud
+  verification_failed
+  webhook_approved
+  webhook_declined
+  webhook_timeout
+}
+
+enum Stripe_IssuingAuthorizationStatusProperty {
+  closed
+  pending
+  reversed
+}
+
+type Stripe_IssuingTransaction {
+  """
+  The transaction amount, which will be reflected in your balance. This amount is in your currency and in the [smallest currency unit](https://stripe.com/docs/currencies#zero-decimal).
+  """
+  amount: Int
+  amount_details: Stripe_IssuingTransactionAmountDetails
+  authorization: Stripe_IssuingTransactionAuthorizationProperty
+  balance_transaction: Stripe_IssuingTransactionBalanceTransactionProperty
+  card: Stripe_IssuingTransactionCardProperty
+  cardholder: Stripe_IssuingTransactionCardholderProperty
+
+  """
+  Time at which the object was created. Measured in seconds since the Unix epoch.
+  """
+  created: Int
+
+  """
+  Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
+  """
+  currency: String
+  dispute: Stripe_IssuingTransactionDisputeProperty
+
+  """Unique identifier for the object."""
+  id: String
+
+  """
+  Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode.
+  """
+  livemode: Boolean
+
+  """
+  The amount that the merchant will receive, denominated in `merchant_currency` and in the [smallest currency unit](https://stripe.com/docs/currencies#zero-decimal). It will be different from `amount` if the merchant is taking payment in a different currency.
+  """
+  merchant_amount: Int
+
+  """The currency with which the merchant is taking payment."""
+  merchant_currency: String
+  merchant_data: Stripe_IssuingAuthorizationMerchantData
+
+  """
+  Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format.
+  """
+  metadata: JSONObject
+
+  """
+  String representing the object's type. Objects of the same type share the same value.
+  """
+  object: Stripe_IssuingTransactionObjectProperty
+  purchase_details: Stripe_IssuingTransactionPurchaseDetails
+
+  """The nature of the transaction."""
+  type: Stripe_IssuingTransactionTypeProperty
+
+  """
+  The digital wallet used for this transaction. One of `apple_pay`, `google_pay`, or `samsung_pay`.
+  """
+  wallet: Stripe_IssuingTransactionWalletProperty
+}
+
+type Stripe_IssuingTransactionAmountDetails {
+  """The fee charged by the ATM for the cash withdrawal."""
+  atm_fee: Int
+}
+
+union Stripe_IssuingTransactionAuthorizationProperty = WrappedString | Stripe_IssuingAuthorization
+
+union Stripe_IssuingTransactionBalanceTransactionProperty = WrappedString | Stripe_BalanceTransaction
+
+union Stripe_IssuingTransactionCardProperty = WrappedString | Stripe_IssuingCard
+
+union Stripe_IssuingTransactionCardholderProperty = WrappedString | Stripe_IssuingCardholder
+
+union Stripe_IssuingTransactionDisputeProperty = WrappedString | Stripe_IssuingDispute
+
+type Stripe_IssuingDispute {
+  """
+  Disputed amount. Usually the amount of the `transaction`, but can differ (usually because of currency fluctuation).
+  """
+  amount: Int
+
+  """List of balance transactions associated with the dispute."""
+  balance_transactions: [Stripe_BalanceTransaction]
+
+  """
+  Time at which the object was created. Measured in seconds since the Unix epoch.
+  """
+  created: Int
+
+  """The currency the `transaction` was made in."""
+  currency: String
+  evidence: Stripe_IssuingDisputeEvidence
+
+  """Unique identifier for the object."""
+  id: String
+
+  """
+  Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode.
+  """
+  livemode: Boolean
+
+  """
+  Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format.
+  """
+  metadata: JSONObject
+
+  """
+  String representing the object's type. Objects of the same type share the same value.
+  """
+  object: Stripe_IssuingDisputeObjectProperty
+
+  """Current status of the dispute."""
+  status: Stripe_IssuingDisputeStatusProperty
+  transaction: Stripe_IssuingDisputeTransactionProperty
+}
+
+type Stripe_IssuingDisputeEvidence {
+  canceled: Stripe_IssuingDisputeCanceledEvidence
+  duplicate: Stripe_IssuingDisputeDuplicateEvidence
+  fraudulent: Stripe_IssuingDisputeFraudulentEvidence
+  merchandise_not_as_described: Stripe_IssuingDisputeMerchandiseNotAsDescribedEvidence
+  not_received: Stripe_IssuingDisputeNotReceivedEvidence
+  other: Stripe_IssuingDisputeOtherEvidence
+
+  """
+  The reason for filing the dispute. Its value will match the field containing the evidence.
+  """
+  reason: Stripe_IssuingDisputeEvidenceReasonProperty
+  service_not_as_described: Stripe_IssuingDisputeServiceNotAsDescribedEvidence
+}
+
+type Stripe_IssuingDisputeCanceledEvidence {
+  additional_documentation: Stripe_IssuingDisputeCanceledEvidenceAdditionalDocumentationProperty
+
+  """Date when order was canceled."""
+  canceled_at: Int
+
+  """Whether the cardholder was provided with a cancellation policy."""
+  cancellation_policy_provided: Boolean
+
+  """Reason for canceling the order."""
+  cancellation_reason: String
+
+  """Date when the cardholder expected to receive the product."""
+  expected_at: Int
+
+  """Explanation of why the cardholder is disputing this transaction."""
+  explanation: String
+
+  """Description of the merchandise or service that was purchased."""
+  product_description: String
+
+  """Whether the product was a merchandise or service."""
+  product_type: Stripe_IssuingDisputeCanceledEvidenceProductTypeProperty
+
+  """Result of cardholder's attempt to return the product."""
+  return_status: Stripe_IssuingDisputeCanceledEvidenceReturnStatusProperty
+
+  """Date when the product was returned or attempted to be returned."""
+  returned_at: Int
+}
+
+union Stripe_IssuingDisputeCanceledEvidenceAdditionalDocumentationProperty = WrappedString | Stripe_File
+
+enum Stripe_IssuingDisputeCanceledEvidenceProductTypeProperty {
+  merchandise
+  service
+}
+
+enum Stripe_IssuingDisputeCanceledEvidenceReturnStatusProperty {
+  merchant_rejected
+  successful
+}
+
+type Stripe_IssuingDisputeDuplicateEvidence {
+  additional_documentation: Stripe_IssuingDisputeDuplicateEvidenceAdditionalDocumentationProperty
+  card_statement: Stripe_IssuingDisputeDuplicateEvidenceCardStatementProperty
+  cash_receipt: Stripe_IssuingDisputeDuplicateEvidenceCashReceiptProperty
+  check_image: Stripe_IssuingDisputeDuplicateEvidenceCheckImageProperty
+
+  """Explanation of why the cardholder is disputing this transaction."""
+  explanation: String
+
+  """
+  Transaction (e.g., ipi_...) that the disputed transaction is a duplicate of. Of the two or more transactions that are copies of each other, this is original undisputed one.
+  """
+  original_transaction: String
+}
+
+union Stripe_IssuingDisputeDuplicateEvidenceAdditionalDocumentationProperty = WrappedString | Stripe_File
+
+union Stripe_IssuingDisputeDuplicateEvidenceCardStatementProperty = WrappedString | Stripe_File
+
+union Stripe_IssuingDisputeDuplicateEvidenceCashReceiptProperty = WrappedString | Stripe_File
+
+union Stripe_IssuingDisputeDuplicateEvidenceCheckImageProperty = WrappedString | Stripe_File
+
+type Stripe_IssuingDisputeFraudulentEvidence {
+  additional_documentation: Stripe_IssuingDisputeFraudulentEvidenceAdditionalDocumentationProperty
+
+  """Explanation of why the cardholder is disputing this transaction."""
+  explanation: String
+}
+
+union Stripe_IssuingDisputeFraudulentEvidenceAdditionalDocumentationProperty = WrappedString | Stripe_File
+
+type Stripe_IssuingDisputeMerchandiseNotAsDescribedEvidence {
+  additional_documentation: Stripe_IssuingDisputeMerchandiseNotAsDescribedEvidenceAdditionalDocumentationProperty
+
+  """Explanation of why the cardholder is disputing this transaction."""
+  explanation: String
+
+  """Date when the product was received."""
+  received_at: Int
+
+  """Description of the cardholder's attempt to return the product."""
+  return_description: String
+
+  """Result of cardholder's attempt to return the product."""
+  return_status: Stripe_IssuingDisputeMerchandiseNotAsDescribedEvidenceReturnStatusProperty
+
+  """Date when the product was returned or attempted to be returned."""
+  returned_at: Int
+}
+
+union Stripe_IssuingDisputeMerchandiseNotAsDescribedEvidenceAdditionalDocumentationProperty = WrappedString | Stripe_File
+
+enum Stripe_IssuingDisputeMerchandiseNotAsDescribedEvidenceReturnStatusProperty {
+  merchant_rejected
+  successful
+}
+
+type Stripe_IssuingDisputeNotReceivedEvidence {
+  additional_documentation: Stripe_IssuingDisputeNotReceivedEvidenceAdditionalDocumentationProperty
+
+  """Date when the cardholder expected to receive the product."""
+  expected_at: Int
+
+  """Explanation of why the cardholder is disputing this transaction."""
+  explanation: String
+
+  """Description of the merchandise or service that was purchased."""
+  product_description: String
+
+  """Whether the product was a merchandise or service."""
+  product_type: Stripe_IssuingDisputeNotReceivedEvidenceProductTypeProperty
+}
+
+union Stripe_IssuingDisputeNotReceivedEvidenceAdditionalDocumentationProperty = WrappedString | Stripe_File
+
+enum Stripe_IssuingDisputeNotReceivedEvidenceProductTypeProperty {
+  merchandise
+  service
+}
+
+type Stripe_IssuingDisputeOtherEvidence {
+  additional_documentation: Stripe_IssuingDisputeOtherEvidenceAdditionalDocumentationProperty
+
+  """Explanation of why the cardholder is disputing this transaction."""
+  explanation: String
+
+  """Description of the merchandise or service that was purchased."""
+  product_description: String
+
+  """Whether the product was a merchandise or service."""
+  product_type: Stripe_IssuingDisputeOtherEvidenceProductTypeProperty
+}
+
+union Stripe_IssuingDisputeOtherEvidenceAdditionalDocumentationProperty = WrappedString | Stripe_File
+
+enum Stripe_IssuingDisputeOtherEvidenceProductTypeProperty {
+  merchandise
+  service
+}
+
+enum Stripe_IssuingDisputeEvidenceReasonProperty {
+  canceled
+  duplicate
+  fraudulent
+  merchandise_not_as_described
+  not_received
+  other
+  service_not_as_described
+}
+
+type Stripe_IssuingDisputeServiceNotAsDescribedEvidence {
+  additional_documentation: Stripe_IssuingDisputeServiceNotAsDescribedEvidenceAdditionalDocumentationProperty
+
+  """Date when order was canceled."""
+  canceled_at: Int
+
+  """Reason for canceling the order."""
+  cancellation_reason: String
+
+  """Explanation of why the cardholder is disputing this transaction."""
+  explanation: String
+
+  """Date when the product was received."""
+  received_at: Int
+}
+
+union Stripe_IssuingDisputeServiceNotAsDescribedEvidenceAdditionalDocumentationProperty = WrappedString | Stripe_File
+
+enum Stripe_IssuingDisputeObjectProperty {
+  issuingDOTdispute
+}
+
+enum Stripe_IssuingDisputeStatusProperty {
+  expired
+  lost
+  submitted
+  unsubmitted
+  won
+}
+
+union Stripe_IssuingDisputeTransactionProperty = WrappedString | Stripe_IssuingTransaction
+
+enum Stripe_IssuingTransactionObjectProperty {
+  issuingDOTtransaction
+}
+
+type Stripe_IssuingTransactionPurchaseDetails {
+  flight: Stripe_IssuingTransactionFlightData
+  fuel: Stripe_IssuingTransactionFuelData
+  lodging: Stripe_IssuingTransactionLodgingData
+
+  """The line items in the purchase."""
+  receipt: [Stripe_IssuingTransactionReceiptData]
+
+  """A merchant-specific order number."""
+  reference: String
+}
+
+type Stripe_IssuingTransactionFlightData {
+  """The time that the flight departed."""
+  departure_at: Int
+
+  """The name of the passenger."""
+  passenger_name: String
+
+  """Whether the ticket is refundable."""
+  refundable: Boolean
+
+  """The legs of the trip."""
+  segments: [Stripe_IssuingTransactionFlightDataLeg]
+
+  """The travel agency that issued the ticket."""
+  travel_agency: String
+}
+
+type Stripe_IssuingTransactionFlightDataLeg {
+  """The three-letter IATA airport code of the flight's destination."""
+  arrival_airport_code: String
+
+  """The airline carrier code."""
+  carrier: String
+
+  """The three-letter IATA airport code that the flight departed from."""
+  departure_airport_code: String
+
+  """The flight number."""
+  flight_number: String
+
+  """The flight's service class."""
+  service_class: String
+
+  """Whether a stopover is allowed on this flight."""
+  stopover_allowed: Boolean
+}
+
+type Stripe_IssuingTransactionFuelData {
+  """
+  The type of fuel that was purchased. One of `diesel`, `unleaded_plus`, `unleaded_regular`, `unleaded_super`, or `other`.
+  """
+  type: String
+
+  """The units for `volume_decimal`. One of `us_gallon` or `liter`."""
+  unit: String
+
+  """
+  The cost in cents per each unit of fuel, represented as a decimal string with at most 12 decimal places.
+  """
+  unit_cost_decimal: String
+
+  """
+  The volume of the fuel that was pumped, represented as a decimal string with at most 12 decimal places.
+  """
+  volume_decimal: String
+}
+
+type Stripe_IssuingTransactionLodgingData {
+  """The time of checking into the lodging."""
+  check_in_at: Int
+
+  """The number of nights stayed at the lodging."""
+  nights: Int
+}
+
+type Stripe_IssuingTransactionReceiptData {
+  """
+  The description of the item. The maximum length of this field is 26 characters.
+  """
+  description: String
+
+  """The quantity of the item."""
+  quantity: Float
+
+  """The total for this line item in cents."""
+  total: Int
+
+  """The unit cost of the item in cents."""
+  unit_cost: Int
+}
+
+enum Stripe_IssuingTransactionTypeProperty {
+  capture
+  refund
+}
+
+enum Stripe_IssuingTransactionWalletProperty {
+  apple_pay
+  google_pay
+  samsung_pay
+}
+
+type Stripe_IssuingAuthorizationVerificationData {
+  """
+  Whether the cardholder provided an address first line and if it matched the cardholder’s `billing.address.line1`.
+  """
+  address_line1_check: Stripe_IssuingAuthorizationVerificationDataAddressLine1CheckProperty
+
+  """
+  Whether the cardholder provided a postal code and if it matched the cardholder’s `billing.address.postal_code`.
+  """
+  address_postal_code_check: Stripe_IssuingAuthorizationVerificationDataAddressPostalCodeCheckProperty
+
+  """
+  Whether the cardholder provided a CVC and if it matched Stripe’s record.
+  """
+  cvc_check: Stripe_IssuingAuthorizationVerificationDataCvcCheckProperty
+
+  """
+  Whether the cardholder provided an expiry date and if it matched Stripe’s record.
+  """
+  expiry_check: Stripe_IssuingAuthorizationVerificationDataExpiryCheckProperty
+}
+
+enum Stripe_IssuingAuthorizationVerificationDataAddressLine1CheckProperty {
+  match
+  mismatch
+  not_provided
+}
+
+enum Stripe_IssuingAuthorizationVerificationDataAddressPostalCodeCheckProperty {
+  match
+  mismatch
+  not_provided
+}
+
+enum Stripe_IssuingAuthorizationVerificationDataCvcCheckProperty {
+  match
+  mismatch
+  not_provided
+}
+
+enum Stripe_IssuingAuthorizationVerificationDataExpiryCheckProperty {
+  match
+  mismatch
+  not_provided
+}
+
+type Stripe_Payout {
+  """Amount (in %s) to be transferred to your bank account or debit card."""
+  amount: Int
+
+  """
+  Date the payout is expected to arrive in the bank. This factors in delays like weekends or bank holidays.
+  """
+  arrival_date: Int
+
+  """
+  Returns `true` if the payout was created by an [automated payout schedule](https://stripe.com/docs/payouts#payout-schedule), and `false` if it was [requested manually](https://stripe.com/docs/payouts#manual-payouts).
+  """
+  automatic: Boolean
+  balance_transaction: Stripe_PayoutBalanceTransactionProperty
+
+  """
+  Time at which the object was created. Measured in seconds since the Unix epoch.
+  """
+  created: Int
+
+  """
+  Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
+  """
+  currency: String
+
+  """
+  An arbitrary string attached to the object. Often useful for displaying to users.
+  """
+  description: String
+  destination: Stripe_PayoutDestinationProperty
+  failure_balance_transaction: Stripe_PayoutFailureBalanceTransactionProperty
+
+  """
+  Error code explaining reason for payout failure if available. See [Types of payout failures](https://stripe.com/docs/api#payout_failures) for a list of failure codes.
+  """
+  failure_code: String
+
+  """
+  Message to user further explaining reason for payout failure if available.
+  """
+  failure_message: String
+
+  """Unique identifier for the object."""
+  id: String
+
+  """
+  Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode.
+  """
+  livemode: Boolean
+
+  """
+  Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format.
+  """
+  metadata: JSONObject
+
+  """
+  The method used to send this payout, which can be `standard` or `instant`. `instant` is only supported for payouts to debit cards. (See [Instant payouts for marketplaces](https://stripe.com/blog/instant-payouts-for-marketplaces) for more information.)
+  """
+  method: String
+
+  """
+  String representing the object's type. Objects of the same type share the same value.
+  """
+  object: Stripe_PayoutObjectProperty
+  original_payout: Stripe_PayoutOriginalPayoutProperty
+  reversed_by: Stripe_PayoutReversedByProperty
+
+  """
+  The source balance this payout came from. One of `card`, `fpx`, or `bank_account`.
+  """
+  source_type: String
+
+  """
+  Extra information about a payout to be displayed on the user's bank statement.
+  """
+  statement_descriptor: String
+
+  """
+  Current status of the payout: `paid`, `pending`, `in_transit`, `canceled` or `failed`. A payout is `pending` until it is submitted to the bank, when it becomes `in_transit`. The status then changes to `paid` if the transaction goes through, or to `failed` or `canceled` (within 5 business days). Some failed payouts may initially show as `paid` but then change to `failed`.
+  """
+  status: String
+
+  """Can be `bank_account` or `card`."""
+  type: Stripe_PayoutTypeProperty
+}
+
+union Stripe_PayoutBalanceTransactionProperty = WrappedString | Stripe_BalanceTransaction
+
+union Stripe_PayoutDestinationProperty = WrappedString | Stripe_BankAccount | Stripe_Card | Stripe_DeletedBankAccount | Stripe_DeletedCard
+
+type Stripe_DeletedBankAccount {
+  """
+  Three-letter [ISO code for the currency](https://stripe.com/docs/payouts) paid out to the bank account.
+  """
+  currency: String
+
+  """Unique identifier for the object."""
+  id: String
+
+  """
+  String representing the object's type. Objects of the same type share the same value.
+  """
+  object: Stripe_DeletedBankAccountObjectProperty
+}
+
+enum Stripe_DeletedBankAccountObjectProperty {
+  bank_account
+}
+
+type Stripe_DeletedCard {
+  """
+  Three-letter [ISO code for the currency](https://stripe.com/docs/payouts) paid out to the bank account.
+  """
+  currency: String
+
+  """Unique identifier for the object."""
+  id: String
+
+  """
+  String representing the object's type. Objects of the same type share the same value.
+  """
+  object: Stripe_DeletedCardObjectProperty
+}
+
+enum Stripe_DeletedCardObjectProperty {
+  card
+}
+
+union Stripe_PayoutFailureBalanceTransactionProperty = WrappedString | Stripe_BalanceTransaction
+
+enum Stripe_PayoutObjectProperty {
+  payout
+}
+
+union Stripe_PayoutOriginalPayoutProperty = WrappedString | Stripe_Payout
+
+union Stripe_PayoutReversedByProperty = WrappedString | Stripe_Payout
+
+enum Stripe_PayoutTypeProperty {
+  bank_account
+  card
+}
+
+type Stripe_PlatformTaxFee {
+  """The Connected account that incurred this charge."""
+  account: String
+
+  """Unique identifier for the object."""
+  id: String
+
+  """
+  String representing the object's type. Objects of the same type share the same value.
+  """
+  object: Stripe_PlatformTaxFeeObjectProperty
+
+  """The payment object that caused this tax to be inflicted."""
+  source_transaction: String
+
+  """The type of tax (VAT)."""
+  type: String
+}
+
+enum Stripe_PlatformTaxFeeObjectProperty {
+  platform_tax_fee
+}
+
+type Stripe_Refund {
+  """Amount, in %s."""
+  amount: Int
+  balance_transaction: Stripe_RefundBalanceTransactionProperty
+  charge: Stripe_RefundChargeProperty
+
+  """
+  Time at which the object was created. Measured in seconds since the Unix epoch.
+  """
+  created: Int
+
+  """
+  Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
+  """
+  currency: String
+
+  """
+  An arbitrary string attached to the object. Often useful for displaying to users. (Available on non-card refunds only)
+  """
+  description: String
+  failure_balance_transaction: Stripe_RefundFailureBalanceTransactionProperty
+
+  """
+  If the refund failed, the reason for refund failure if known. Possible values are `lost_or_stolen_card`, `expired_or_canceled_card`, or `unknown`.
+  """
+  failure_reason: String
+
+  """Unique identifier for the object."""
+  id: String
+
+  """
+  Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format.
+  """
+  metadata: JSONObject
+
+  """
+  String representing the object's type. Objects of the same type share the same value.
+  """
+  object: Stripe_RefundObjectProperty
+  payment_intent: Stripe_RefundPaymentIntentProperty
+
+  """
+  Reason for the refund, either user-provided (`duplicate`, `fraudulent`, or `requested_by_customer`) or generated by Stripe internally (`expired_uncaptured_charge`).
+  """
+  reason: String
+
+  """
+  This is the transaction number that appears on email receipts sent for this refund.
+  """
+  receipt_number: String
+  source_transfer_reversal: Stripe_RefundSourceTransferReversalProperty
+
+  """
+  Status of the refund. For credit card refunds, this can be `pending`, `succeeded`, or `failed`. For other types of refunds, it can be `pending`, `succeeded`, `failed`, or `canceled`. Refer to our [refunds](https://stripe.com/docs/refunds#failed-refunds) documentation for more details.
+  """
+  status: String
+  transfer_reversal: Stripe_RefundTransferReversalProperty
+}
+
+union Stripe_RefundBalanceTransactionProperty = WrappedString | Stripe_BalanceTransaction
+
+union Stripe_RefundChargeProperty = WrappedString | Stripe_Charge
+
+union Stripe_RefundFailureBalanceTransactionProperty = WrappedString | Stripe_BalanceTransaction
+
+enum Stripe_RefundObjectProperty {
+  refund
+}
+
+union Stripe_RefundPaymentIntentProperty = WrappedString | Stripe_PaymentIntent
+
+union Stripe_RefundSourceTransferReversalProperty = WrappedString | Stripe_TransferReversal
+
+type Stripe_TransferReversal {
+  """Amount, in %s."""
+  amount: Int
+  balance_transaction: Stripe_TransferReversalBalanceTransactionProperty
+
+  """
+  Time at which the object was created. Measured in seconds since the Unix epoch.
+  """
+  created: Int
+
+  """
+  Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
+  """
+  currency: String
+  destination_payment_refund: Stripe_TransferReversalDestinationPaymentRefundProperty
+
+  """Unique identifier for the object."""
+  id: String
+
+  """
+  Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format.
+  """
+  metadata: JSONObject
+
+  """
+  String representing the object's type. Objects of the same type share the same value.
+  """
+  object: Stripe_TransferReversalObjectProperty
+  source_refund: Stripe_TransferReversalSourceRefundProperty
+  transfer: Stripe_TransferReversalTransferProperty
+}
+
+union Stripe_TransferReversalBalanceTransactionProperty = WrappedString | Stripe_BalanceTransaction
+
+union Stripe_TransferReversalDestinationPaymentRefundProperty = WrappedString | Stripe_Refund
+
+enum Stripe_TransferReversalObjectProperty {
+  transfer_reversal
+}
+
+union Stripe_TransferReversalSourceRefundProperty = WrappedString | Stripe_Refund
+
+union Stripe_TransferReversalTransferProperty = WrappedString | Stripe_Transfer
+
+type Stripe_Transfer {
+  """Amount in %s to be transferred."""
+  amount: Int
+
+  """
+  Amount in %s reversed (can be less than the amount attribute on the transfer if a partial reversal was issued).
+  """
+  amount_reversed: Int
+  balance_transaction: Stripe_TransferBalanceTransactionProperty
+
+  """Time that this record of the transfer was first created."""
+  created: Int
+
+  """
+  Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
+  """
+  currency: String
+
+  """
+  An arbitrary string attached to the object. Often useful for displaying to users.
+  """
+  description: String
+  destination: Stripe_TransferDestinationProperty
+  destination_payment: Stripe_TransferDestinationPaymentProperty
+
+  """Unique identifier for the object."""
+  id: String
+
+  """
+  Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode.
+  """
+  livemode: Boolean
+
+  """
+  Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format.
+  """
+  metadata: JSONObject
+
+  """
+  String representing the object's type. Objects of the same type share the same value.
+  """
+  object: Stripe_TransferObjectProperty
+
+  """A list of reversals that have been applied to the transfer."""
+  reversals: Stripe_TransferReversalsProperty
+
+  """
+  Whether the transfer has been fully reversed. If the transfer is only partially reversed, this attribute will still be false.
+  """
+  reversed: Boolean
+  source_transaction: Stripe_TransferSourceTransactionProperty
+
+  """
+  The source balance this transfer came from. One of `card`, `fpx`, or `bank_account`.
+  """
+  source_type: String
+
+  """
+  A string that identifies this transaction as part of a group. See the [Connect documentation](https://stripe.com/docs/connect/charges-transfers#transfer-options) for details.
+  """
+  transfer_group: String
+}
+
+union Stripe_TransferBalanceTransactionProperty = WrappedString | Stripe_BalanceTransaction
+
+union Stripe_TransferDestinationProperty = WrappedString | Stripe_Account
+
+union Stripe_TransferDestinationPaymentProperty = WrappedString | Stripe_Charge
+
+enum Stripe_TransferObjectProperty {
+  transfer
+}
+
+"""A list of reversals that have been applied to the transfer."""
+type Stripe_TransferReversalsProperty {
+  """Details about each object."""
+  data: [Stripe_TransferReversal!]!
+
+  """
+  True if this list has another page of items after this one that can be fetched.
+  """
+  has_more: Boolean!
+
+  """
+  String representing the object's type. Objects of the same type share the same value. Always has the value `list`.
+  """
+  object: Stripe_TransferReversalsObjectProperty!
+
+  """The URL where this list can be accessed."""
+  url: String!
+}
+
+enum Stripe_TransferReversalsObjectProperty {
+  list
+}
+
+union Stripe_TransferSourceTransactionProperty = WrappedString | Stripe_Charge
+
+union Stripe_RefundTransferReversalProperty = WrappedString | Stripe_TransferReversal
+
+type Stripe_ReserveTransaction {
+  amount: Int
+
+  """
+  Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
+  """
+  currency: String
+
+  """
+  An arbitrary string attached to the object. Often useful for displaying to users.
+  """
+  description: String
+
+  """Unique identifier for the object."""
+  id: String
+
+  """
+  String representing the object's type. Objects of the same type share the same value.
+  """
+  object: Stripe_ReserveTransactionObjectProperty
+}
+
+enum Stripe_ReserveTransactionObjectProperty {
+  reserve_transaction
+}
+
+type Stripe_TaxDeductedAtSource {
+  """Unique identifier for the object."""
+  id: String
+
+  """
+  String representing the object's type. Objects of the same type share the same value.
+  """
+  object: Stripe_TaxDeductedAtSourceObjectProperty
+
+  """
+  The end of the invoicing period. This TDS applies to Stripe fees collected during this invoicing period.
+  """
+  period_end: Int
+
+  """
+  The start of the invoicing period. This TDS applies to Stripe fees collected during this invoicing period.
+  """
+  period_start: Int
+
+  """The TAN that was supplied to Stripe when TDS was assessed"""
+  tax_deduction_account_number: String
+}
+
+enum Stripe_TaxDeductedAtSourceObjectProperty {
+  tax_deducted_at_source
+}
+
+type Stripe_Topup {
+  """Amount transferred."""
+  amount: Int
+  balance_transaction: Stripe_TopupBalanceTransactionProperty
+
+  """
+  Time at which the object was created. Measured in seconds since the Unix epoch.
+  """
+  created: Int
+
+  """
+  Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
+  """
+  currency: String
+
+  """
+  An arbitrary string attached to the object. Often useful for displaying to users.
+  """
+  description: String
+
+  """
+  Date the funds are expected to arrive in your Stripe account for payouts. This factors in delays like weekends or bank holidays. May not be specified depending on status of top-up.
+  """
+  expected_availability_date: Int
+
+  """
+  Error code explaining reason for top-up failure if available (see [the errors section](https://stripe.com/docs/api#errors) for a list of codes).
+  """
+  failure_code: String
+
+  """
+  Message to user further explaining reason for top-up failure if available.
+  """
+  failure_message: String
+
+  """Unique identifier for the object."""
+  id: String
+
+  """
+  Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode.
+  """
+  livemode: Boolean
+
+  """
+  Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format.
+  """
+  metadata: JSONObject
+
+  """
+  String representing the object's type. Objects of the same type share the same value.
+  """
+  object: Stripe_TopupObjectProperty
+  source: Stripe_Source
+
+  """
+  Extra information about a top-up. This will appear on your source's bank statement. It must contain at least one letter.
+  """
+  statement_descriptor: String
+
+  """
+  The status of the top-up is either `canceled`, `failed`, `pending`, `reversed`, or `succeeded`.
+  """
+  status: Stripe_TopupStatusProperty
+
+  """A string that identifies this top-up as part of a group."""
+  transfer_group: String
+}
+
+union Stripe_TopupBalanceTransactionProperty = WrappedString | Stripe_BalanceTransaction
+
+enum Stripe_TopupObjectProperty {
+  topup
+}
+
+enum Stripe_TopupStatusProperty {
+  canceled
+  failed
+  pending
+  reversed
+  succeeded
+}
+
+enum Stripe_BalanceTransactionTypeProperty {
+  adjustment
+  advance
+  advance_funding
+  anticipation_repayment
+  application_fee
+  application_fee_refund
+  charge
+  connect_collection_transfer
+  contribution
+  issuing_authorization_hold
+  issuing_authorization_release
+  issuing_dispute
+  issuing_transaction
+  payment
+  payment_failure_refund
+  payment_refund
+  payout
+  payout_cancel
+  payout_failure
+  refund
+  refund_failure
+  reserve_transaction
+  reserved_funds
+  stripe_fee
+  stripe_fx_fee
+  tax_fee
+  topup
+  topup_reversal
+  transfer
+  transfer_cancel
+  transfer_failure
+  transfer_refund
+}
+
+union Stripe_ApplicationFeeChargeProperty = WrappedString | Stripe_Charge
+
+enum Stripe_ApplicationFeeObjectProperty {
+  application_fee
+}
+
+union Stripe_ApplicationFeeOriginatingTransactionProperty = WrappedString | Stripe_Charge
+
+"""A list of refunds that have been applied to the fee."""
+type Stripe_ApplicationFeeRefundsProperty {
+  """Details about each object."""
+  data: [Stripe_FeeRefund!]!
+
+  """
+  True if this list has another page of items after this one that can be fetched.
+  """
+  has_more: Boolean!
+
+  """
+  String representing the object's type. Objects of the same type share the same value. Always has the value `list`.
+  """
+  object: Stripe_ApplicationFeeRefundsObjectProperty!
+
+  """The URL where this list can be accessed."""
+  url: String!
+}
+
+enum Stripe_ApplicationFeeRefundsObjectProperty {
+  list
+}
+
+union Stripe_ChargeBalanceTransactionProperty = WrappedString | Stripe_BalanceTransaction
+
+union Stripe_ChargeCustomerProperty = WrappedString | Stripe_Customer | Stripe_DeletedCustomer
+
+type Stripe_ChargeFraudDetails {
+  """Assessments from Stripe. If set, the value is `fraudulent`."""
+  stripe_report: String
+
+  """
+  Assessments reported by you. If set, possible values of are `safe` and `fraudulent`.
+  """
+  user_report: String
+}
+
+union Stripe_ChargeInvoiceProperty = WrappedString | Stripe_Invoice
+
+type Stripe_Invoice {
+  """
+  The country of the business associated with this invoice, most often the business creating the invoice.
+  """
+  account_country: String
+
+  """
+  The public name of the business associated with this invoice, most often the business creating the invoice.
+  """
+  account_name: String
+
+  """
+  The account tax IDs associated with the invoice. Only editable when the invoice is a draft.
+  """
+  account_tax_ids: [Stripe_InvoiceAccountTaxIdsProperty]
+
+  """
+  Final amount due at this time for this invoice. If the invoice's total is smaller than the minimum charge amount, for example, or if there is account credit that can be applied to the invoice, the `amount_due` may be 0. If there is a positive `starting_balance` for the invoice (the customer owes money), the `amount_due` will also take that into account. The charge that gets generated for the invoice will be for the amount specified in `amount_due`.
+  """
+  amount_due: Int
+
+  """The amount, in %s, that was paid."""
+  amount_paid: Int
+
+  """The amount remaining, in %s, that is due."""
+  amount_remaining: Int
+
+  """
+  The fee in %s that will be applied to the invoice and transferred to the application owner's Stripe account when the invoice is paid.
+  """
+  application_fee_amount: Int
+
+  """
+  Number of payment attempts made for this invoice, from the perspective of the payment retry schedule. Any payment attempt counts as the first attempt, and subsequently only automatic retries increment the attempt count. In other words, manual payment attempts after the first attempt do not affect the retry schedule.
+  """
+  attempt_count: Int
+
+  """
+  Whether an attempt has been made to pay the invoice. An invoice is not attempted until 1 hour after the `invoice.created` webhook, for example, so you might not want to display that invoice as unpaid to your users.
+  """
+  attempted: Boolean
+
+  """
+  Controls whether Stripe will perform [automatic collection](https://stripe.com/docs/billing/invoices/workflow/#auto_advance) of the invoice. When `false`, the invoice's state will not automatically advance without an explicit action.
+  """
+  auto_advance: Boolean
+  automatic_tax: Stripe_AutomaticTax
+
+  """
+  Indicates the reason why the invoice was created. `subscription_cycle` indicates an invoice created by a subscription advancing into a new period. `subscription_create` indicates an invoice created due to creating a subscription. `subscription_update` indicates an invoice created due to updating a subscription. `subscription` is set for all old invoices to indicate either a change to a subscription or a period advancement. `manual` is set for all invoices unrelated to a subscription (for example: created via the invoice editor). The `upcoming` value is reserved for simulated invoices per the upcoming invoice endpoint. `subscription_threshold` indicates an invoice created due to a billing threshold being reached.
+  """
+  billing_reason: Stripe_InvoiceBillingReasonProperty
+  charge: Stripe_InvoiceChargeProperty
+
+  """
+  Either `charge_automatically`, or `send_invoice`. When charging automatically, Stripe will attempt to pay this invoice using the default source attached to the customer. When sending an invoice, Stripe will email this invoice to the customer with payment instructions.
+  """
+  collection_method: Stripe_InvoiceCollectionMethodProperty
+
+  """
+  Time at which the object was created. Measured in seconds since the Unix epoch.
+  """
+  created: Int
+
+  """
+  Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
+  """
+  currency: String
+
+  """Custom fields displayed on the invoice."""
+  custom_fields: [Stripe_InvoiceSettingCustomField]
+  customer: Stripe_InvoiceCustomerProperty
+  customer_address: Stripe_Address
+
+  """
+  The customer's email. Until the invoice is finalized, this field will equal `customer.email`. Once the invoice is finalized, this field will no longer be updated.
+  """
+  customer_email: String
+
+  """
+  The customer's name. Until the invoice is finalized, this field will equal `customer.name`. Once the invoice is finalized, this field will no longer be updated.
+  """
+  customer_name: String
+
+  """
+  The customer's phone number. Until the invoice is finalized, this field will equal `customer.phone`. Once the invoice is finalized, this field will no longer be updated.
+  """
+  customer_phone: String
+  customer_shipping: Stripe_Shipping
+
+  """
+  The customer's tax exempt status. Until the invoice is finalized, this field will equal `customer.tax_exempt`. Once the invoice is finalized, this field will no longer be updated.
+  """
+  customer_tax_exempt: Stripe_InvoiceCustomerTaxExemptProperty
+
+  """
+  The customer's tax IDs. Until the invoice is finalized, this field will contain the same tax IDs as `customer.tax_ids`. Once the invoice is finalized, this field will no longer be updated.
+  """
+  customer_tax_ids: [Stripe_InvoicesResourceInvoiceTaxId]
+  default_payment_method: Stripe_InvoiceDefaultPaymentMethodProperty
+  default_source: Stripe_InvoiceDefaultSourceProperty
+
+  """The tax rates applied to this invoice, if any."""
+  default_tax_rates: [Stripe_TaxRate]
+
+  """
+  An arbitrary string attached to the object. Often useful for displaying to users. Referenced as 'memo' in the Dashboard.
+  """
+  description: String
+  discount: Stripe_Discount
+
+  """
+  The discounts applied to the invoice. Line item discounts are applied before invoice discounts. Use `expand[]=discounts` to expand each discount.
+  """
+  discounts: [Stripe_InvoiceDiscountsProperty]
+
+  """
+  The date on which payment for this invoice is due. This value will be `null` for invoices where `collection_method=charge_automatically`.
+  """
+  due_date: Int
+
+  """
+  Ending customer balance after the invoice is finalized. Invoices are finalized approximately an hour after successful webhook delivery or when payment collection is attempted for the invoice. If the invoice has not been finalized yet, this will be null.
+  """
+  ending_balance: Int
+
+  """Footer displayed on the invoice."""
+  footer: String
+
+  """
+  The URL for the hosted invoice page, which allows customers to view and pay an invoice. If the invoice has not been finalized yet, this will be null.
+  """
+  hosted_invoice_url: String
+
+  """Unique identifier for the object."""
+  id: String
+
+  """
+  The link to download the PDF for the invoice. If the invoice has not been finalized yet, this will be null.
+  """
+  invoice_pdf: String
+  last_finalization_error: Stripe_ApiErrors
+
+  """
+  The individual line items that make up the invoice. `lines` is sorted as follows: invoice items in reverse chronological order, followed by the subscription, if any.
+  """
+  lines: Stripe_InvoiceLinesProperty
+
+  """
+  Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode.
+  """
+  livemode: Boolean
+
+  """
+  Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format.
+  """
+  metadata: JSONObject
+
+  """
+  The time at which payment will next be attempted. This value will be `null` for invoices where `collection_method=send_invoice`.
+  """
+  next_payment_attempt: Int
+
+  """
+  A unique, identifying string that appears on emails sent to the customer for this invoice. This starts with the customer's unique invoice_prefix if it is specified.
+  """
+  number: String
+
+  """
+  String representing the object's type. Objects of the same type share the same value.
+  """
+  object: Stripe_InvoiceObjectProperty
+  on_behalf_of: Stripe_InvoiceOnBehalfOfProperty
+
+  """
+  Whether payment was successfully collected for this invoice. An invoice can be paid (most commonly) with a charge or with credit from the customer's account balance.
+  """
+  paid: Boolean
+  payment_intent: Stripe_InvoicePaymentIntentProperty
+  payment_settings: Stripe_InvoicesPaymentSettings
+
+  """
+  End of the usage period during which invoice items were added to this invoice.
+  """
+  period_end: Int
+
+  """
+  Start of the usage period during which invoice items were added to this invoice.
+  """
+  period_start: Int
+
+  """Total amount of all post-payment credit notes issued for this invoice."""
+  post_payment_credit_notes_amount: Int
+
+  """Total amount of all pre-payment credit notes issued for this invoice."""
+  pre_payment_credit_notes_amount: Int
+  quote: Stripe_InvoiceQuoteProperty
+
+  """
+  This is the transaction number that appears on email receipts sent for this invoice.
+  """
+  receipt_number: String
+
+  """
+  Starting customer balance before the invoice is finalized. If the invoice has not been finalized yet, this will be the current customer balance.
+  """
+  starting_balance: Int
+
+  """
+  Extra information about an invoice for the customer's credit card statement.
+  """
+  statement_descriptor: String
+
+  """
+  The status of the invoice, one of `draft`, `open`, `paid`, `uncollectible`, or `void`. [Learn more](https://stripe.com/docs/billing/invoices/workflow#workflow-overview)
+  """
+  status: Stripe_InvoiceStatusProperty
+  status_transitions: Stripe_InvoicesStatusTransitions
+  subscription: Stripe_InvoiceSubscriptionProperty
+
+  """
+  Only set for upcoming invoices that preview prorations. The time used to calculate prorations.
+  """
+  subscription_proration_date: Int
+
+  """
+  Total of all subscriptions, invoice items, and prorations on the invoice before any invoice level discount or tax is applied. Item discounts are already incorporated
+  """
+  subtotal: Int
+
+  """
+  The amount of tax on this invoice. This is the sum of all the tax amounts on this invoice.
+  """
+  tax: Int
+  threshold_reason: Stripe_InvoiceThresholdReason
+
+  """Total after discounts and taxes."""
+  total: Int
+
+  """The aggregate amounts calculated per discount across all line items."""
+  total_discount_amounts: [Stripe_DiscountsResourceDiscountAmount]
+
+  """The aggregate amounts calculated per tax rate for all line items."""
+  total_tax_amounts: [Stripe_InvoiceTaxAmount]
+  transfer_data: Stripe_InvoiceTransferData
+
+  """
+  Invoices are automatically paid or sent 1 hour after webhooks are delivered, or until all webhook delivery attempts have [been exhausted](https://stripe.com/docs/billing/webhooks#understand). This field tracks the time when webhooks for this invoice were successfully delivered. If the invoice had no webhooks to deliver, this will be set while the invoice is being created.
+  """
+  webhooks_delivered_at: Int
+}
+
+union Stripe_InvoiceAccountTaxIdsProperty = WrappedString | Stripe_TaxId
+
+type Stripe_TaxId {
+  """Two-letter ISO code representing the country of the tax ID."""
+  country: String
+
+  """
+  Time at which the object was created. Measured in seconds since the Unix epoch.
+  """
+  created: Int
+  customer: Stripe_TaxIdCustomerProperty
+
+  """Unique identifier for the object."""
+  id: String
+
+  """
+  Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode.
+  """
+  livemode: Boolean
+
+  """
+  String representing the object's type. Objects of the same type share the same value.
+  """
+  object: Stripe_TaxIdObjectProperty
+
+  """
+  Type of the tax ID, one of `ae_trn`, `au_abn`, `br_cnpj`, `br_cpf`, `ca_bn`, `ca_gst_hst`, `ca_pst_bc`, `ca_pst_mb`, `ca_pst_sk`, `ca_qst`, `ch_vat`, `cl_tin`, `es_cif`, `eu_vat`, `gb_vat`, `hk_br`, `id_npwp`, `il_vat`, `in_gst`, `jp_cn`, `jp_rn`, `kr_brn`, `li_uid`, `mx_rfc`, `my_frp`, `my_itn`, `my_sst`, `no_vat`, `nz_gst`, `ru_inn`, `ru_kpp`, `sa_vat`, `sg_gst`, `sg_uen`, `th_vat`, `tw_vat`, `us_ein`, or `za_vat`. Note that some legacy tax IDs have type `unknown`
+  """
+  type: Stripe_TaxIdTypeProperty
+
+  """Value of the tax ID."""
+  value: String
+  verification: Stripe_TaxIdVerification
+}
+
+union Stripe_TaxIdCustomerProperty = WrappedString | Stripe_Customer
+
+enum Stripe_TaxIdObjectProperty {
+  tax_id
+}
+
+enum Stripe_TaxIdTypeProperty {
+  ae_trn
+  au_abn
+  br_cnpj
+  br_cpf
+  ca_bn
+  ca_gst_hst
+  ca_pst_bc
+  ca_pst_mb
+  ca_pst_sk
+  ca_qst
+  ch_vat
+  cl_tin
+  es_cif
+  eu_vat
+  gb_vat
+  hk_br
+  id_npwp
+  il_vat
+  in_gst
+  jp_cn
+  jp_rn
+  kr_brn
+  li_uid
+  mx_rfc
+  my_frp
+  my_itn
+  my_sst
+  no_vat
+  nz_gst
+  ru_inn
+  ru_kpp
+  sa_vat
+  sg_gst
+  sg_uen
+  th_vat
+  tw_vat
+  unknown
+  us_ein
+  za_vat
+}
+
+type Stripe_TaxIdVerification {
+  """
+  Verification status, one of `pending`, `verified`, `unverified`, or `unavailable`.
+  """
+  status: Stripe_TaxIdVerificationStatusProperty
+
+  """Verified address."""
+  verified_address: String
+
+  """Verified name."""
+  verified_name: String
+}
+
+enum Stripe_TaxIdVerificationStatusProperty {
+  pending
+  unavailable
+  unverified
+  verified
+}
+
+type Stripe_AutomaticTax {
+  """Whether Stripe automatically computes tax on this invoice."""
+  enabled: Boolean
+
+  """
+  The status of the most recent automated tax calculation for this invoice.
+  """
+  status: Stripe_AutomaticTaxStatusProperty
+}
+
+enum Stripe_AutomaticTaxStatusProperty {
+  complete
+  failed
+  requires_location_inputs
+}
+
+enum Stripe_InvoiceBillingReasonProperty {
+  automatic_pending_invoice_item_invoice
+  manual
+  quote_accept
+  subscription
+  subscription_create
+  subscription_cycle
+  subscription_threshold
+  subscription_update
+  upcoming
+}
+
+union Stripe_InvoiceChargeProperty = WrappedString | Stripe_Charge
+
+enum Stripe_InvoiceCollectionMethodProperty {
+  charge_automatically
+  send_invoice
+}
+
+union Stripe_InvoiceCustomerProperty = WrappedString | Stripe_Customer | Stripe_DeletedCustomer
+
+enum Stripe_InvoiceCustomerTaxExemptProperty {
+  exempt
+  none
+  reverse
+}
+
+type Stripe_InvoicesResourceInvoiceTaxId {
+  """
+  The type of the tax ID, one of `eu_vat`, `br_cnpj`, `br_cpf`, `gb_vat`, `nz_gst`, `au_abn`, `in_gst`, `no_vat`, `za_vat`, `ch_vat`, `mx_rfc`, `sg_uen`, `ru_inn`, `ru_kpp`, `ca_bn`, `hk_br`, `es_cif`, `tw_vat`, `th_vat`, `jp_cn`, `jp_rn`, `li_uid`, `my_itn`, `us_ein`, `kr_brn`, `ca_qst`, `ca_gst_hst`, `ca_pst_bc`, `ca_pst_mb`, `ca_pst_sk`, `my_sst`, `sg_gst`, `ae_trn`, `cl_tin`, `sa_vat`, `id_npwp`, `my_frp`, `il_vat`, or `unknown`
+  """
+  type: Stripe_InvoicesResourceInvoiceTaxIdTypeProperty
+
+  """The value of the tax ID."""
+  value: String
+}
+
+enum Stripe_InvoicesResourceInvoiceTaxIdTypeProperty {
+  ae_trn
+  au_abn
+  br_cnpj
+  br_cpf
+  ca_bn
+  ca_gst_hst
+  ca_pst_bc
+  ca_pst_mb
+  ca_pst_sk
+  ca_qst
+  ch_vat
+  cl_tin
+  es_cif
+  eu_vat
+  gb_vat
+  hk_br
+  id_npwp
+  il_vat
+  in_gst
+  jp_cn
+  jp_rn
+  kr_brn
+  li_uid
+  mx_rfc
+  my_frp
+  my_itn
+  my_sst
+  no_vat
+  nz_gst
+  ru_inn
+  ru_kpp
+  sa_vat
+  sg_gst
+  sg_uen
+  th_vat
+  tw_vat
+  unknown
+  us_ein
+  za_vat
+}
+
+union Stripe_InvoiceDefaultPaymentMethodProperty = WrappedString | Stripe_PaymentMethod
+
+union Stripe_InvoiceDefaultSourceProperty = WrappedString | Stripe_AlipayAccount | Stripe_BankAccount | Stripe_BitcoinReceiver | Stripe_Card | Stripe_Source
+
+type Stripe_TaxRate {
+  """
+  Defaults to `true`. When set to `false`, this tax rate cannot be used with new applications or Checkout Sessions, but will still work for subscriptions and invoices that already have it set.
+  """
+  active: Boolean
+
+  """
+  Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
+  """
+  country: String
+
+  """
+  Time at which the object was created. Measured in seconds since the Unix epoch.
+  """
+  created: Int
+
+  """
+  An arbitrary string attached to the tax rate for your internal use only. It will not be visible to your customers.
+  """
+  description: String
+
+  """
+  The display name of the tax rates as it will appear to your customer on their receipt email, PDF, and the hosted invoice page.
+  """
+  display_name: String
+
+  """Unique identifier for the object."""
+  id: String
+
+  """This specifies if the tax rate is inclusive or exclusive."""
+  inclusive: Boolean
+
+  """
+  The jurisdiction for the tax rate. You can use this label field for tax reporting purposes. It also appears on your customer’s invoice.
+  """
+  jurisdiction: String
+
+  """
+  Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode.
+  """
+  livemode: Boolean
+
+  """
+  Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format.
+  """
+  metadata: JSONObject
+
+  """
+  String representing the object's type. Objects of the same type share the same value.
+  """
+  object: Stripe_TaxRateObjectProperty
+
+  """This represents the tax rate percent out of 100."""
+  percentage: Float
+
+  """
+  [ISO 3166-2 subdivision code](https://en.wikipedia.org/wiki/ISO_3166-2:US), without country prefix. For example, "NY" for New York, United States.
+  """
+  state: String
+
+  """The high-level tax type, such as `vat` or `sales_tax`."""
+  tax_type: Stripe_TaxRateTaxTypeProperty
+}
+
+enum Stripe_TaxRateObjectProperty {
+  tax_rate
+}
+
+enum Stripe_TaxRateTaxTypeProperty {
+  gst
+  hst
+  pst
+  qst
+  sales_tax
+  vat
+}
+
+union Stripe_InvoiceDiscountsProperty = WrappedString | Stripe_Discount | Stripe_DeletedDiscount
+
+type Stripe_DeletedDiscount {
+  """
+  The Checkout session that this coupon is applied to, if it is applied to a particular session in payment mode. Will not be present for subscription mode.
+  """
+  checkout_session: String
+  coupon: Stripe_Coupon
+  customer: Stripe_DeletedDiscountCustomerProperty
+
+  """
+  The ID of the discount object. Discounts cannot be fetched by ID. Use `expand[]=discounts` in API calls to expand discount IDs in an array.
+  """
+  id: String
+
+  """
+  The invoice that the discount's coupon was applied to, if it was applied directly to a particular invoice.
+  """
+  invoice: String
+
+  """
+  The invoice item `id` (or invoice line item `id` for invoice line items of type='subscription') that the discount's coupon was applied to, if it was applied directly to a particular invoice item or invoice line item.
+  """
+  invoice_item: String
+
+  """
+  String representing the object's type. Objects of the same type share the same value.
+  """
+  object: Stripe_DeletedDiscountObjectProperty
+  promotion_code: Stripe_DeletedDiscountPromotionCodeProperty
+
+  """Date that the coupon was applied."""
+  start: Int
+
+  """
+  The subscription that this coupon is applied to, if it is applied to a particular subscription.
+  """
+  subscription: String
+}
+
+union Stripe_DeletedDiscountCustomerProperty = WrappedString | Stripe_Customer | Stripe_DeletedCustomer
+
+enum Stripe_DeletedDiscountObjectProperty {
+  discount
+}
+
+union Stripe_DeletedDiscountPromotionCodeProperty = WrappedString | Stripe_PromotionCode
+
+"""
+The individual line items that make up the invoice. `lines` is sorted as follows: invoice items in reverse chronological order, followed by the subscription, if any.
+"""
+type Stripe_InvoiceLinesProperty {
+  """Details about each object."""
+  data: [Stripe_LineItem!]!
+
+  """
+  True if this list has another page of items after this one that can be fetched.
+  """
+  has_more: Boolean!
+
+  """
+  String representing the object's type. Objects of the same type share the same value. Always has the value `list`.
+  """
+  object: Stripe_InvoiceLinesObjectProperty!
+
+  """The URL where this list can be accessed."""
+  url: String!
+}
+
+type Stripe_LineItem {
+  """The amount, in %s."""
+  amount: Int
+
+  """
+  Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
+  """
+  currency: String
+
+  """
+  An arbitrary string attached to the object. Often useful for displaying to users.
+  """
+  description: String
+
+  """The amount of discount calculated per discount for this line item."""
+  discount_amounts: [Stripe_DiscountsResourceDiscountAmount]
+
+  """
+  If true, discounts will apply to this line item. Always false for prorations.
+  """
+  discountable: Boolean
+
+  """
+  The discounts applied to the invoice line item. Line item discounts are applied before invoice discounts. Use `expand[]=discounts` to expand each discount.
+  """
+  discounts: [Stripe_LineItemDiscountsProperty]
+
+  """Unique identifier for the object."""
+  id: String
+
+  """
+  The ID of the [invoice item](https://stripe.com/docs/api/invoiceitems) associated with this line item if any.
+  """
+  invoice_item: String
+
+  """
+  Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode.
+  """
+  livemode: Boolean
+
+  """
+  Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Note that for line items with `type=subscription` this will reflect the metadata of the subscription that caused the line item to be created.
+  """
+  metadata: JSONObject
+
+  """
+  String representing the object's type. Objects of the same type share the same value.
+  """
+  object: Stripe_LineItemObjectProperty
+  period: Stripe_InvoiceLineItemPeriod
+  price: Stripe_Price
+
+  """Whether this is a proration."""
+  proration: Boolean
+
+  """
+  The quantity of the subscription, if the line item is a subscription or a proration.
+  """
+  quantity: Int
+
+  """The subscription that the invoice item pertains to, if any."""
+  subscription: String
+
+  """
+  The subscription item that generated this invoice item. Left empty if the line item is not an explicit result of a subscription.
+  """
+  subscription_item: String
+
+  """The amount of tax calculated per tax rate for this line item"""
+  tax_amounts: [Stripe_InvoiceTaxAmount]
+
+  """The tax rates which apply to the line item."""
+  tax_rates: [Stripe_TaxRate]
+
+  """
+  A string identifying the type of the source of this line item, either an `invoiceitem` or a `subscription`.
+  """
+  type: Stripe_LineItemTypeProperty
+}
+
+type Stripe_DiscountsResourceDiscountAmount {
+  """The amount, in %s, of the discount."""
+  amount: Int
+  discount: Stripe_DiscountsResourceDiscountAmountDiscountProperty
+}
+
+union Stripe_DiscountsResourceDiscountAmountDiscountProperty = WrappedString | Stripe_Discount | Stripe_DeletedDiscount
+
+union Stripe_LineItemDiscountsProperty = WrappedString | Stripe_Discount
+
+enum Stripe_LineItemObjectProperty {
+  line_item
+}
+
+type Stripe_InvoiceLineItemPeriod {
+  """End of the line item's billing period"""
+  end: Int
+
+  """Start of the line item's billing period"""
+  start: Int
+}
+
+type Stripe_InvoiceTaxAmount {
+  """The amount, in %s, of the tax."""
+  amount: Int
+
+  """Whether this tax amount is inclusive or exclusive."""
+  inclusive: Boolean
+  tax_rate: Stripe_InvoiceTaxAmountTaxRateProperty
+}
+
+union Stripe_InvoiceTaxAmountTaxRateProperty = WrappedString | Stripe_TaxRate
+
+enum Stripe_LineItemTypeProperty {
+  invoiceitem
+  subscription
+}
+
+enum Stripe_InvoiceLinesObjectProperty {
+  list
+}
+
+enum Stripe_InvoiceObjectProperty {
+  invoice
+}
+
+union Stripe_InvoiceOnBehalfOfProperty = WrappedString | Stripe_Account
+
+union Stripe_InvoicePaymentIntentProperty = WrappedString | Stripe_PaymentIntent
+
+type Stripe_InvoicesPaymentSettings {
+  payment_method_options: Stripe_InvoicesPaymentMethodOptions
+
+  """
+  The list of payment method types (e.g. card) to provide to the invoice’s PaymentIntent. If not set, Stripe attempts to automatically determine the types to use by looking at the invoice’s default payment method, the subscription’s default payment method, the customer’s default payment method, and your [invoice template settings](https://dashboard.stripe.com/settings/billing/invoice).
+  """
+  payment_method_types: [Stripe_InvoicesPaymentSettingsPaymentMethodTypesProperty]
+}
+
+type Stripe_InvoicesPaymentMethodOptions {
+  bancontact: Stripe_InvoicePaymentMethodOptionsBancontact
+  card: Stripe_InvoicePaymentMethodOptionsCard
+}
+
+type Stripe_InvoicePaymentMethodOptionsBancontact {
+  """
+  Preferred language of the Bancontact authorization page that the customer is redirected to.
+  """
+  preferred_language: Stripe_InvoicePaymentMethodOptionsBancontactPreferredLanguageProperty
+}
+
+enum Stripe_InvoicePaymentMethodOptionsBancontactPreferredLanguageProperty {
+  de
+  en
+  fr
+  nl
+}
+
+type Stripe_InvoicePaymentMethodOptionsCard {
+  """
+  We strongly recommend that you rely on our SCA Engine to automatically prompt your customers for authentication based on risk level and [other requirements](https://stripe.com/docs/strong-customer-authentication). However, if you wish to request 3D Secure based on logic from your own fraud engine, provide this option. Read our guide on [manually requesting 3D Secure](https://stripe.com/docs/payments/3d-secure#manual-three-ds) for more information on how this configuration interacts with Radar and our SCA Engine.
+  """
+  request_three_d_secure: Stripe_InvoicePaymentMethodOptionsCardRequestThreeDSecureProperty
+}
+
+enum Stripe_InvoicePaymentMethodOptionsCardRequestThreeDSecureProperty {
+  any
+  automatic
+}
+
+enum Stripe_InvoicesPaymentSettingsPaymentMethodTypesProperty {
+  ach_credit_transfer
+  ach_debit
+  au_becs_debit
+  bacs_debit
+  bancontact
+  boleto
+  card
+  fpx
+  giropay
+  ideal
+  sepa_debit
+  sofort
+  wechat_pay
+}
+
+union Stripe_InvoiceQuoteProperty = WrappedString | Stripe_Quote
+
+type Stripe_Quote {
+  """Total before any discounts or taxes are applied."""
+  amount_subtotal: Int
+
+  """Total after discounts and taxes are applied."""
+  amount_total: Int
+
+  """
+  The amount of the application fee (if any) that will be requested to be applied to the payment and transferred to the application owner's Stripe account. Only applicable if there are no line items with recurring prices on the quote.
+  """
+  application_fee_amount: Int
+
+  """
+  A non-negative decimal between 0 and 100, with at most two decimal places. This represents the percentage of the subscription invoice subtotal that will be transferred to the application owner's Stripe account. Only applicable if there are line items with recurring prices on the quote.
+  """
+  application_fee_percent: Float
+  automatic_tax: Stripe_QuotesResourceAutomaticTax
+
+  """
+  Either `charge_automatically`, or `send_invoice`. When charging automatically, Stripe will attempt to pay invoices at the end of the subscription cycle or on finalization using the default payment method attached to the subscription or customer. When sending an invoice, Stripe will email your customer an invoice with payment instructions. Defaults to `charge_automatically`.
+  """
+  collection_method: Stripe_QuoteCollectionMethodProperty
+  computed: Stripe_QuotesResourceComputed
+
+  """
+  Time at which the object was created. Measured in seconds since the Unix epoch.
+  """
+  created: Int
+
+  """
+  Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
+  """
+  currency: String
+  customer: Stripe_QuoteCustomerProperty
+
+  """The tax rates applied to this quote."""
+  default_tax_rates: [Stripe_QuoteDefaultTaxRatesProperty]
+
+  """A description that will be displayed on the quote PDF."""
+  description: String
+
+  """The discounts applied to this quote."""
+  discounts: [Stripe_QuoteDiscountsProperty]
+
+  """
+  The date on which the quote will be canceled if in `open` or `draft` status. Measured in seconds since the Unix epoch.
+  """
+  expires_at: Int
+
+  """A footer that will be displayed on the quote PDF."""
+  footer: String
+  from_quote: Stripe_QuotesResourceFromQuote
+
+  """A header that will be displayed on the quote PDF."""
+  header: String
+
+  """Unique identifier for the object."""
+  id: String
+  invoice: Stripe_QuoteInvoiceProperty
+  invoice_settings: Stripe_InvoiceSettingQuoteSetting
+
+  """A list of items the customer is being quoted for."""
+  line_items: Stripe_QuoteLineItemsProperty
+
+  """
+  Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode.
+  """
+  livemode: Boolean
+
+  """
+  Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format.
+  """
+  metadata: JSONObject
+
+  """
+  A unique number that identifies this particular quote. This number is assigned once the quote is [finalized](https://stripe.com/docs/quotes/overview#finalize).
+  """
+  number: String
+
+  """
+  String representing the object's type. Objects of the same type share the same value.
+  """
+  object: Stripe_QuoteObjectProperty
+  on_behalf_of: Stripe_QuoteOnBehalfOfProperty
+
+  """The status of the quote."""
+  status: Stripe_QuoteStatusProperty
+  status_transitions: Stripe_QuotesResourceStatusTransitions
+  subscription: Stripe_QuoteSubscriptionProperty
+  subscription_data: Stripe_QuotesResourceSubscriptionData
+  subscription_schedule: Stripe_QuoteSubscriptionScheduleProperty
+  total_details: Stripe_QuotesResourceTotalDetails
+  transfer_data: Stripe_QuotesResourceTransferData
+}
+
+type Stripe_QuotesResourceAutomaticTax {
+  """Automatically calculate taxes"""
+  enabled: Boolean
+
+  """
+  The status of the most recent automated tax calculation for this quote.
+  """
+  status: Stripe_QuotesResourceAutomaticTaxStatusProperty
+}
+
+enum Stripe_QuotesResourceAutomaticTaxStatusProperty {
+  complete
+  failed
+  requires_location_inputs
+}
+
+enum Stripe_QuoteCollectionMethodProperty {
+  charge_automatically
+  send_invoice
+}
+
+type Stripe_QuotesResourceComputed {
+  recurring: Stripe_QuotesResourceRecurring
+  upfront: Stripe_QuotesResourceUpfront
+}
+
+type Stripe_QuotesResourceRecurring {
+  """Total before any discounts or taxes are applied."""
+  amount_subtotal: Int
+
+  """Total after discounts and taxes are applied."""
+  amount_total: Int
+
+  """
+  The frequency at which a subscription is billed. One of `day`, `week`, `month` or `year`.
+  """
+  interval: Stripe_QuotesResourceRecurringIntervalProperty
+
+  """
+  The number of intervals (specified in the `interval` attribute) between subscription billings. For example, `interval=month` and `interval_count=3` bills every 3 months.
+  """
+  interval_count: Int
+  total_details: Stripe_QuotesResourceTotalDetails
+}
+
+enum Stripe_QuotesResourceRecurringIntervalProperty {
+  day
+  month
+  week
+  year
+}
+
+type Stripe_QuotesResourceTotalDetails {
+  """This is the sum of all the line item discounts."""
+  amount_discount: Int
+
+  """This is the sum of all the line item shipping amounts."""
+  amount_shipping: Int
+
+  """This is the sum of all the line item tax amounts."""
+  amount_tax: Int
+  breakdown: Stripe_QuotesResourceTotalDetailsResourceBreakdown
+}
+
+type Stripe_QuotesResourceTotalDetailsResourceBreakdown {
+  """The aggregated line item discounts."""
+  discounts: [Stripe_LineItemsDiscountAmount]
+
+  """The aggregated line item tax amounts by rate."""
+  taxes: [Stripe_LineItemsTaxAmount]
+}
+
+type Stripe_LineItemsDiscountAmount {
+  """The amount discounted."""
+  amount: Int
+  discount: Stripe_Discount
+}
+
+type Stripe_LineItemsTaxAmount {
+  """Amount of tax applied for this rate."""
+  amount: Int
+  rate: Stripe_TaxRate
+}
+
+type Stripe_QuotesResourceUpfront {
+  """Total before any discounts or taxes are applied."""
+  amount_subtotal: Int
+
+  """Total after discounts and taxes are applied."""
+  amount_total: Int
+
+  """
+  The line items that will appear on the next invoice after this quote is accepted. This does not include pending invoice items that exist on the customer but may still be included in the next invoice.
+  """
+  line_items: Stripe_QuotesResourceUpfrontLineItemsProperty
+  total_details: Stripe_QuotesResourceTotalDetails
+}
+
+"""
+The line items that will appear on the next invoice after this quote is accepted. This does not include pending invoice items that exist on the customer but may still be included in the next invoice.
+"""
+type Stripe_QuotesResourceUpfrontLineItemsProperty {
+  """Details about each object."""
+  data: [Stripe_Item!]!
+
+  """
+  True if this list has another page of items after this one that can be fetched.
+  """
+  has_more: Boolean!
+
+  """
+  String representing the object's type. Objects of the same type share the same value. Always has the value `list`.
+  """
+  object: Stripe_QuotesResourceUpfrontLineItemsObjectProperty!
+
+  """The URL where this list can be accessed."""
+  url: String!
+}
+
+type Stripe_Item {
+  """Total before any discounts or taxes are applied."""
+  amount_subtotal: Int
+
+  """Total after discounts and taxes."""
+  amount_total: Int
+
+  """
+  Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
+  """
+  currency: String
+
+  """
+  An arbitrary string attached to the object. Often useful for displaying to users. Defaults to product name.
+  """
+  description: String
+
+  """The discounts applied to the line item."""
+  discounts: [Stripe_LineItemsDiscountAmount]
+
+  """Unique identifier for the object."""
+  id: String
+
+  """
+  String representing the object's type. Objects of the same type share the same value.
+  """
+  object: Stripe_ItemObjectProperty
+  price: Stripe_Price
+
+  """The quantity of products being purchased."""
+  quantity: Int
+
+  """The taxes applied to the line item."""
+  taxes: [Stripe_LineItemsTaxAmount]
+}
+
+enum Stripe_ItemObjectProperty {
+  item
+}
+
+enum Stripe_QuotesResourceUpfrontLineItemsObjectProperty {
+  list
+}
+
+union Stripe_QuoteCustomerProperty = WrappedString | Stripe_Customer | Stripe_DeletedCustomer
+
+union Stripe_QuoteDefaultTaxRatesProperty = WrappedString | Stripe_TaxRate
+
+union Stripe_QuoteDiscountsProperty = WrappedString | Stripe_Discount
+
+type Stripe_QuotesResourceFromQuote {
+  """Whether this quote is a revision of a different quote."""
+  is_revision: Boolean
+  quote: Stripe_QuotesResourceFromQuoteQuoteProperty
+}
+
+union Stripe_QuotesResourceFromQuoteQuoteProperty = WrappedString | Stripe_Quote
+
+union Stripe_QuoteInvoiceProperty = WrappedString | Stripe_Invoice | Stripe_DeletedInvoice
+
+type Stripe_DeletedInvoice {
+  """Unique identifier for the object."""
+  id: String
+
+  """
+  String representing the object's type. Objects of the same type share the same value.
+  """
+  object: Stripe_DeletedInvoiceObjectProperty
+}
+
+enum Stripe_DeletedInvoiceObjectProperty {
+  invoice
+}
+
+type Stripe_InvoiceSettingQuoteSetting {
+  """
+  Number of days within which a customer must pay invoices generated by this quote. This value will be `null` for quotes where `collection_method=charge_automatically`.
+  """
+  days_until_due: Int
+}
+
+"""A list of items the customer is being quoted for."""
+type Stripe_QuoteLineItemsProperty {
+  """Details about each object."""
+  data: [Stripe_Item!]!
+
+  """
+  True if this list has another page of items after this one that can be fetched.
+  """
+  has_more: Boolean!
+
+  """
+  String representing the object's type. Objects of the same type share the same value. Always has the value `list`.
+  """
+  object: Stripe_QuoteLineItemsObjectProperty!
+
+  """The URL where this list can be accessed."""
+  url: String!
+}
+
+enum Stripe_QuoteLineItemsObjectProperty {
+  list
+}
+
+enum Stripe_QuoteObjectProperty {
+  quote
+}
+
+union Stripe_QuoteOnBehalfOfProperty = WrappedString | Stripe_Account
+
+enum Stripe_QuoteStatusProperty {
+  accepted
+  canceled
+  draft
+  open
+}
+
+type Stripe_QuotesResourceStatusTransitions {
+  """
+  The time that the quote was accepted. Measured in seconds since Unix epoch.
+  """
+  accepted_at: Int
+
+  """
+  The time that the quote was canceled. Measured in seconds since Unix epoch.
+  """
+  canceled_at: Int
+
+  """
+  The time that the quote was finalized. Measured in seconds since Unix epoch.
+  """
+  finalized_at: Int
+}
+
+union Stripe_QuoteSubscriptionProperty = WrappedString | Stripe_Subscription
+
+type Stripe_Subscription {
+  """
+  A non-negative decimal between 0 and 100, with at most two decimal places. This represents the percentage of the subscription invoice subtotal that will be transferred to the application owner's Stripe account.
+  """
+  application_fee_percent: Float
+  automatic_tax: Stripe_SubscriptionAutomaticTax
+
+  """
+  Determines the date of the first full invoice, and, for plans with `month` or `year` intervals, the day of the month for subsequent invoices.
+  """
+  billing_cycle_anchor: Int
+  billing_thresholds: Stripe_SubscriptionBillingThresholds
+
+  """
+  A date in the future at which the subscription will automatically get canceled
+  """
+  cancel_at: Int
+
+  """
+  If the subscription has been canceled with the `at_period_end` flag set to `true`, `cancel_at_period_end` on the subscription will be true. You can use this attribute to determine whether a subscription that has a status of active is scheduled to be canceled at the end of the current period.
+  """
+  cancel_at_period_end: Boolean
+
+  """
+  If the subscription has been canceled, the date of that cancellation. If the subscription was canceled with `cancel_at_period_end`, `canceled_at` will reflect the time of the most recent update request, not the end of the subscription period when the subscription is automatically moved to a canceled state.
+  """
+  canceled_at: Int
+
+  """
+  Either `charge_automatically`, or `send_invoice`. When charging automatically, Stripe will attempt to pay this subscription at the end of the cycle using the default source attached to the customer. When sending an invoice, Stripe will email your customer an invoice with payment instructions.
+  """
+  collection_method: Stripe_SubscriptionCollectionMethodProperty
+
+  """
+  Time at which the object was created. Measured in seconds since the Unix epoch.
+  """
+  created: Int
+
+  """
+  End of the current period that the subscription has been invoiced for. At the end of this period, a new invoice will be created.
+  """
+  current_period_end: Int
+
+  """
+  Start of the current period that the subscription has been invoiced for.
+  """
+  current_period_start: Int
+  customer: Stripe_SubscriptionCustomerProperty
+
+  """
+  Number of days a customer has to pay invoices generated by this subscription. This value will be `null` for subscriptions where `collection_method=charge_automatically`.
+  """
+  days_until_due: Int
+  default_payment_method: Stripe_SubscriptionDefaultPaymentMethodProperty
+  default_source: Stripe_SubscriptionDefaultSourceProperty
+
+  """
+  The tax rates that will apply to any subscription item that does not have `tax_rates` set. Invoices created will have their `default_tax_rates` populated from the subscription.
+  """
+  default_tax_rates: [Stripe_TaxRate]
+  discount: Stripe_Discount
+
+  """If the subscription has ended, the date the subscription ended."""
+  ended_at: Int
+
+  """Unique identifier for the object."""
+  id: String
+
+  """List of subscription items, each with an attached price."""
+  items: Stripe_SubscriptionItemsProperty
+  latest_invoice: Stripe_SubscriptionLatestInvoiceProperty
+
+  """
+  Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode.
+  """
+  livemode: Boolean
+
+  """
+  Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format.
+  """
+  metadata: JSONObject
+
+  """
+  Specifies the approximate timestamp on which any pending invoice items will be billed according to the schedule provided at `pending_invoice_item_interval`.
+  """
+  next_pending_invoice_item_invoice: Int
+
+  """
+  String representing the object's type. Objects of the same type share the same value.
+  """
+  object: Stripe_SubscriptionObjectProperty
+  pause_collection: Stripe_SubscriptionsResourcePauseCollection
+  payment_settings: Stripe_SubscriptionsResourcePaymentSettings
+  pending_invoice_item_interval: Stripe_SubscriptionPendingInvoiceItemInterval
+  pending_setup_intent: Stripe_SubscriptionPendingSetupIntentProperty
+  pending_update: Stripe_SubscriptionsResourcePendingUpdate
+  schedule: Stripe_SubscriptionScheduleProperty
+
+  """
+  Date when the subscription was first created. The date might differ from the `created` date due to backdating.
+  """
+  start_date: Int
+
+  """
+  Possible values are `incomplete`, `incomplete_expired`, `trialing`, `active`, `past_due`, `canceled`, or `unpaid`. 
+  
+  For `collection_method=charge_automatically` a subscription moves into `incomplete` if the initial payment attempt fails. A subscription in this state can only have metadata and default_source updated. Once the first invoice is paid, the subscription moves into an `active` state. If the first invoice is not paid within 23 hours, the subscription transitions to `incomplete_expired`. This is a terminal state, the open invoice will be voided and no further invoices will be generated. 
+  
+  A subscription that is currently in a trial period is `trialing` and moves to `active` when the trial period is over. 
+  
+  If subscription `collection_method=charge_automatically` it becomes `past_due` when payment to renew it fails and `canceled` or `unpaid` (depending on your subscriptions settings) when Stripe has exhausted all payment retry attempts. 
+  
+  If subscription `collection_method=send_invoice` it becomes `past_due` when its invoice is not paid by the due date, and `canceled` or `unpaid` if it is still not paid by an additional deadline after that. Note that when a subscription has a status of `unpaid`, no subsequent invoices will be attempted (invoices will be created, but then immediately automatically closed). After receiving updated payment information from a customer, you may choose to reopen and pay their closed invoices.
+  """
+  status: Stripe_SubscriptionStatusProperty
+  transfer_data: Stripe_SubscriptionTransferData
+
+  """If the subscription has a trial, the end of that trial."""
+  trial_end: Int
+
+  """If the subscription has a trial, the beginning of that trial."""
+  trial_start: Int
+}
+
+type Stripe_SubscriptionAutomaticTax {
+  """Whether Stripe automatically computes tax on this subscription."""
+  enabled: Boolean
+}
+
+type Stripe_SubscriptionBillingThresholds {
+  """Monetary threshold that triggers the subscription to create an invoice"""
+  amount_gte: Int
+
+  """
+  Indicates if the `billing_cycle_anchor` should be reset when a threshold is reached. If true, `billing_cycle_anchor` will be updated to the date/time the threshold was last reached; otherwise, the value will remain unchanged. This value may not be `true` if the subscription contains items with plans that have `aggregate_usage=last_ever`.
+  """
+  reset_billing_cycle_anchor: Boolean
+}
+
+enum Stripe_SubscriptionCollectionMethodProperty {
+  charge_automatically
+  send_invoice
+}
+
+union Stripe_SubscriptionCustomerProperty = WrappedString | Stripe_Customer | Stripe_DeletedCustomer
+
+union Stripe_SubscriptionDefaultPaymentMethodProperty = WrappedString | Stripe_PaymentMethod
+
+union Stripe_SubscriptionDefaultSourceProperty = WrappedString | Stripe_AlipayAccount | Stripe_BankAccount | Stripe_BitcoinReceiver | Stripe_Card | Stripe_Source
+
+"""List of subscription items, each with an attached price."""
+type Stripe_SubscriptionItemsProperty {
+  """Details about each object."""
+  data: [Stripe_SubscriptionItem!]!
+
+  """
+  True if this list has another page of items after this one that can be fetched.
+  """
+  has_more: Boolean!
+
+  """
+  String representing the object's type. Objects of the same type share the same value. Always has the value `list`.
+  """
+  object: Stripe_SubscriptionItemsObjectProperty!
+
+  """The URL where this list can be accessed."""
+  url: String!
+}
+
+type Stripe_SubscriptionItem {
+  billing_thresholds: Stripe_SubscriptionItemBillingThresholds
+
+  """
+  Time at which the object was created. Measured in seconds since the Unix epoch.
+  """
+  created: Int
+
+  """Unique identifier for the object."""
+  id: String
+
+  """
+  Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format.
+  """
+  metadata: JSONObject
+
+  """
+  String representing the object's type. Objects of the same type share the same value.
+  """
+  object: Stripe_SubscriptionItemObjectProperty
+  price: Stripe_Price
+
+  """
+  The [quantity](https://stripe.com/docs/subscriptions/quantities) of the plan to which the customer should be subscribed.
+  """
+  quantity: Int
+
+  """The `subscription` this `subscription_item` belongs to."""
+  subscription: String
+
+  """
+  The tax rates which apply to this `subscription_item`. When set, the `default_tax_rates` on the subscription do not apply to this `subscription_item`.
+  """
+  tax_rates: [Stripe_TaxRate]
+}
+
+type Stripe_SubscriptionItemBillingThresholds {
+  """Usage threshold that triggers the subscription to create an invoice"""
+  usage_gte: Int
+}
+
+enum Stripe_SubscriptionItemObjectProperty {
+  subscription_item
+}
+
+enum Stripe_SubscriptionItemsObjectProperty {
+  list
+}
+
+union Stripe_SubscriptionLatestInvoiceProperty = WrappedString | Stripe_Invoice
+
+enum Stripe_SubscriptionObjectProperty {
+  subscription
+}
+
+type Stripe_SubscriptionsResourcePauseCollection {
+  """
+  The payment collection behavior for this subscription while paused. One of `keep_as_draft`, `mark_uncollectible`, or `void`.
+  """
+  behavior: Stripe_SubscriptionsResourcePauseCollectionBehaviorProperty
+
+  """The time after which the subscription will resume collecting payments."""
+  resumes_at: Int
+}
+
+enum Stripe_SubscriptionsResourcePauseCollectionBehaviorProperty {
+  keep_as_draft
+  mark_uncollectible
+  void
+}
+
+type Stripe_SubscriptionsResourcePaymentSettings {
+  payment_method_options: Stripe_SubscriptionsResourcePaymentMethodOptions
+
+  """
+  The list of payment method types to provide to every invoice created by the subscription. If not set, Stripe attempts to automatically determine the types to use by looking at the invoice’s default payment method, the subscription’s default payment method, the customer’s default payment method, and your [invoice template settings](https://dashboard.stripe.com/settings/billing/invoice).
+  """
+  payment_method_types: [Stripe_SubscriptionsResourcePaymentSettingsPaymentMethodTypesProperty]
+}
+
+type Stripe_SubscriptionsResourcePaymentMethodOptions {
+  bancontact: Stripe_InvoicePaymentMethodOptionsBancontact
+  card: Stripe_InvoicePaymentMethodOptionsCard
+}
+
+enum Stripe_SubscriptionsResourcePaymentSettingsPaymentMethodTypesProperty {
+  ach_credit_transfer
+  ach_debit
+  au_becs_debit
+  bacs_debit
+  bancontact
+  boleto
+  card
+  fpx
+  giropay
+  ideal
+  sepa_debit
+  sofort
+  wechat_pay
+}
+
+type Stripe_SubscriptionPendingInvoiceItemInterval {
+  """
+  Specifies invoicing frequency. Either `day`, `week`, `month` or `year`.
+  """
+  interval: Stripe_SubscriptionPendingInvoiceItemIntervalIntervalProperty
+
+  """
+  The number of intervals between invoices. For example, `interval=month` and `interval_count=3` bills every 3 months. Maximum of one year interval allowed (1 year, 12 months, or 52 weeks).
+  """
+  interval_count: Int
+}
+
+enum Stripe_SubscriptionPendingInvoiceItemIntervalIntervalProperty {
+  day
+  month
+  week
+  year
+}
+
+union Stripe_SubscriptionPendingSetupIntentProperty = WrappedString | Stripe_SetupIntent
+
+type Stripe_SetupIntent {
+  application: Stripe_SetupIntentApplicationProperty
+
+  """
+  Reason for cancellation of this SetupIntent, one of `abandoned`, `requested_by_customer`, or `duplicate`.
+  """
+  cancellation_reason: Stripe_SetupIntentCancellationReasonProperty
+
+  """
+  The client secret of this SetupIntent. Used for client-side retrieval using a publishable key.
+  
+  The client secret can be used to complete payment setup from your frontend. It should not be stored, logged, embedded in URLs, or exposed to anyone other than the customer. Make sure that you have TLS enabled on any page that includes the client secret.
+  """
+  client_secret: String
+
+  """
+  Time at which the object was created. Measured in seconds since the Unix epoch.
+  """
+  created: Int
+  customer: Stripe_SetupIntentCustomerProperty
+
+  """
+  An arbitrary string attached to the object. Often useful for displaying to users.
+  """
+  description: String
+
+  """Unique identifier for the object."""
+  id: String
+  last_setup_error: Stripe_ApiErrors
+  latest_attempt: Stripe_SetupIntentLatestAttemptProperty
+
+  """
+  Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode.
+  """
+  livemode: Boolean
+  mandate: Stripe_SetupIntentMandateProperty
+
+  """
+  Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format.
+  """
+  metadata: JSONObject
+  next_action: Stripe_SetupIntentNextAction
+
+  """
+  String representing the object's type. Objects of the same type share the same value.
+  """
+  object: Stripe_SetupIntentObjectProperty
+  on_behalf_of: Stripe_SetupIntentOnBehalfOfProperty
+  payment_method: Stripe_SetupIntentPaymentMethodProperty
+  payment_method_options: Stripe_SetupIntentPaymentMethodOptions
+
+  """
+  The list of payment method types (e.g. card) that this SetupIntent is allowed to set up.
+  """
+  payment_method_types: [String]
+  single_use_mandate: Stripe_SetupIntentSingleUseMandateProperty
+
+  """
+  [Status](https://stripe.com/docs/payments/intents#intent-statuses) of this SetupIntent, one of `requires_payment_method`, `requires_confirmation`, `requires_action`, `processing`, `canceled`, or `succeeded`.
+  """
+  status: Stripe_SetupIntentStatusProperty
+
+  """
+  Indicates how the payment method is intended to be used in the future.
+  
+  Use `on_session` if you intend to only reuse the payment method when the customer is in your checkout flow. Use `off_session` if your customer may or may not be in your checkout flow. If not provided, this value defaults to `off_session`.
+  """
+  usage: String
+}
+
+union Stripe_SetupIntentApplicationProperty = WrappedString | Stripe_Application
+
+enum Stripe_SetupIntentCancellationReasonProperty {
+  abandoned
+  duplicate
+  requested_by_customer
+}
+
+union Stripe_SetupIntentCustomerProperty = WrappedString | Stripe_Customer | Stripe_DeletedCustomer
+
+union Stripe_SetupIntentLatestAttemptProperty = WrappedString | Stripe_SetupAttempt
+
+union Stripe_SetupIntentMandateProperty = WrappedString | Stripe_Mandate
+
+type Stripe_SetupIntentNextAction {
+  redirect_to_url: Stripe_SetupIntentNextActionRedirectToUrl
+
+  """
+  Type of the next action to perform, one of `redirect_to_url`, `use_stripe_sdk`, `alipay_handle_redirect`, or `oxxo_display_details`.
+  """
+  type: String
+
+  """
+  When confirming a SetupIntent with Stripe.js, Stripe.js depends on the contents of this dictionary to invoke authentication flows. The shape of the contents is subject to change and is only intended to be used by Stripe.js.
+  """
+  use_stripe_sdk: JSONObject
+  verify_with_microdeposits: Stripe_SetupIntentNextActionVerifyWithMicrodeposits
+}
+
+type Stripe_SetupIntentNextActionRedirectToUrl {
+  """
+  If the customer does not exit their browser while authenticating, they will be redirected to this specified URL after completion.
+  """
+  return_url: String
+
+  """The URL you must redirect your customer to in order to authenticate."""
+  url: String
+}
+
+type Stripe_SetupIntentNextActionVerifyWithMicrodeposits {
+  """The timestamp when the microdeposits are expected to land."""
+  arrival_date: Int
+
+  """
+  The URL for the hosted verification page, which allows customers to verify their bank account.
+  """
+  hosted_verification_url: String
+}
+
+enum Stripe_SetupIntentObjectProperty {
+  setup_intent
+}
+
+union Stripe_SetupIntentOnBehalfOfProperty = WrappedString | Stripe_Account
+
+union Stripe_SetupIntentPaymentMethodProperty = WrappedString | Stripe_PaymentMethod
+
+type Stripe_SetupIntentPaymentMethodOptions {
+  acss_debit: Stripe_SetupIntentPaymentMethodOptionsAcssDebit
+  card: Stripe_SetupIntentPaymentMethodOptionsCard
+  sepa_debit: Stripe_SetupIntentPaymentMethodOptionsSepaDebit
+}
+
+type Stripe_SetupIntentPaymentMethodOptionsAcssDebit {
+  """Currency supported by the bank account"""
+  currency: Stripe_SetupIntentPaymentMethodOptionsAcssDebitCurrencyProperty
+  mandate_options: Stripe_SetupIntentPaymentMethodOptionsMandateOptionsAcssDebit
+
+  """Bank account verification method."""
+  verification_method: Stripe_SetupIntentPaymentMethodOptionsAcssDebitVerificationMethodProperty
+}
+
+enum Stripe_SetupIntentPaymentMethodOptionsAcssDebitCurrencyProperty {
+  cad
+  usd
+}
+
+type Stripe_SetupIntentPaymentMethodOptionsMandateOptionsAcssDebit {
+  """A URL for custom mandate text"""
+  custom_mandate_url: String
+
+  """
+  Description of the interval. Only required if 'payment_schedule' parmeter is 'interval' or 'combined'.
+  """
+  interval_description: String
+
+  """Payment schedule for the mandate."""
+  payment_schedule: Stripe_SetupIntentPaymentMethodOptionsMandateOptionsAcssDebitPaymentScheduleProperty
+
+  """Transaction type of the mandate."""
+  transaction_type: Stripe_SetupIntentPaymentMethodOptionsMandateOptionsAcssDebitTransactionTypeProperty
+}
+
+enum Stripe_SetupIntentPaymentMethodOptionsMandateOptionsAcssDebitPaymentScheduleProperty {
+  combined
+  interval
+  sporadic
+}
+
+enum Stripe_SetupIntentPaymentMethodOptionsMandateOptionsAcssDebitTransactionTypeProperty {
+  business
+  personal
+}
+
+enum Stripe_SetupIntentPaymentMethodOptionsAcssDebitVerificationMethodProperty {
+  automatic
+  instant
+  microdeposits
+}
+
+type Stripe_SetupIntentPaymentMethodOptionsCard {
+  """
+  We strongly recommend that you rely on our SCA Engine to automatically prompt your customers for authentication based on risk level and [other requirements](https://stripe.com/docs/strong-customer-authentication). However, if you wish to request 3D Secure based on logic from your own fraud engine, provide this option. Permitted values include: `automatic` or `any`. If not provided, defaults to `automatic`. Read our guide on [manually requesting 3D Secure](https://stripe.com/docs/payments/3d-secure#manual-three-ds) for more information on how this configuration interacts with Radar and our SCA Engine.
+  """
+  request_three_d_secure: Stripe_SetupIntentPaymentMethodOptionsCardRequestThreeDSecureProperty
+}
+
+enum Stripe_SetupIntentPaymentMethodOptionsCardRequestThreeDSecureProperty {
+  any
+  automatic
+  challenge_only
+}
+
+type Stripe_SetupIntentPaymentMethodOptionsSepaDebit {
+  mandate_options: Stripe_SetupIntentPaymentMethodOptionsMandateOptionsSepaDebit
+}
+
+type Stripe_SetupIntentPaymentMethodOptionsMandateOptionsSepaDebit {
+  result: JSONObject
+}
+
+union Stripe_SetupIntentSingleUseMandateProperty = WrappedString | Stripe_Mandate
+
+enum Stripe_SetupIntentStatusProperty {
+  canceled
+  processing
+  requires_action
+  requires_confirmation
+  requires_payment_method
+  succeeded
+}
+
+type Stripe_SubscriptionsResourcePendingUpdate {
+  """
+  If the update is applied, determines the date of the first full invoice, and, for plans with `month` or `year` intervals, the day of the month for subsequent invoices.
+  """
+  billing_cycle_anchor: Int
+
+  """
+  The point after which the changes reflected by this update will be discarded and no longer applied.
+  """
+  expires_at: Int
+
+  """
+  List of subscription items, each with an attached plan, that will be set if the update is applied.
+  """
+  subscription_items: [Stripe_SubscriptionItem]
+
+  """
+  Unix timestamp representing the end of the trial period the customer will get before being charged for the first time, if the update is applied.
+  """
+  trial_end: Int
+
+  """
+  Indicates if a plan's `trial_period_days` should be applied to the subscription. Setting `trial_end` per subscription is preferred, and this defaults to `false`. Setting this flag to `true` together with `trial_end` is not allowed.
+  """
+  trial_from_plan: Boolean
+}
+
+union Stripe_SubscriptionScheduleProperty = WrappedString | Stripe_SubscriptionSchedule
+
+type Stripe_SubscriptionSchedule {
+  """
+  Time at which the subscription schedule was canceled. Measured in seconds since the Unix epoch.
+  """
+  canceled_at: Int
+
+  """
+  Time at which the subscription schedule was completed. Measured in seconds since the Unix epoch.
+  """
+  completed_at: Int
+
+  """
+  Time at which the object was created. Measured in seconds since the Unix epoch.
+  """
+  created: Int
+  current_phase: Stripe_SubscriptionScheduleCurrentPhase
+  customer: Stripe_SubscriptionScheduleCustomerProperty
+  default_settings: Stripe_SubscriptionSchedulesResourceDefaultSettings
+
+  """
+  Behavior of the subscription schedule and underlying subscription when it ends. Possible values are `release` and `cancel`.
+  """
+  end_behavior: Stripe_SubscriptionScheduleEndBehaviorProperty
+
+  """Unique identifier for the object."""
+  id: String
+
+  """
+  Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode.
+  """
+  livemode: Boolean
+
+  """
+  Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format.
+  """
+  metadata: JSONObject
+
+  """
+  String representing the object's type. Objects of the same type share the same value.
+  """
+  object: Stripe_SubscriptionScheduleObjectProperty
+
+  """Configuration for the subscription schedule's phases."""
+  phases: [Stripe_SubscriptionSchedulePhaseConfiguration]
+
+  """
+  Time at which the subscription schedule was released. Measured in seconds since the Unix epoch.
+  """
+  released_at: Int
+
+  """
+  ID of the subscription once managed by the subscription schedule (if it is released).
+  """
+  released_subscription: String
+
+  """
+  The present status of the subscription schedule. Possible values are `not_started`, `active`, `completed`, `released`, and `canceled`. You can read more about the different states in our [behavior guide](https://stripe.com/docs/billing/subscriptions/subscription-schedules).
+  """
+  status: Stripe_SubscriptionScheduleStatusProperty
+  subscription: Stripe_SubscriptionScheduleSubscriptionProperty
+}
+
+type Stripe_SubscriptionScheduleCurrentPhase {
+  """The end of this phase of the subscription schedule."""
+  end_date: Int
+
+  """The start of this phase of the subscription schedule."""
+  start_date: Int
+}
+
+union Stripe_SubscriptionScheduleCustomerProperty = WrappedString | Stripe_Customer | Stripe_DeletedCustomer
+
+type Stripe_SubscriptionSchedulesResourceDefaultSettings {
+  """
+  A non-negative decimal between 0 and 100, with at most two decimal places. This represents the percentage of the subscription invoice subtotal that will be transferred to the application owner's Stripe account during this phase of the schedule.
+  """
+  application_fee_percent: Float
+  automatic_tax: Stripe_SubscriptionSchedulesResourceDefaultSettingsAutomaticTax
+
+  """
+  Possible values are `phase_start` or `automatic`. If `phase_start` then billing cycle anchor of the subscription is set to the start of the phase when entering the phase. If `automatic` then the billing cycle anchor is automatically modified as needed when entering the phase. For more information, see the billing cycle [documentation](https://stripe.com/docs/billing/subscriptions/billing-cycle).
+  """
+  billing_cycle_anchor: Stripe_SubscriptionSchedulesResourceDefaultSettingsBillingCycleAnchorProperty
+  billing_thresholds: Stripe_SubscriptionBillingThresholds
+
+  """
+  Either `charge_automatically`, or `send_invoice`. When charging automatically, Stripe will attempt to pay the underlying subscription at the end of each billing cycle using the default source attached to the customer. When sending an invoice, Stripe will email your customer an invoice with payment instructions.
+  """
+  collection_method: Stripe_SubscriptionSchedulesResourceDefaultSettingsCollectionMethodProperty
+  default_payment_method: Stripe_SubscriptionSchedulesResourceDefaultSettingsDefaultPaymentMethodProperty
+  invoice_settings: Stripe_InvoiceSettingSubscriptionScheduleSetting
+  transfer_data: Stripe_SubscriptionTransferData
+}
+
+type Stripe_SubscriptionSchedulesResourceDefaultSettingsAutomaticTax {
+  """
+  Whether Stripe automatically computes tax on invoices created during this phase.
+  """
+  enabled: Boolean
+}
+
+enum Stripe_SubscriptionSchedulesResourceDefaultSettingsBillingCycleAnchorProperty {
+  automatic
+  phase_start
+}
+
+enum Stripe_SubscriptionSchedulesResourceDefaultSettingsCollectionMethodProperty {
+  charge_automatically
+  send_invoice
+}
+
+union Stripe_SubscriptionSchedulesResourceDefaultSettingsDefaultPaymentMethodProperty = WrappedString | Stripe_PaymentMethod
+
+type Stripe_InvoiceSettingSubscriptionScheduleSetting {
+  """
+  Number of days within which a customer must pay invoices generated by this subscription schedule. This value will be `null` for subscription schedules where `billing=charge_automatically`.
+  """
+  days_until_due: Int
+}
+
+type Stripe_SubscriptionTransferData {
+  """
+  A non-negative decimal between 0 and 100, with at most two decimal places. This represents the percentage of the subscription invoice subtotal that will be transferred to the destination account. By default, the entire amount is transferred to the destination.
+  """
+  amount_percent: Float
+  destination: Stripe_SubscriptionTransferDataDestinationProperty
+}
+
+union Stripe_SubscriptionTransferDataDestinationProperty = WrappedString | Stripe_Account
+
+enum Stripe_SubscriptionScheduleEndBehaviorProperty {
+  cancel
+  none
+  release
+  renew
+}
+
+enum Stripe_SubscriptionScheduleObjectProperty {
+  subscription_schedule
+}
+
+type Stripe_SubscriptionSchedulePhaseConfiguration {
+  """
+  A list of prices and quantities that will generate invoice items appended to the first invoice for this phase.
+  """
+  add_invoice_items: [Stripe_SubscriptionScheduleAddInvoiceItem]
+
+  """
+  A non-negative decimal between 0 and 100, with at most two decimal places. This represents the percentage of the subscription invoice subtotal that will be transferred to the application owner's Stripe account during this phase of the schedule.
+  """
+  application_fee_percent: Float
+  automatic_tax: Stripe_SchedulesPhaseAutomaticTax
+
+  """
+  Possible values are `phase_start` or `automatic`. If `phase_start` then billing cycle anchor of the subscription is set to the start of the phase when entering the phase. If `automatic` then the billing cycle anchor is automatically modified as needed when entering the phase. For more information, see the billing cycle [documentation](https://stripe.com/docs/billing/subscriptions/billing-cycle).
+  """
+  billing_cycle_anchor: Stripe_SubscriptionSchedulePhaseConfigurationBillingCycleAnchorProperty
+  billing_thresholds: Stripe_SubscriptionBillingThresholds
+
+  """
+  Either `charge_automatically`, or `send_invoice`. When charging automatically, Stripe will attempt to pay the underlying subscription at the end of each billing cycle using the default source attached to the customer. When sending an invoice, Stripe will email your customer an invoice with payment instructions.
+  """
+  collection_method: Stripe_SubscriptionSchedulePhaseConfigurationCollectionMethodProperty
+  coupon: Stripe_SubscriptionSchedulePhaseConfigurationCouponProperty
+  default_payment_method: Stripe_SubscriptionSchedulePhaseConfigurationDefaultPaymentMethodProperty
+
+  """
+  The default tax rates to apply to the subscription during this phase of the subscription schedule.
+  """
+  default_tax_rates: [Stripe_TaxRate]
+
+  """The end of this phase of the subscription schedule."""
+  end_date: Int
+  invoice_settings: Stripe_InvoiceSettingSubscriptionScheduleSetting
+
+  """
+  Subscription items to configure the subscription to during this phase of the subscription schedule.
+  """
+  items: [Stripe_SubscriptionScheduleConfigurationItem]
+
+  """
+  If the subscription schedule will prorate when transitioning to this phase. Possible values are `create_prorations` and `none`.
+  """
+  proration_behavior: Stripe_SubscriptionSchedulePhaseConfigurationProrationBehaviorProperty
+
+  """The start of this phase of the subscription schedule."""
+  start_date: Int
+  transfer_data: Stripe_SubscriptionTransferData
+
+  """When the trial ends within the phase."""
+  trial_end: Int
+}
+
+type Stripe_SubscriptionScheduleAddInvoiceItem {
+  price: Stripe_SubscriptionScheduleAddInvoiceItemPriceProperty
+
+  """The quantity of the invoice item."""
+  quantity: Int
+
+  """
+  The tax rates which apply to the item. When set, the `default_tax_rates` do not apply to this item.
+  """
+  tax_rates: [Stripe_TaxRate]
+}
+
+union Stripe_SubscriptionScheduleAddInvoiceItemPriceProperty = WrappedString | Stripe_Price | Stripe_DeletedPrice
+
+type Stripe_DeletedPrice {
+  """Unique identifier for the object."""
+  id: String
+
+  """
+  String representing the object's type. Objects of the same type share the same value.
+  """
+  object: Stripe_DeletedPriceObjectProperty
+}
+
+enum Stripe_DeletedPriceObjectProperty {
+  price
+}
+
+type Stripe_SchedulesPhaseAutomaticTax {
+  """
+  Whether Stripe automatically computes tax on invoices created during this phase.
+  """
+  enabled: Boolean
+}
+
+enum Stripe_SubscriptionSchedulePhaseConfigurationBillingCycleAnchorProperty {
+  automatic
+  phase_start
+}
+
+enum Stripe_SubscriptionSchedulePhaseConfigurationCollectionMethodProperty {
+  charge_automatically
+  send_invoice
+}
+
+union Stripe_SubscriptionSchedulePhaseConfigurationCouponProperty = WrappedString | Stripe_Coupon | Stripe_DeletedCoupon
+
+type Stripe_DeletedCoupon {
+  """Unique identifier for the object."""
+  id: String
+
+  """
+  String representing the object's type. Objects of the same type share the same value.
+  """
+  object: Stripe_DeletedCouponObjectProperty
+}
+
+enum Stripe_DeletedCouponObjectProperty {
+  coupon
+}
+
+union Stripe_SubscriptionSchedulePhaseConfigurationDefaultPaymentMethodProperty = WrappedString | Stripe_PaymentMethod
+
+type Stripe_SubscriptionScheduleConfigurationItem {
+  billing_thresholds: Stripe_SubscriptionItemBillingThresholds
+  price: Stripe_SubscriptionScheduleConfigurationItemPriceProperty
+
+  """Quantity of the plan to which the customer should be subscribed."""
+  quantity: Int
+
+  """
+  The tax rates which apply to this `phase_item`. When set, the `default_tax_rates` on the phase do not apply to this `phase_item`.
+  """
+  tax_rates: [Stripe_TaxRate]
+}
+
+union Stripe_SubscriptionScheduleConfigurationItemPriceProperty = WrappedString | Stripe_Price | Stripe_DeletedPrice
+
+enum Stripe_SubscriptionSchedulePhaseConfigurationProrationBehaviorProperty {
+  always_invoice
+  create_prorations
+  none
+}
+
+enum Stripe_SubscriptionScheduleStatusProperty {
+  active
+  canceled
+  completed
+  not_started
+  released
+}
+
+union Stripe_SubscriptionScheduleSubscriptionProperty = WrappedString | Stripe_Subscription
+
+enum Stripe_SubscriptionStatusProperty {
+  active
+  canceled
+  incomplete
+  incomplete_expired
+  past_due
+  trialing
+  unpaid
+}
+
+type Stripe_QuotesResourceSubscriptionData {
+  """
+  When creating a new subscription, the date of which the subscription schedule will start after the quote is accepted. This date is ignored if it is in the past when the quote is accepted. Measured in seconds since the Unix epoch.
+  """
+  effective_date: Int
+
+  """
+  Integer representing the number of trial period days before the customer is charged for the first time.
+  """
+  trial_period_days: Int
+}
+
+union Stripe_QuoteSubscriptionScheduleProperty = WrappedString | Stripe_SubscriptionSchedule
+
+type Stripe_QuotesResourceTransferData {
+  """
+  The amount in %s that will be transferred to the destination account when the invoice is paid. By default, the entire amount is transferred to the destination.
+  """
+  amount: Int
+
+  """
+  A non-negative decimal between 0 and 100, with at most two decimal places. This represents the percentage of the subscription invoice subtotal that will be transferred to the destination account. By default, the entire amount will be transferred to the destination.
+  """
+  amount_percent: Float
+  destination: Stripe_QuotesResourceTransferDataDestinationProperty
+}
+
+union Stripe_QuotesResourceTransferDataDestinationProperty = WrappedString | Stripe_Account
+
+enum Stripe_InvoiceStatusProperty {
+  deleted
+  draft
+  open
+  paid
+  uncollectible
+  void
+}
+
+type Stripe_InvoicesStatusTransitions {
+  """The time that the invoice draft was finalized."""
+  finalized_at: Int
+
+  """The time that the invoice was marked uncollectible."""
+  marked_uncollectible_at: Int
+
+  """The time that the invoice was paid."""
+  paid_at: Int
+
+  """The time that the invoice was voided."""
+  voided_at: Int
+}
+
+union Stripe_InvoiceSubscriptionProperty = WrappedString | Stripe_Subscription
+
+type Stripe_InvoiceThresholdReason {
+  """
+  The total invoice amount threshold boundary if it triggered the threshold invoice.
+  """
+  amount_gte: Int
+
+  """Indicates which line items triggered a threshold invoice."""
+  item_reasons: [Stripe_InvoiceItemThresholdReason]
+}
+
+type Stripe_InvoiceItemThresholdReason {
+  """The IDs of the line items that triggered the threshold invoice."""
+  line_item_ids: [String]
+
+  """The quantity threshold boundary that applied to the given line item."""
+  usage_gte: Int
+}
+
+type Stripe_InvoiceTransferData {
+  """
+  The amount in %s that will be transferred to the destination account when the invoice is paid. By default, the entire amount is transferred to the destination.
+  """
+  amount: Int
+  destination: Stripe_InvoiceTransferDataDestinationProperty
+}
+
+union Stripe_InvoiceTransferDataDestinationProperty = WrappedString | Stripe_Account
+
+enum Stripe_ChargeObjectProperty {
+  charge
+}
+
+union Stripe_ChargeOnBehalfOfProperty = WrappedString | Stripe_Account
+
+union Stripe_ChargeOrderProperty = WrappedString | Stripe_Order
+
+type Stripe_Order {
+  """
+  A positive integer in the smallest currency unit (that is, 100 cents for $1.00, or 1 for ¥1, Japanese Yen being a zero-decimal currency) representing the total amount for the order.
+  """
+  amount: Int
+
+  """The total amount that was returned to the customer."""
+  amount_returned: Int
+
+  """ID of the Connect Application that created the order."""
+  application: String
+
+  """
+  A fee in cents that will be applied to the order and transferred to the application owner’s Stripe account. The request must be made with an OAuth key or the Stripe-Account header in order to take an application fee. For more information, see the application fees documentation.
+  """
+  application_fee: Int
+  charge: Stripe_OrderChargeProperty
+
+  """
+  Time at which the object was created. Measured in seconds since the Unix epoch.
+  """
+  created: Int
+
+  """
+  Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
+  """
+  currency: String
+  customer: Stripe_OrderCustomerProperty
+
+  """The email address of the customer placing the order."""
+  email: String
+
+  """External coupon code to load for this order."""
+  external_coupon_code: String
+
+  """Unique identifier for the object."""
+  id: String
+
+  """
+  List of items constituting the order. An order can have up to 25 items.
+  """
+  items: [Stripe_OrderItem]
+
+  """
+  Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode.
+  """
+  livemode: Boolean
+
+  """
+  Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format.
+  """
+  metadata: JSONObject
+
+  """
+  String representing the object's type. Objects of the same type share the same value.
+  """
+  object: Stripe_OrderObjectProperty
+
+  """A list of returns that have taken place for this order."""
+  returns: Stripe_OrderReturnsProperty
+
+  """
+  The shipping method that is currently selected for this order, if any. If present, it is equal to one of the `id`s of shipping methods in the `shipping_methods` array. At order creation time, if there are multiple shipping methods, Stripe will automatically selected the first method.
+  """
+  selected_shipping_method: String
+  shipping: Stripe_Shipping
+
+  """
+  A list of supported shipping methods for this order. The desired shipping method can be specified either by updating the order, or when paying it.
+  """
+  shipping_methods: [Stripe_ShippingMethod]
+
+  """
+  Current order status. One of `created`, `paid`, `canceled`, `fulfilled`, or `returned`. More details in the [Orders Guide](https://stripe.com/docs/orders/guide#understanding-order-statuses).
+  """
+  status: String
+  status_transitions: Stripe_StatusTransitions
+
+  """
+  Time at which the object was last updated. Measured in seconds since the Unix epoch.
+  """
+  updated: Int
+
+  """The user's order ID if it is different from the Stripe order ID."""
+  upstream_id: String
+}
+
+union Stripe_OrderChargeProperty = WrappedString | Stripe_Charge
+
+union Stripe_OrderCustomerProperty = WrappedString | Stripe_Customer | Stripe_DeletedCustomer
+
+type Stripe_OrderItem {
+  """
+  A positive integer in the smallest currency unit (that is, 100 cents for $1.00, or 1 for ¥1, Japanese Yen being a zero-decimal currency) representing the total amount for the line item.
+  """
+  amount: Int
+
+  """
+  Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
+  """
+  currency: String
+
+  """
+  Description of the line item, meant to be displayable to the user (e.g., `"Express shipping"`).
+  """
+  description: String
+
+  """
+  String representing the object's type. Objects of the same type share the same value.
+  """
+  object: Stripe_OrderItemObjectProperty
+  parent: Stripe_OrderItemParentProperty
+
+  """
+  A positive integer representing the number of instances of `parent` that are included in this order item. Applicable/present only if `type` is `sku`.
+  """
+  quantity: Int
+
+  """The type of line item. One of `sku`, `tax`, `shipping`, or `discount`."""
+  type: String
+}
+
+enum Stripe_OrderItemObjectProperty {
+  order_item
+}
+
+union Stripe_OrderItemParentProperty = WrappedString | Stripe_Sku
+
+type Stripe_Sku {
+  """Whether the SKU is available for purchase."""
+  active: Boolean
+
+  """
+  A dictionary of attributes and values for the attributes defined by the product. If, for example, a product's attributes are `["size", "gender"]`, a valid SKU has the following dictionary of attributes: `{"size": "Medium", "gender": "Unisex"}`.
+  """
+  attributes: JSONObject
+
+  """
+  Time at which the object was created. Measured in seconds since the Unix epoch.
+  """
+  created: Int
+
+  """
+  Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
+  """
+  currency: String
+
+  """Unique identifier for the object."""
+  id: String
+
+  """
+  The URL of an image for this SKU, meant to be displayable to the customer.
+  """
+  image: String
+  inventory: Stripe_SkuInventory
+
+  """
+  Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode.
+  """
+  livemode: Boolean
+
+  """
+  Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format.
+  """
+  metadata: JSONObject
+
+  """
+  String representing the object's type. Objects of the same type share the same value.
+  """
+  object: Stripe_SkuObjectProperty
+  package_dimensions: Stripe_PackageDimensions
+
+  """
+  The cost of the item as a positive integer in the smallest currency unit (that is, 100 cents to charge $1.00, or 100 to charge ¥100, Japanese Yen being a zero-decimal currency).
+  """
+  price: Int
+  product: Stripe_SkuProductProperty
+
+  """
+  Time at which the object was last updated. Measured in seconds since the Unix epoch.
+  """
+  updated: Int
+}
+
+type Stripe_SkuInventory {
+  """
+  The count of inventory available. Will be present if and only if `type` is `finite`.
+  """
+  quantity: Int
+
+  """
+  Inventory type. Possible values are `finite`, `bucket` (not quantified), and `infinite`.
+  """
+  type: String
+
+  """
+  An indicator of the inventory available. Possible values are `in_stock`, `limited`, and `out_of_stock`. Will be present if and only if `type` is `bucket`.
+  """
+  value: String
+}
+
+enum Stripe_SkuObjectProperty {
+  sku
+}
+
+union Stripe_SkuProductProperty = WrappedString | Stripe_Product
+
+enum Stripe_OrderObjectProperty {
+  order
+}
+
+"""A list of returns that have taken place for this order."""
+type Stripe_OrderReturnsProperty {
+  """Details about each object."""
+  data: [Stripe_OrderReturn!]!
+
+  """
+  True if this list has another page of items after this one that can be fetched.
+  """
+  has_more: Boolean!
+
+  """
+  String representing the object's type. Objects of the same type share the same value. Always has the value `list`.
+  """
+  object: Stripe_OrderReturnsObjectProperty!
+
+  """The URL where this list can be accessed."""
+  url: String!
+}
+
+type Stripe_OrderReturn {
+  """
+  A positive integer in the smallest currency unit (that is, 100 cents for $1.00, or 1 for ¥1, Japanese Yen being a zero-decimal currency) representing the total amount for the returned line item.
+  """
+  amount: Int
+
+  """
+  Time at which the object was created. Measured in seconds since the Unix epoch.
+  """
+  created: Int
+
+  """
+  Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
+  """
+  currency: String
+
+  """Unique identifier for the object."""
+  id: String
+
+  """The items included in this order return."""
+  items: [Stripe_OrderItem]
+
+  """
+  Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode.
+  """
+  livemode: Boolean
+
+  """
+  String representing the object's type. Objects of the same type share the same value.
+  """
+  object: Stripe_OrderReturnObjectProperty
+  order: Stripe_OrderReturnOrderProperty
+  refund: Stripe_OrderReturnRefundProperty
+}
+
+enum Stripe_OrderReturnObjectProperty {
+  order_return
+}
+
+union Stripe_OrderReturnOrderProperty = WrappedString | Stripe_Order
+
+union Stripe_OrderReturnRefundProperty = WrappedString | Stripe_Refund
+
+enum Stripe_OrderReturnsObjectProperty {
+  list
+}
+
+type Stripe_ShippingMethod {
+  """
+  A positive integer in the smallest currency unit (that is, 100 cents for $1.00, or 1 for ¥1, Japanese Yen being a zero-decimal currency) representing the total amount for the line item.
+  """
+  amount: Int
+
+  """
+  Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
+  """
+  currency: String
+  delivery_estimate: Stripe_DeliveryEstimate
+
+  """
+  An arbitrary string attached to the object. Often useful for displaying to users.
+  """
+  description: String
+
+  """Unique identifier for the object."""
+  id: String
+}
+
+type Stripe_DeliveryEstimate {
+  """
+  If `type` is `"exact"`, `date` will be the expected delivery date in the format YYYY-MM-DD.
+  """
+  date: String
+
+  """
+  If `type` is `"range"`, `earliest` will be be the earliest delivery date in the format YYYY-MM-DD.
+  """
+  earliest: String
+
+  """
+  If `type` is `"range"`, `latest` will be the latest delivery date in the format YYYY-MM-DD.
+  """
+  latest: String
+
+  """The type of estimate. Must be either `"range"` or `"exact"`."""
+  type: String
+}
+
+type Stripe_StatusTransitions {
+  """The time that the order was canceled."""
+  canceled: Int
+
+  """The time that the order was fulfilled."""
+  fulfiled: Int
+
+  """The time that the order was paid."""
+  paid: Int
+
+  """The time that the order was returned."""
+  returned: Int
+}
+
+type Stripe_ChargeOutcome {
+  """
+  Possible values are `approved_by_network`, `declined_by_network`, `not_sent_to_network`, and `reversed_after_approval`. The value `reversed_after_approval` indicates the payment was [blocked by Stripe](https://stripe.com/docs/declines#blocked-payments) after bank authorization, and may temporarily appear as "pending" on a cardholder's statement.
+  """
+  network_status: String
+
+  """
+  An enumerated value providing a more detailed explanation of the outcome's `type`. Charges blocked by Radar's default block rule have the value `highest_risk_level`. Charges placed in review by Radar's default review rule have the value `elevated_risk_level`. Charges authorized, blocked, or placed in review by custom rules have the value `rule`. See [understanding declines](https://stripe.com/docs/declines) for more details.
+  """
+  reason: String
+
+  """
+  Stripe Radar's evaluation of the riskiness of the payment. Possible values for evaluated payments are `normal`, `elevated`, `highest`. For non-card payments, and card-based payments predating the public assignment of risk levels, this field will have the value `not_assessed`. In the event of an error in the evaluation, this field will have the value `unknown`. This field is only available with Radar.
+  """
+  risk_level: String
+
+  """
+  Stripe Radar's evaluation of the riskiness of the payment. Possible values for evaluated payments are between 0 and 100. For non-card payments, card-based payments predating the public assignment of risk scores, or in the event of an error during evaluation, this field will not be present. This field is only available with Radar for Fraud Teams.
+  """
+  risk_score: Int
+  rule: Stripe_ChargeOutcomeRuleProperty
+
+  """
+  A human-readable description of the outcome type and reason, designed for you (the recipient of the payment), not your customer.
+  """
+  seller_message: String
+
+  """
+  Possible values are `authorized`, `manual_review`, `issuer_declined`, `blocked`, and `invalid`. See [understanding declines](https://stripe.com/docs/declines) and [Radar reviews](https://stripe.com/docs/radar/reviews) for details.
+  """
+  type: String
+}
+
+union Stripe_ChargeOutcomeRuleProperty = WrappedString | Stripe_Rule
+
+type Stripe_Rule {
+  """The action taken on the payment."""
+  action: String
+
+  """Unique identifier for the object."""
+  id: String
+
+  """The predicate to evaluate the payment against."""
+  predicate: String
+}
+
+union Stripe_ChargePaymentIntentProperty = WrappedString | Stripe_PaymentIntent
+
+type Stripe_PaymentMethodDetails {
+  ach_credit_transfer: Stripe_PaymentMethodDetailsAchCreditTransfer
+  ach_debit: Stripe_PaymentMethodDetailsAchDebit
+  acss_debit: Stripe_PaymentMethodDetailsAcssDebit
+  afterpay_clearpay: Stripe_PaymentMethodDetailsAfterpayClearpay
+  alipay: Stripe_PaymentFlowsPrivatePaymentMethodsAlipayDetails
+  au_becs_debit: Stripe_PaymentMethodDetailsAuBecsDebit
+  bacs_debit: Stripe_PaymentMethodDetailsBacsDebit
+  bancontact: Stripe_PaymentMethodDetailsBancontact
+  boleto: Stripe_PaymentMethodDetailsBoleto
+  card: Stripe_PaymentMethodDetailsCard
+  card_present: Stripe_PaymentMethodDetailsCardPresent
+  eps: Stripe_PaymentMethodDetailsEps
+  fpx: Stripe_PaymentMethodDetailsFpx
+  giropay: Stripe_PaymentMethodDetailsGiropay
+  grabpay: Stripe_PaymentMethodDetailsGrabpay
+  ideal: Stripe_PaymentMethodDetailsIdeal
+  interac_present: Stripe_PaymentMethodDetailsInteracPresent
+  klarna: Stripe_PaymentMethodDetailsKlarna
+  multibanco: Stripe_PaymentMethodDetailsMultibanco
+  oxxo: Stripe_PaymentMethodDetailsOxxo
+  p24: Stripe_PaymentMethodDetailsP24
+  sepa_debit: Stripe_PaymentMethodDetailsSepaDebit
+  sofort: Stripe_PaymentMethodDetailsSofort
+  stripe_account: Stripe_PaymentMethodDetailsStripeAccount
+
+  """
+  The type of transaction-specific details of the payment method used in the payment, one of `ach_credit_transfer`, `ach_debit`, `acss_debit`, `alipay`, `au_becs_debit`, `bancontact`, `card`, `card_present`, `eps`, `giropay`, `ideal`, `klarna`, `multibanco`, `p24`, `sepa_debit`, `sofort`, `stripe_account`, or `wechat`.
+  An additional hash is included on `payment_method_details` with a name matching this value.
+  It contains information specific to the payment method.
+  """
+  type: String
+  wechat: Stripe_PaymentMethodDetailsWechat
+  wechat_pay: Stripe_PaymentMethodDetailsWechatPay
+}
+
+type Stripe_PaymentMethodDetailsAchCreditTransfer {
+  """Account number to transfer funds to."""
+  account_number: String
+
+  """Name of the bank associated with the routing number."""
+  bank_name: String
+
+  """Routing transit number for the bank account to transfer funds to."""
+  routing_number: String
+
+  """SWIFT code of the bank associated with the routing number."""
+  swift_code: String
+}
+
+type Stripe_PaymentMethodDetailsAchDebit {
+  """
+  Type of entity that holds the account. This can be either `individual` or `company`.
+  """
+  account_holder_type: Stripe_PaymentMethodDetailsAchDebitAccountHolderTypeProperty
+
+  """Name of the bank associated with the bank account."""
+  bank_name: String
+
+  """
+  Two-letter ISO code representing the country the bank account is located in.
+  """
+  country: String
+
+  """
+  Uniquely identifies this particular bank account. You can use this attribute to check whether two bank accounts are the same.
+  """
+  fingerprint: String
+
+  """Last four digits of the bank account number."""
+  last4: String
+
+  """Routing transit number of the bank account."""
+  routing_number: String
+}
+
+enum Stripe_PaymentMethodDetailsAchDebitAccountHolderTypeProperty {
+  company
+  individual
+}
+
+type Stripe_PaymentMethodDetailsAcssDebit {
+  """Name of the bank associated with the bank account."""
+  bank_name: String
+
+  """
+  Uniquely identifies this particular bank account. You can use this attribute to check whether two bank accounts are the same.
+  """
+  fingerprint: String
+
+  """Institution number of the bank account"""
+  institution_number: String
+
+  """Last four digits of the bank account number."""
+  last4: String
+
+  """ID of the mandate used to make this payment."""
+  mandate: String
+
+  """Transit number of the bank account."""
+  transit_number: String
+}
+
+type Stripe_PaymentMethodDetailsAfterpayClearpay {
+  """Order identifier shown to the merchant in Afterpay’s online portal."""
+  reference: String
+}
+
+type Stripe_PaymentFlowsPrivatePaymentMethodsAlipayDetails {
+  """
+  Uniquely identifies this particular Alipay account. You can use this attribute to check whether two Alipay accounts are the same.
+  """
+  fingerprint: String
+
+  """Transaction ID of this particular Alipay transaction."""
+  transaction_id: String
+}
+
+type Stripe_PaymentMethodDetailsAuBecsDebit {
+  """Bank-State-Branch number of the bank account."""
+  bsb_number: String
+
+  """
+  Uniquely identifies this particular bank account. You can use this attribute to check whether two bank accounts are the same.
+  """
+  fingerprint: String
+
+  """Last four digits of the bank account number."""
+  last4: String
+
+  """ID of the mandate used to make this payment."""
+  mandate: String
+}
+
+type Stripe_PaymentMethodDetailsBacsDebit {
+  """
+  Uniquely identifies this particular bank account. You can use this attribute to check whether two bank accounts are the same.
+  """
+  fingerprint: String
+
+  """Last four digits of the bank account number."""
+  last4: String
+
+  """ID of the mandate used to make this payment."""
+  mandate: String
+
+  """Sort code of the bank account. (e.g., `10-20-30`)"""
+  sort_code: String
+}
+
+type Stripe_PaymentMethodDetailsBancontact {
+  """Bank code of bank associated with the bank account."""
+  bank_code: String
+
+  """Name of the bank associated with the bank account."""
+  bank_name: String
+
+  """Bank Identifier Code of the bank associated with the bank account."""
+  bic: String
+  generated_sepa_debit: Stripe_PaymentMethodDetailsBancontactGeneratedSepaDebitProperty
+  generated_sepa_debit_mandate: Stripe_PaymentMethodDetailsBancontactGeneratedSepaDebitMandateProperty
+
+  """Last four characters of the IBAN."""
+  iban_last4: String
+
+  """
+  Preferred language of the Bancontact authorization page that the customer is redirected to.
+  Can be one of `en`, `de`, `fr`, or `nl`
+  """
+  preferred_language: Stripe_PaymentMethodDetailsBancontactPreferredLanguageProperty
+
+  """
+  Owner's verified full name. Values are verified or provided by Bancontact directly
+  (if supported) at the time of authorization or settlement. They cannot be set or mutated.
+  """
+  verified_name: String
+}
+
+union Stripe_PaymentMethodDetailsBancontactGeneratedSepaDebitProperty = WrappedString | Stripe_PaymentMethod
+
+union Stripe_PaymentMethodDetailsBancontactGeneratedSepaDebitMandateProperty = WrappedString | Stripe_Mandate
+
+enum Stripe_PaymentMethodDetailsBancontactPreferredLanguageProperty {
+  de
+  en
+  fr
+  nl
+}
+
+type Stripe_PaymentMethodDetailsBoleto {
+  """Uniquely identifies this customer tax_id (CNPJ or CPF)"""
+  tax_id: String
+}
+
+type Stripe_PaymentMethodDetailsCard {
+  """
+  Card brand. Can be `amex`, `diners`, `discover`, `jcb`, `mastercard`, `unionpay`, `visa`, or `unknown`.
+  """
+  brand: String
+  checks: Stripe_PaymentMethodDetailsCardChecks
+
+  """
+  Two-letter ISO code representing the country of the card. You could use this attribute to get a sense of the international breakdown of cards you've collected.
+  """
+  country: String
+
+  """Two-digit number representing the card's expiration month."""
+  exp_month: Int
+
+  """Four-digit number representing the card's expiration year."""
+  exp_year: Int
+
+  """
+  Uniquely identifies this particular card number. You can use this attribute to check whether two customers who’ve signed up with you are using the same card number, for example. For payment methods that tokenize card information (Apple Pay, Google Pay), the tokenized number might be provided instead of the underlying card number.
+  
+  *Starting May 1, 2021, card fingerprint in India for Connect will change to allow two fingerprints for the same card --- one for India and one for the rest of the world.*
+  """
+  fingerprint: String
+
+  """Card funding type. Can be `credit`, `debit`, `prepaid`, or `unknown`."""
+  funding: String
+  installments: Stripe_PaymentMethodDetailsCardInstallments
+
+  """The last four digits of the card."""
+  last4: String
+
+  """
+  Identifies which network this charge was processed on. Can be `amex`, `cartes_bancaires`, `diners`, `discover`, `interac`, `jcb`, `mastercard`, `unionpay`, `visa`, or `unknown`.
+  """
+  network: String
+  three_d_secure: Stripe_ThreeDSecureDetails
+  wallet: Stripe_PaymentMethodDetailsCardWallet
+}
+
+type Stripe_PaymentMethodDetailsCardChecks {
+  """
+  If a address line1 was provided, results of the check, one of `pass`, `fail`, `unavailable`, or `unchecked`.
+  """
+  address_line1_check: String
+
+  """
+  If a address postal code was provided, results of the check, one of `pass`, `fail`, `unavailable`, or `unchecked`.
+  """
+  address_postal_code_check: String
+
+  """
+  If a CVC was provided, results of the check, one of `pass`, `fail`, `unavailable`, or `unchecked`.
+  """
+  cvc_check: String
+}
+
+type Stripe_PaymentMethodDetailsCardInstallments {
+  plan: Stripe_PaymentMethodDetailsCardInstallmentsPlan
+}
+
+type Stripe_PaymentMethodDetailsCardInstallmentsPlan {
+  """
+  For `fixed_count` installment plans, this is the number of installment payments your customer will make to their credit card.
+  """
+  count: Int
+
+  """
+  For `fixed_count` installment plans, this is the interval between installment payments your customer will make to their credit card.
+  One of `month`.
+  """
+  interval: Stripe_PaymentMethodDetailsCardInstallmentsPlanIntervalProperty
+
+  """Type of installment plan, one of `fixed_count`."""
+  type: Stripe_PaymentMethodDetailsCardInstallmentsPlanTypeProperty
+}
+
+enum Stripe_PaymentMethodDetailsCardInstallmentsPlanIntervalProperty {
+  month
+}
+
+enum Stripe_PaymentMethodDetailsCardInstallmentsPlanTypeProperty {
+  fixed_count
+}
+
+type Stripe_PaymentMethodDetailsCardWallet {
+  amex_express_checkout: Stripe_PaymentMethodDetailsCardWalletAmexExpressCheckout
+  apple_pay: Stripe_PaymentMethodDetailsCardWalletApplePay
+
+  """
+  (For tokenized numbers only.) The last four digits of the device account number.
+  """
+  dynamic_last4: String
+  google_pay: Stripe_PaymentMethodDetailsCardWalletGooglePay
+  masterpass: Stripe_PaymentMethodDetailsCardWalletMasterpass
+  samsung_pay: Stripe_PaymentMethodDetailsCardWalletSamsungPay
+
+  """
+  The type of the card wallet, one of `amex_express_checkout`, `apple_pay`, `google_pay`, `masterpass`, `samsung_pay`, or `visa_checkout`. An additional hash is included on the Wallet subhash with a name matching this value. It contains additional information specific to the card wallet type.
+  """
+  type: Stripe_PaymentMethodDetailsCardWalletTypeProperty
+  visa_checkout: Stripe_PaymentMethodDetailsCardWalletVisaCheckout
+}
+
+type Stripe_PaymentMethodDetailsCardWalletAmexExpressCheckout {
+  result: JSONObject
+}
+
+type Stripe_PaymentMethodDetailsCardWalletApplePay {
+  result: JSONObject
+}
+
+type Stripe_PaymentMethodDetailsCardWalletGooglePay {
+  result: JSONObject
+}
+
+type Stripe_PaymentMethodDetailsCardWalletMasterpass {
+  billing_address: Stripe_Address
+
+  """
+  Owner's verified email. Values are verified or provided by the wallet directly (if supported) at the time of authorization or settlement. They cannot be set or mutated.
+  """
+  email: String
+
+  """
+  Owner's verified full name. Values are verified or provided by the wallet directly (if supported) at the time of authorization or settlement. They cannot be set or mutated.
+  """
+  name: String
+  shipping_address: Stripe_Address
+}
+
+type Stripe_PaymentMethodDetailsCardWalletSamsungPay {
+  result: JSONObject
+}
+
+enum Stripe_PaymentMethodDetailsCardWalletTypeProperty {
+  amex_express_checkout
+  apple_pay
+  google_pay
+  masterpass
+  samsung_pay
+  visa_checkout
+}
+
+type Stripe_PaymentMethodDetailsCardWalletVisaCheckout {
+  billing_address: Stripe_Address
+
+  """
+  Owner's verified email. Values are verified or provided by the wallet directly (if supported) at the time of authorization or settlement. They cannot be set or mutated.
+  """
+  email: String
+
+  """
+  Owner's verified full name. Values are verified or provided by the wallet directly (if supported) at the time of authorization or settlement. They cannot be set or mutated.
+  """
+  name: String
+  shipping_address: Stripe_Address
+}
+
+type Stripe_PaymentMethodDetailsEps {
+  """
+  The customer's bank. Should be one of `arzte_und_apotheker_bank`, `austrian_anadi_bank_ag`, `bank_austria`, `bankhaus_carl_spangler`, `bankhaus_schelhammer_und_schattera_ag`, `bawag_psk_ag`, `bks_bank_ag`, `brull_kallmus_bank_ag`, `btv_vier_lander_bank`, `capital_bank_grawe_gruppe_ag`, `dolomitenbank`, `easybank_ag`, `erste_bank_und_sparkassen`, `hypo_alpeadriabank_international_ag`, `hypo_noe_lb_fur_niederosterreich_u_wien`, `hypo_oberosterreich_salzburg_steiermark`, `hypo_tirol_bank_ag`, `hypo_vorarlberg_bank_ag`, `hypo_bank_burgenland_aktiengesellschaft`, `marchfelder_bank`, `oberbank_ag`, `raiffeisen_bankengruppe_osterreich`, `schoellerbank_ag`, `sparda_bank_wien`, `volksbank_gruppe`, `volkskreditbank_ag`, or `vr_bank_braunau`.
+  """
+  bank: Stripe_PaymentMethodDetailsEpsBankProperty
+
+  """
+  Owner's verified full name. Values are verified or provided by EPS directly
+  (if supported) at the time of authorization or settlement. They cannot be set or mutated.
+  EPS rarely provides this information so the attribute is usually empty.
+  """
+  verified_name: String
+}
+
+enum Stripe_PaymentMethodDetailsEpsBankProperty {
+  arzte_und_apotheker_bank
+  austrian_anadi_bank_ag
+  bank_austria
+  bankhaus_carl_spangler
+  bankhaus_schelhammer_und_schattera_ag
+  bawag_psk_ag
+  bks_bank_ag
+  brull_kallmus_bank_ag
+  btv_vier_lander_bank
+  capital_bank_grawe_gruppe_ag
+  dolomitenbank
+  easybank_ag
+  erste_bank_und_sparkassen
+  hypo_alpeadriabank_international_ag
+  hypo_bank_burgenland_aktiengesellschaft
+  hypo_noe_lb_fur_niederosterreich_u_wien
+  hypo_oberosterreich_salzburg_steiermark
+  hypo_tirol_bank_ag
+  hypo_vorarlberg_bank_ag
+  marchfelder_bank
+  oberbank_ag
+  raiffeisen_bankengruppe_osterreich
+  schoellerbank_ag
+  sparda_bank_wien
+  volksbank_gruppe
+  volkskreditbank_ag
+  vr_bank_braunau
+}
+
+type Stripe_PaymentMethodDetailsFpx {
+  """
+  The customer's bank. Can be one of `affin_bank`, `alliance_bank`, `ambank`, `bank_islam`, `bank_muamalat`, `bank_rakyat`, `bsn`, `cimb`, `hong_leong_bank`, `hsbc`, `kfh`, `maybank2u`, `ocbc`, `public_bank`, `rhb`, `standard_chartered`, `uob`, `deutsche_bank`, `maybank2e`, or `pb_enterprise`.
+  """
+  bank: Stripe_PaymentMethodDetailsFpxBankProperty
+
+  """
+  Unique transaction id generated by FPX for every request from the merchant
+  """
+  transaction_id: String
+}
+
+enum Stripe_PaymentMethodDetailsFpxBankProperty {
+  affin_bank
+  alliance_bank
+  ambank
+  bank_islam
+  bank_muamalat
+  bank_rakyat
+  bsn
+  cimb
+  deutsche_bank
+  hong_leong_bank
+  hsbc
+  kfh
+  maybank2e
+  maybank2u
+  ocbc
+  pb_enterprise
+  public_bank
+  rhb
+  standard_chartered
+  uob
+}
+
+type Stripe_PaymentMethodDetailsGiropay {
+  """Bank code of bank associated with the bank account."""
+  bank_code: String
+
+  """Name of the bank associated with the bank account."""
+  bank_name: String
+
+  """Bank Identifier Code of the bank associated with the bank account."""
+  bic: String
+
+  """
+  Owner's verified full name. Values are verified or provided by Giropay directly
+  (if supported) at the time of authorization or settlement. They cannot be set or mutated.
+  Giropay rarely provides this information so the attribute is usually empty.
+  """
+  verified_name: String
+}
+
+type Stripe_PaymentMethodDetailsGrabpay {
+  """Unique transaction id generated by GrabPay"""
+  transaction_id: String
+}
+
+type Stripe_PaymentMethodDetailsIdeal {
+  """
+  The customer's bank. Can be one of `abn_amro`, `asn_bank`, `bunq`, `handelsbanken`, `ing`, `knab`, `moneyou`, `rabobank`, `regiobank`, `revolut`, `sns_bank`, `triodos_bank`, or `van_lanschot`.
+  """
+  bank: Stripe_PaymentMethodDetailsIdealBankProperty
+
+  """The Bank Identifier Code of the customer's bank."""
+  bic: Stripe_PaymentMethodDetailsIdealBicProperty
+  generated_sepa_debit: Stripe_PaymentMethodDetailsIdealGeneratedSepaDebitProperty
+  generated_sepa_debit_mandate: Stripe_PaymentMethodDetailsIdealGeneratedSepaDebitMandateProperty
+
+  """Last four characters of the IBAN."""
+  iban_last4: String
+
+  """
+  Owner's verified full name. Values are verified or provided by iDEAL directly
+  (if supported) at the time of authorization or settlement. They cannot be set or mutated.
+  """
+  verified_name: String
+}
+
+enum Stripe_PaymentMethodDetailsIdealBankProperty {
+  abn_amro
+  asn_bank
+  bunq
+  handelsbanken
+  ing
+  knab
+  moneyou
+  rabobank
+  regiobank
+  revolut
+  sns_bank
+  triodos_bank
+  van_lanschot
+}
+
+enum Stripe_PaymentMethodDetailsIdealBicProperty {
+  ABNANL2A
+  ASNBNL21
+  BUNQNL2A
+  FVLBNL22
+  HANDNL2A
+  INGBNL2A
+  KNABNL2H
+  MOYONL21
+  RABONL2U
+  RBRBNL21
+  REVOLT21
+  SNSBNL2A
+  TRIONL2U
+}
+
+union Stripe_PaymentMethodDetailsIdealGeneratedSepaDebitProperty = WrappedString | Stripe_PaymentMethod
+
+union Stripe_PaymentMethodDetailsIdealGeneratedSepaDebitMandateProperty = WrappedString | Stripe_Mandate
+
+type Stripe_PaymentMethodDetailsInteracPresent {
+  """Card brand. Can be `interac`, `mastercard` or `visa`."""
+  brand: String
+
+  """
+  The cardholder name as read from the card, in [ISO 7813](https://en.wikipedia.org/wiki/ISO/IEC_7813) format. May include alphanumeric characters, special characters and first/last name separator (`/`).
+  """
+  cardholder_name: String
+
+  """
+  Two-letter ISO code representing the country of the card. You could use this attribute to get a sense of the international breakdown of cards you've collected.
+  """
+  country: String
+
+  """Authorization response cryptogram."""
+  emv_auth_data: String
+
+  """Two-digit number representing the card's expiration month."""
+  exp_month: Int
+
+  """Four-digit number representing the card's expiration year."""
+  exp_year: Int
+
+  """
+  Uniquely identifies this particular card number. You can use this attribute to check whether two customers who’ve signed up with you are using the same card number, for example. For payment methods that tokenize card information (Apple Pay, Google Pay), the tokenized number might be provided instead of the underlying card number.
+  
+  *Starting May 1, 2021, card fingerprint in India for Connect will change to allow two fingerprints for the same card --- one for India and one for the rest of the world.*
+  """
+  fingerprint: String
+
+  """Card funding type. Can be `credit`, `debit`, `prepaid`, or `unknown`."""
+  funding: String
+
+  """
+  ID of a card PaymentMethod generated from the card_present PaymentMethod that may be attached to a Customer for future transactions. Only present if it was possible to generate a card PaymentMethod.
+  """
+  generated_card: String
+
+  """The last four digits of the card."""
+  last4: String
+
+  """
+  Identifies which network this charge was processed on. Can be `amex`, `cartes_bancaires`, `diners`, `discover`, `interac`, `jcb`, `mastercard`, `unionpay`, `visa`, or `unknown`.
+  """
+  network: String
+
+  """
+  EMV tag 5F2D. Preferred languages specified by the integrated circuit chip.
+  """
+  preferred_locales: [String]
+
+  """How card details were read in this transaction."""
+  read_method: Stripe_PaymentMethodDetailsInteracPresentReadMethodProperty
+  receipt: Stripe_PaymentMethodDetailsInteracPresentReceipt
+}
+
+enum Stripe_PaymentMethodDetailsInteracPresentReadMethodProperty {
+  contact_emv
+  contactless_emv
+  contactless_magstripe_mode
+  magnetic_stripe_fallback
+  magnetic_stripe_track2
+}
+
+type Stripe_PaymentMethodDetailsInteracPresentReceipt {
+  """The type of account being debited or credited"""
+  account_type: Stripe_PaymentMethodDetailsInteracPresentReceiptAccountTypeProperty
+
+  """EMV tag 9F26, cryptogram generated by the integrated circuit chip."""
+  application_cryptogram: String
+
+  """Mnenomic of the Application Identifier."""
+  application_preferred_name: String
+
+  """Identifier for this transaction."""
+  authorization_code: String
+
+  """EMV tag 8A. A code returned by the card issuer."""
+  authorization_response_code: String
+
+  """How the cardholder verified ownership of the card."""
+  cardholder_verification_method: String
+
+  """
+  EMV tag 84. Similar to the application identifier stored on the integrated circuit chip.
+  """
+  dedicated_file_name: String
+
+  """The outcome of a series of EMV functions performed by the card reader."""
+  terminal_verification_results: String
+
+  """
+  An indication of various EMV functions performed during the transaction.
+  """
+  transaction_status_information: String
+}
+
+enum Stripe_PaymentMethodDetailsInteracPresentReceiptAccountTypeProperty {
+  checking
+  savings
+  unknown
+}
+
+type Stripe_PaymentMethodDetailsKlarna {
+  result: JSONObject
+}
+
+type Stripe_PaymentMethodDetailsMultibanco {
+  """Entity number associated with this Multibanco payment."""
+  entity: String
+
+  """Reference number associated with this Multibanco payment."""
+  reference: String
+}
+
+type Stripe_PaymentMethodDetailsOxxo {
+  """OXXO reference number"""
+  number: String
+}
+
+type Stripe_PaymentMethodDetailsP24 {
+  """
+  The customer's bank. Can be one of `ing`, `citi_handlowy`, `tmobile_usbugi_bankowe`, `plus_bank`, `etransfer_pocztowy24`, `banki_spbdzielcze`, `bank_nowy_bfg_sa`, `getin_bank`, `blik`, `noble_pay`, `ideabank`, `envelobank`, `santander_przelew24`, `nest_przelew`, `mbank_mtransfer`, `inteligo`, `pbac_z_ipko`, `bnp_paribas`, `credit_agricole`, `toyota_bank`, `bank_pekao_sa`, `volkswagen_bank`, `bank_millennium`, `alior_bank`, or `boz`.
+  """
+  bank: Stripe_PaymentMethodDetailsP24BankProperty
+
+  """Unique reference for this Przelewy24 payment."""
+  reference: String
+
+  """
+  Owner's verified full name. Values are verified or provided by Przelewy24 directly
+  (if supported) at the time of authorization or settlement. They cannot be set or mutated.
+  Przelewy24 rarely provides this information so the attribute is usually empty.
+  """
+  verified_name: String
+}
+
+enum Stripe_PaymentMethodDetailsP24BankProperty {
+  alior_bank
+  bank_millennium
+  bank_nowy_bfg_sa
+  bank_pekao_sa
+  banki_spbdzielcze
+  blik
+  bnp_paribas
+  boz
+  citi_handlowy
+  credit_agricole
+  envelobank
+  etransfer_pocztowy24
+  getin_bank
+  ideabank
+  ing
+  inteligo
+  mbank_mtransfer
+  nest_przelew
+  noble_pay
+  pbac_z_ipko
+  plus_bank
+  santander_przelew24
+  tmobile_usbugi_bankowe
+  toyota_bank
+  volkswagen_bank
+}
+
+type Stripe_PaymentMethodDetailsSepaDebit {
+  """Bank code of bank associated with the bank account."""
+  bank_code: String
+
+  """Branch code of bank associated with the bank account."""
+  branch_code: String
+
+  """
+  Two-letter ISO code representing the country the bank account is located in.
+  """
+  country: String
+
+  """
+  Uniquely identifies this particular bank account. You can use this attribute to check whether two bank accounts are the same.
+  """
+  fingerprint: String
+
+  """Last four characters of the IBAN."""
+  last4: String
+
+  """ID of the mandate used to make this payment."""
+  mandate: String
+}
+
+type Stripe_PaymentMethodDetailsSofort {
+  """Bank code of bank associated with the bank account."""
+  bank_code: String
+
+  """Name of the bank associated with the bank account."""
+  bank_name: String
+
+  """Bank Identifier Code of the bank associated with the bank account."""
+  bic: String
+
+  """
+  Two-letter ISO code representing the country the bank account is located in.
+  """
+  country: String
+  generated_sepa_debit: Stripe_PaymentMethodDetailsSofortGeneratedSepaDebitProperty
+  generated_sepa_debit_mandate: Stripe_PaymentMethodDetailsSofortGeneratedSepaDebitMandateProperty
+
+  """Last four characters of the IBAN."""
+  iban_last4: String
+
+  """
+  Preferred language of the SOFORT authorization page that the customer is redirected to.
+  Can be one of `de`, `en`, `es`, `fr`, `it`, `nl`, or `pl`
+  """
+  preferred_language: Stripe_PaymentMethodDetailsSofortPreferredLanguageProperty
+
+  """
+  Owner's verified full name. Values are verified or provided by SOFORT directly
+  (if supported) at the time of authorization or settlement. They cannot be set or mutated.
+  """
+  verified_name: String
+}
+
+union Stripe_PaymentMethodDetailsSofortGeneratedSepaDebitProperty = WrappedString | Stripe_PaymentMethod
+
+union Stripe_PaymentMethodDetailsSofortGeneratedSepaDebitMandateProperty = WrappedString | Stripe_Mandate
+
+enum Stripe_PaymentMethodDetailsSofortPreferredLanguageProperty {
+  de
+  en
+  es
+  fr
+  it
+  nl
+  pl
+}
+
+type Stripe_PaymentMethodDetailsStripeAccount {
+  result: JSONObject
+}
+
+type Stripe_PaymentMethodDetailsWechat {
+  result: JSONObject
+}
+
+type Stripe_PaymentMethodDetailsWechatPay {
+  """
+  Uniquely identifies this particular WeChat Pay account. You can use this attribute to check whether two WeChat accounts are the same.
+  """
+  fingerprint: String
+
+  """Transaction ID of this particular WeChat Pay transaction."""
+  transaction_id: String
+}
+
+"""A list of refunds that have been applied to the charge."""
+type Stripe_ChargeRefundsProperty {
+  """Details about each object."""
+  data: [Stripe_Refund!]!
+
+  """
+  True if this list has another page of items after this one that can be fetched.
+  """
+  has_more: Boolean!
+
+  """
+  String representing the object's type. Objects of the same type share the same value. Always has the value `list`.
+  """
+  object: Stripe_ChargeRefundsObjectProperty!
+
+  """The URL where this list can be accessed."""
+  url: String!
+}
+
+enum Stripe_ChargeRefundsObjectProperty {
+  list
+}
+
+union Stripe_ChargeReviewProperty = WrappedString | Stripe_Review
+
+type Stripe_Review {
+  """The ZIP or postal code of the card used, if applicable."""
+  billing_zip: String
+  charge: Stripe_ReviewChargeProperty
+
+  """
+  The reason the review was closed, or null if it has not yet been closed. One of `approved`, `refunded`, `refunded_as_fraud`, or `disputed`.
+  """
+  closed_reason: Stripe_ReviewClosedReasonProperty
+
+  """
+  Time at which the object was created. Measured in seconds since the Unix epoch.
+  """
+  created: Int
+
+  """Unique identifier for the object."""
+  id: String
+
+  """The IP address where the payment originated."""
+  ip_address: String
+  ip_address_location: Stripe_RadarReviewResourceLocation
+
+  """
+  Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode.
+  """
+  livemode: Boolean
+
+  """
+  String representing the object's type. Objects of the same type share the same value.
+  """
+  object: Stripe_ReviewObjectProperty
+
+  """If `true`, the review needs action."""
+  open: Boolean
+
+  """The reason the review was opened. One of `rule` or `manual`."""
+  opened_reason: Stripe_ReviewOpenedReasonProperty
+  payment_intent: Stripe_ReviewPaymentIntentProperty
+
+  """
+  The reason the review is currently open or closed. One of `rule`, `manual`, `approved`, `refunded`, `refunded_as_fraud`, or `disputed`.
+  """
+  reason: String
+  session: Stripe_RadarReviewResourceSession
+}
+
+union Stripe_ReviewChargeProperty = WrappedString | Stripe_Charge
+
+enum Stripe_ReviewClosedReasonProperty {
+  approved
+  disputed
+  refunded
+  refunded_as_fraud
+}
+
+type Stripe_RadarReviewResourceLocation {
+  """The city where the payment originated."""
+  city: String
+
+  """
+  Two-letter ISO code representing the country where the payment originated.
+  """
+  country: String
+
+  """The geographic latitude where the payment originated."""
+  latitude: Float
+
+  """The geographic longitude where the payment originated."""
+  longitude: Float
+
+  """The state/county/province/region where the payment originated."""
+  region: String
+}
+
+enum Stripe_ReviewObjectProperty {
+  review
+}
+
+enum Stripe_ReviewOpenedReasonProperty {
+  manual
+  rule
+}
+
+union Stripe_ReviewPaymentIntentProperty = WrappedString | Stripe_PaymentIntent
+
+type Stripe_RadarReviewResourceSession {
+  """The browser used in this browser session (e.g., `Chrome`)."""
+  browser: String
+
+  """
+  Information about the device used for the browser session (e.g., `Samsung SM-G930T`).
+  """
+  device: String
+
+  """The platform for the browser session (e.g., `Macintosh`)."""
+  platform: String
+
+  """The version for the browser session (e.g., `61.0.3163.100`)."""
+  version: String
+}
+
+union Stripe_ChargeSourceTransferProperty = WrappedString | Stripe_Transfer
+
+union Stripe_ChargeTransferProperty = WrappedString | Stripe_Transfer
+
+type Stripe_ChargeTransferData {
+  """
+  The amount transferred to the destination account, if specified. By default, the entire charge amount is transferred to the destination account.
+  """
+  amount: Int
+  destination: Stripe_ChargeTransferDataDestinationProperty
+}
+
+union Stripe_ChargeTransferDataDestinationProperty = WrappedString | Stripe_Account
+
+enum Stripe_PaymentIntentChargesObjectProperty {
+  list
+}
+
+enum Stripe_PaymentIntentConfirmationMethodProperty {
+  automatic
+  manual
+}
+
+union Stripe_PaymentIntentCustomerProperty = WrappedString | Stripe_Customer | Stripe_DeletedCustomer
+
+union Stripe_PaymentIntentInvoiceProperty = WrappedString | Stripe_Invoice
+
+type Stripe_PaymentIntentNextAction {
+  alipay_handle_redirect: Stripe_PaymentIntentNextActionAlipayHandleRedirect
+  boleto_display_details: Stripe_PaymentIntentNextActionBoleto
+  oxxo_display_details: Stripe_PaymentIntentNextActionDisplayOxxoDetails
+  redirect_to_url: Stripe_PaymentIntentNextActionRedirectToUrl
+
+  """
+  Type of the next action to perform, one of `redirect_to_url`, `use_stripe_sdk`, `alipay_handle_redirect`, or `oxxo_display_details`.
+  """
+  type: String
+
+  """
+  When confirming a PaymentIntent with Stripe.js, Stripe.js depends on the contents of this dictionary to invoke authentication flows. The shape of the contents is subject to change and is only intended to be used by Stripe.js.
+  """
+  use_stripe_sdk: JSONObject
+  verify_with_microdeposits: Stripe_PaymentIntentNextActionVerifyWithMicrodeposits
+  wechat_pay_display_qr_code: Stripe_PaymentIntentNextActionWechatPayDisplayQrCode
+  wechat_pay_redirect_to_android_app: Stripe_PaymentIntentNextActionWechatPayRedirectToAndroidApp
+  wechat_pay_redirect_to_ios_app: Stripe_PaymentIntentNextActionWechatPayRedirectToIosApp
+}
+
+type Stripe_PaymentIntentNextActionAlipayHandleRedirect {
+  """
+  The native data to be used with Alipay SDK you must redirect your customer to in order to authenticate the payment in an Android App.
+  """
+  native_data: String
+
+  """
+  The native URL you must redirect your customer to in order to authenticate the payment in an iOS App.
+  """
+  native_url: String
+
+  """
+  If the customer does not exit their browser while authenticating, they will be redirected to this specified URL after completion.
+  """
+  return_url: String
+
+  """
+  The URL you must redirect your customer to in order to authenticate the payment.
+  """
+  url: String
+}
+
+type Stripe_PaymentIntentNextActionBoleto {
+  """The timestamp after which the boleto expires."""
+  expires_at: Int
+
+  """
+  The URL to the hosted boleto voucher page, which allows customers to view the boleto voucher.
+  """
+  hosted_voucher_url: String
+
+  """The boleto number."""
+  number: String
+
+  """The URL to the downloadable boleto voucher PDF."""
+  pdf: String
+}
+
+type Stripe_PaymentIntentNextActionDisplayOxxoDetails {
+  """The timestamp after which the OXXO voucher expires."""
+  expires_after: Int
+
+  """
+  The URL for the hosted OXXO voucher page, which allows customers to view and print an OXXO voucher.
+  """
+  hosted_voucher_url: String
+
+  """OXXO reference number."""
+  number: String
+}
+
+type Stripe_PaymentIntentNextActionRedirectToUrl {
+  """
+  If the customer does not exit their browser while authenticating, they will be redirected to this specified URL after completion.
+  """
+  return_url: String
+
+  """
+  The URL you must redirect your customer to in order to authenticate the payment.
+  """
+  url: String
+}
+
+type Stripe_PaymentIntentNextActionVerifyWithMicrodeposits {
+  """The timestamp when the microdeposits are expected to land."""
+  arrival_date: Int
+
+  """
+  The URL for the hosted verification page, which allows customers to verify their bank account.
+  """
+  hosted_verification_url: String
+}
+
+type Stripe_PaymentIntentNextActionWechatPayDisplayQrCode {
+  """The data being used to generate QR code"""
+  data: String
+
+  """The base64 image data for a pre-generated QR code"""
+  image_data_url: String
+}
+
+type Stripe_PaymentIntentNextActionWechatPayRedirectToAndroidApp {
+  """app_id is the APP ID registered on WeChat open platform"""
+  app_id: String
+
+  """nonce_str is a random string"""
+  nonce_str: String
+
+  """package is static value"""
+  package: String
+
+  """an unique merchant ID assigned by Wechat Pay"""
+  partner_id: String
+
+  """an unique trading ID assigned by Wechat Pay"""
+  prepay_id: String
+
+  """A signature"""
+  sign: String
+
+  """Specifies the current time in epoch format"""
+  timestamp: String
+}
+
+type Stripe_PaymentIntentNextActionWechatPayRedirectToIosApp {
+  """An universal link that redirect to Wechat Pay APP"""
+  native_url: String
+}
+
+enum Stripe_PaymentIntentObjectProperty {
+  payment_intent
+}
+
+union Stripe_PaymentIntentOnBehalfOfProperty = WrappedString | Stripe_Account
+
+union Stripe_PaymentIntentPaymentMethodProperty = WrappedString | Stripe_PaymentMethod
+
+type Stripe_PaymentIntentPaymentMethodOptions {
+  acss_debit: Stripe_PaymentIntentPaymentMethodOptionsAcssDebit
+  afterpay_clearpay: Stripe_PaymentMethodOptionsAfterpayClearpay
+  alipay: Stripe_PaymentMethodOptionsAlipay
+  bancontact: Stripe_PaymentMethodOptionsBancontact
+  boleto: Stripe_PaymentMethodOptionsBoleto
+  card: Stripe_PaymentIntentPaymentMethodOptionsCard
+  card_present: Stripe_PaymentMethodOptionsCardPresent
+  ideal: Stripe_PaymentMethodOptionsIdeal
+  oxxo: Stripe_PaymentMethodOptionsOxxo
+  p24: Stripe_PaymentMethodOptionsP24
+  sepa_debit: Stripe_PaymentIntentPaymentMethodOptionsSepaDebit
+  sofort: Stripe_PaymentMethodOptionsSofort
+  wechat_pay: Stripe_PaymentMethodOptionsWechatPay
+}
+
+type Stripe_PaymentIntentPaymentMethodOptionsAcssDebit {
+  mandate_options: Stripe_PaymentIntentPaymentMethodOptionsMandateOptionsAcssDebit
+
+  """Bank account verification method."""
+  verification_method: Stripe_PaymentIntentPaymentMethodOptionsAcssDebitVerificationMethodProperty
+}
+
+type Stripe_PaymentIntentPaymentMethodOptionsMandateOptionsAcssDebit {
+  """A URL for custom mandate text"""
+  custom_mandate_url: String
+
+  """
+  Description of the interval. Only required if 'payment_schedule' parmeter is 'interval' or 'combined'.
+  """
+  interval_description: String
+
+  """Payment schedule for the mandate."""
+  payment_schedule: Stripe_PaymentIntentPaymentMethodOptionsMandateOptionsAcssDebitPaymentScheduleProperty
+
+  """Transaction type of the mandate."""
+  transaction_type: Stripe_PaymentIntentPaymentMethodOptionsMandateOptionsAcssDebitTransactionTypeProperty
+}
+
+enum Stripe_PaymentIntentPaymentMethodOptionsMandateOptionsAcssDebitPaymentScheduleProperty {
+  combined
+  interval
+  sporadic
+}
+
+enum Stripe_PaymentIntentPaymentMethodOptionsMandateOptionsAcssDebitTransactionTypeProperty {
+  business
+  personal
+}
+
+enum Stripe_PaymentIntentPaymentMethodOptionsAcssDebitVerificationMethodProperty {
+  automatic
+  instant
+  microdeposits
+}
+
+type Stripe_PaymentMethodOptionsAfterpayClearpay {
+  """
+  Order identifier shown to the merchant in Afterpay’s online portal. We recommend using a value that helps you answer any questions a customer might have about
+  the payment. The identifier is limited to 128 characters and may contain only letters, digits, underscores, backslashes and dashes.
+  """
+  reference: String
+}
+
+type Stripe_PaymentMethodOptionsAlipay {
+  result: JSONObject
+}
+
+type Stripe_PaymentMethodOptionsBancontact {
+  """
+  Preferred language of the Bancontact authorization page that the customer is redirected to.
+  """
+  preferred_language: Stripe_PaymentMethodOptionsBancontactPreferredLanguageProperty
+}
+
+enum Stripe_PaymentMethodOptionsBancontactPreferredLanguageProperty {
+  de
+  en
+  fr
+  nl
+}
+
+type Stripe_PaymentMethodOptionsBoleto {
+  """
+  The number of calendar days before a Boleto voucher expires. For example, if you create a Boleto voucher on Monday and you set expires_after_days to 2, the Boleto voucher will expire on Wednesday at 23:59 America/Sao_Paulo time.
+  """
+  expires_after_days: Int
+}
+
+type Stripe_PaymentIntentPaymentMethodOptionsCard {
+  installments: Stripe_PaymentMethodOptionsCardInstallments
+
+  """
+  Selected network to process this payment intent on. Depends on the available networks of the card attached to the payment intent. Can be only set confirm-time.
+  """
+  network: Stripe_PaymentIntentPaymentMethodOptionsCardNetworkProperty
+
+  """
+  We strongly recommend that you rely on our SCA Engine to automatically prompt your customers for authentication based on risk level and [other requirements](https://stripe.com/docs/strong-customer-authentication). However, if you wish to request 3D Secure based on logic from your own fraud engine, provide this option. Permitted values include: `automatic` or `any`. If not provided, defaults to `automatic`. Read our guide on [manually requesting 3D Secure](https://stripe.com/docs/payments/3d-secure#manual-three-ds) for more information on how this configuration interacts with Radar and our SCA Engine.
+  """
+  request_three_d_secure: Stripe_PaymentIntentPaymentMethodOptionsCardRequestThreeDSecureProperty
+}
+
+type Stripe_PaymentMethodOptionsCardInstallments {
+  """Installment plans that may be selected for this PaymentIntent."""
+  available_plans: [Stripe_PaymentMethodDetailsCardInstallmentsPlan]
+
+  """Whether Installments are enabled for this PaymentIntent."""
+  enabled: Boolean
+  plan: Stripe_PaymentMethodDetailsCardInstallmentsPlan
+}
+
+enum Stripe_PaymentIntentPaymentMethodOptionsCardNetworkProperty {
+  amex
+  cartes_bancaires
+  diners
+  discover
+  interac
+  jcb
+  mastercard
+  unionpay
+  unknown
+  visa
+}
+
+enum Stripe_PaymentIntentPaymentMethodOptionsCardRequestThreeDSecureProperty {
+  any
+  automatic
+  challenge_only
+}
+
+type Stripe_PaymentMethodOptionsCardPresent {
+  result: JSONObject
+}
+
+type Stripe_PaymentMethodOptionsIdeal {
+  result: JSONObject
+}
+
+type Stripe_PaymentMethodOptionsOxxo {
+  """
+  The number of calendar days before an OXXO invoice expires. For example, if you create an OXXO invoice on Monday and you set expires_after_days to 2, the OXXO invoice will expire on Wednesday at 23:59 America/Mexico_City time.
+  """
+  expires_after_days: Int
+}
+
+type Stripe_PaymentMethodOptionsP24 {
+  result: JSONObject
+}
+
+type Stripe_PaymentIntentPaymentMethodOptionsSepaDebit {
+  mandate_options: Stripe_PaymentIntentPaymentMethodOptionsMandateOptionsSepaDebit
+}
+
+type Stripe_PaymentIntentPaymentMethodOptionsMandateOptionsSepaDebit {
+  result: JSONObject
+}
+
+type Stripe_PaymentMethodOptionsSofort {
+  """
+  Preferred language of the SOFORT authorization page that the customer is redirected to.
+  """
+  preferred_language: Stripe_PaymentMethodOptionsSofortPreferredLanguageProperty
+}
+
+enum Stripe_PaymentMethodOptionsSofortPreferredLanguageProperty {
+  de
+  en
+  es
+  fr
+  it
+  nl
+  pl
+}
+
+type Stripe_PaymentMethodOptionsWechatPay {
+  """
+  The app ID registered with WeChat Pay. Only required when client is ios or android.
+  """
+  app_id: String
+
+  """The client type that the end customer will pay from"""
+  client: Stripe_PaymentMethodOptionsWechatPayClientProperty
+}
+
+enum Stripe_PaymentMethodOptionsWechatPayClientProperty {
+  android
+  ios
+  web
+}
+
+union Stripe_PaymentIntentReviewProperty = WrappedString | Stripe_Review
+
+enum Stripe_PaymentIntentSetupFutureUsageProperty {
+  off_session
+  on_session
+}
+
+enum Stripe_PaymentIntentStatusProperty {
+  canceled
+  processing
+  requires_action
+  requires_capture
+  requires_confirmation
+  requires_payment_method
+  succeeded
+}
+
+type Stripe_TransferData {
+  """
+  Amount intended to be collected by this PaymentIntent. A positive integer representing how much to charge in the [smallest currency unit](https://stripe.com/docs/currencies#zero-decimal) (e.g., 100 cents to charge $1.00 or 100 to charge ¥100, a zero-decimal currency). The minimum amount is $0.50 US or [equivalent in charge currency](https://stripe.com/docs/currencies#minimum-and-maximum-charge-amounts). The amount value supports up to eight digits (e.g., a value of 99999999 for a USD charge of $999,999.99).
+  """
+  amount: Int
+  destination: Stripe_TransferDataDestinationProperty
+}
+
+union Stripe_TransferDataDestinationProperty = WrappedString | Stripe_Account
+
+union Stripe_ApiErrorsSourceProperty = Stripe_BankAccount | Stripe_Card | Stripe_Source
+
+enum Stripe_ApiErrorsTypeProperty {
+  api_error
+  card_error
+  idempotency_error
+  invalid_request_error
+}
+
+union Stripe_SetupAttemptSetupIntentProperty = WrappedString | Stripe_SetupIntent
+
+type Stripe_Networks {
+  """All available networks for the card."""
+  available: [String]
+
+  """The preferred network for the card."""
+  preferred: String
+}
+
+type Stripe_ThreeDSecureUsage {
+  """Whether 3D Secure is supported on this card."""
+  supported: Boolean
+}
+
+type Stripe_PaymentMethodCardWallet {
+  amex_express_checkout: Stripe_PaymentMethodCardWalletAmexExpressCheckout
+  apple_pay: Stripe_PaymentMethodCardWalletApplePay
+
+  """
+  (For tokenized numbers only.) The last four digits of the device account number.
+  """
+  dynamic_last4: String
+  google_pay: Stripe_PaymentMethodCardWalletGooglePay
+  masterpass: Stripe_PaymentMethodCardWalletMasterpass
+  samsung_pay: Stripe_PaymentMethodCardWalletSamsungPay
+
+  """
+  The type of the card wallet, one of `amex_express_checkout`, `apple_pay`, `google_pay`, `masterpass`, `samsung_pay`, or `visa_checkout`. An additional hash is included on the Wallet subhash with a name matching this value. It contains additional information specific to the card wallet type.
+  """
+  type: Stripe_PaymentMethodCardWalletTypeProperty
+  visa_checkout: Stripe_PaymentMethodCardWalletVisaCheckout
+}
+
+type Stripe_PaymentMethodCardWalletAmexExpressCheckout {
+  result: JSONObject
+}
+
+type Stripe_PaymentMethodCardWalletApplePay {
+  result: JSONObject
+}
+
+type Stripe_PaymentMethodCardWalletGooglePay {
+  result: JSONObject
+}
+
+type Stripe_PaymentMethodCardWalletMasterpass {
+  billing_address: Stripe_Address
+
+  """
+  Owner's verified email. Values are verified or provided by the wallet directly (if supported) at the time of authorization or settlement. They cannot be set or mutated.
+  """
+  email: String
+
+  """
+  Owner's verified full name. Values are verified or provided by the wallet directly (if supported) at the time of authorization or settlement. They cannot be set or mutated.
+  """
+  name: String
+  shipping_address: Stripe_Address
+}
+
+type Stripe_PaymentMethodCardWalletSamsungPay {
+  result: JSONObject
+}
+
+enum Stripe_PaymentMethodCardWalletTypeProperty {
+  amex_express_checkout
+  apple_pay
+  google_pay
+  masterpass
+  samsung_pay
+  visa_checkout
+}
+
+type Stripe_PaymentMethodCardWalletVisaCheckout {
+  billing_address: Stripe_Address
+
+  """
+  Owner's verified email. Values are verified or provided by the wallet directly (if supported) at the time of authorization or settlement. They cannot be set or mutated.
+  """
+  email: String
+
+  """
+  Owner's verified full name. Values are verified or provided by the wallet directly (if supported) at the time of authorization or settlement. They cannot be set or mutated.
+  """
+  name: String
+  shipping_address: Stripe_Address
+}
+
+type Stripe_PaymentMethodCardPresent {
+  result: JSONObject
+}
+
+union Stripe_PaymentMethodCustomerProperty = WrappedString | Stripe_Customer
+
+type Stripe_PaymentMethodEps {
+  """
+  The customer's bank. Should be one of `arzte_und_apotheker_bank`, `austrian_anadi_bank_ag`, `bank_austria`, `bankhaus_carl_spangler`, `bankhaus_schelhammer_und_schattera_ag`, `bawag_psk_ag`, `bks_bank_ag`, `brull_kallmus_bank_ag`, `btv_vier_lander_bank`, `capital_bank_grawe_gruppe_ag`, `dolomitenbank`, `easybank_ag`, `erste_bank_und_sparkassen`, `hypo_alpeadriabank_international_ag`, `hypo_noe_lb_fur_niederosterreich_u_wien`, `hypo_oberosterreich_salzburg_steiermark`, `hypo_tirol_bank_ag`, `hypo_vorarlberg_bank_ag`, `hypo_bank_burgenland_aktiengesellschaft`, `marchfelder_bank`, `oberbank_ag`, `raiffeisen_bankengruppe_osterreich`, `schoellerbank_ag`, `sparda_bank_wien`, `volksbank_gruppe`, `volkskreditbank_ag`, or `vr_bank_braunau`.
+  """
+  bank: Stripe_PaymentMethodEpsBankProperty
+}
+
+enum Stripe_PaymentMethodEpsBankProperty {
+  arzte_und_apotheker_bank
+  austrian_anadi_bank_ag
+  bank_austria
+  bankhaus_carl_spangler
+  bankhaus_schelhammer_und_schattera_ag
+  bawag_psk_ag
+  bks_bank_ag
+  brull_kallmus_bank_ag
+  btv_vier_lander_bank
+  capital_bank_grawe_gruppe_ag
+  dolomitenbank
+  easybank_ag
+  erste_bank_und_sparkassen
+  hypo_alpeadriabank_international_ag
+  hypo_bank_burgenland_aktiengesellschaft
+  hypo_noe_lb_fur_niederosterreich_u_wien
+  hypo_oberosterreich_salzburg_steiermark
+  hypo_tirol_bank_ag
+  hypo_vorarlberg_bank_ag
+  marchfelder_bank
+  oberbank_ag
+  raiffeisen_bankengruppe_osterreich
+  schoellerbank_ag
+  sparda_bank_wien
+  volksbank_gruppe
+  volkskreditbank_ag
+  vr_bank_braunau
+}
+
+type Stripe_PaymentMethodFpx {
+  """
+  The customer's bank, if provided. Can be one of `affin_bank`, `alliance_bank`, `ambank`, `bank_islam`, `bank_muamalat`, `bank_rakyat`, `bsn`, `cimb`, `hong_leong_bank`, `hsbc`, `kfh`, `maybank2u`, `ocbc`, `public_bank`, `rhb`, `standard_chartered`, `uob`, `deutsche_bank`, `maybank2e`, or `pb_enterprise`.
+  """
+  bank: Stripe_PaymentMethodFpxBankProperty
+}
+
+enum Stripe_PaymentMethodFpxBankProperty {
+  affin_bank
+  alliance_bank
+  ambank
+  bank_islam
+  bank_muamalat
+  bank_rakyat
+  bsn
+  cimb
+  deutsche_bank
+  hong_leong_bank
+  hsbc
+  kfh
+  maybank2e
+  maybank2u
+  ocbc
+  pb_enterprise
+  public_bank
+  rhb
+  standard_chartered
+  uob
+}
+
+type Stripe_PaymentMethodGiropay {
+  result: JSONObject
+}
+
+type Stripe_PaymentMethodGrabpay {
+  result: JSONObject
+}
+
+type Stripe_PaymentMethodIdeal {
+  """
+  The customer's bank, if provided. Can be one of `abn_amro`, `asn_bank`, `bunq`, `handelsbanken`, `ing`, `knab`, `moneyou`, `rabobank`, `regiobank`, `revolut`, `sns_bank`, `triodos_bank`, or `van_lanschot`.
+  """
+  bank: Stripe_PaymentMethodIdealBankProperty
+
+  """
+  The Bank Identifier Code of the customer's bank, if the bank was provided.
+  """
+  bic: Stripe_PaymentMethodIdealBicProperty
+}
+
+enum Stripe_PaymentMethodIdealBankProperty {
+  abn_amro
+  asn_bank
+  bunq
+  handelsbanken
+  ing
+  knab
+  moneyou
+  rabobank
+  regiobank
+  revolut
+  sns_bank
+  triodos_bank
+  van_lanschot
+}
+
+enum Stripe_PaymentMethodIdealBicProperty {
+  ABNANL2A
+  ASNBNL21
+  BUNQNL2A
+  FVLBNL22
+  HANDNL2A
+  INGBNL2A
+  KNABNL2H
+  MOYONL21
+  RABONL2U
+  RBRBNL21
+  REVOLT21
+  SNSBNL2A
+  TRIONL2U
+}
+
+type Stripe_PaymentMethodInteracPresent {
+  result: JSONObject
+}
+
+enum Stripe_PaymentMethodObjectProperty {
+  payment_method
+}
+
+type Stripe_PaymentMethodOxxo {
+  result: JSONObject
+}
+
+type Stripe_PaymentMethodP24 {
+  """The customer's bank, if provided."""
+  bank: Stripe_PaymentMethodP24BankProperty
+}
+
+enum Stripe_PaymentMethodP24BankProperty {
+  alior_bank
+  bank_millennium
+  bank_nowy_bfg_sa
+  bank_pekao_sa
+  banki_spbdzielcze
+  blik
+  bnp_paribas
+  boz
+  citi_handlowy
+  credit_agricole
+  envelobank
+  etransfer_pocztowy24
+  getin_bank
+  ideabank
+  ing
+  inteligo
+  mbank_mtransfer
+  nest_przelew
+  noble_pay
+  pbac_z_ipko
+  plus_bank
+  santander_przelew24
+  tmobile_usbugi_bankowe
+  toyota_bank
+  volkswagen_bank
+}
+
+type Stripe_PaymentMethodSepaDebit {
+  """Bank code of bank associated with the bank account."""
+  bank_code: String
+
+  """Branch code of bank associated with the bank account."""
+  branch_code: String
+
+  """
+  Two-letter ISO code representing the country the bank account is located in.
+  """
+  country: String
+
+  """
+  Uniquely identifies this particular bank account. You can use this attribute to check whether two bank accounts are the same.
+  """
+  fingerprint: String
+  generated_from: Stripe_SepaDebitGeneratedFrom
+
+  """Last four characters of the IBAN."""
+  last4: String
+}
+
+type Stripe_SepaDebitGeneratedFrom {
+  charge: Stripe_SepaDebitGeneratedFromChargeProperty
+  setup_attempt: Stripe_SepaDebitGeneratedFromSetupAttemptProperty
+}
+
+union Stripe_SepaDebitGeneratedFromChargeProperty = WrappedString | Stripe_Charge
+
+union Stripe_SepaDebitGeneratedFromSetupAttemptProperty = WrappedString | Stripe_SetupAttempt
+
+type Stripe_PaymentMethodSofort {
+  """
+  Two-letter ISO code representing the country the bank account is located in.
+  """
+  country: String
+}
+
+enum Stripe_PaymentMethodTypeProperty {
+  acss_debit
+  afterpay_clearpay
+  alipay
+  au_becs_debit
+  bacs_debit
+  bancontact
+  boleto
+  card
+  card_present
+  eps
+  fpx
+  giropay
+  grabpay
+  ideal
+  interac_present
+  oxxo
+  p24
+  sepa_debit
+  sofort
+  wechat_pay
+}
+
+type Stripe_PaymentMethodWechatPay {
+  result: JSONObject
+}
+
+enum Stripe_CustomerObjectProperty {
+  customer
+}
+
+"""The customer's payment sources, if any."""
+type Stripe_CustomerSourcesProperty {
+  """Details about each object."""
+  data: [Stripe_CustomerSourcesDataProperty!]!
+
+  """
+  True if this list has another page of items after this one that can be fetched.
+  """
+  has_more: Boolean!
+
+  """
+  String representing the object's type. Objects of the same type share the same value. Always has the value `list`.
+  """
+  object: Stripe_CustomerSourcesObjectProperty!
+
+  """The URL where this list can be accessed."""
+  url: String!
+}
+
+union Stripe_CustomerSourcesDataProperty = Stripe_AlipayAccount | Stripe_BankAccount | Stripe_BitcoinReceiver | Stripe_Card | Stripe_Source
+
+enum Stripe_CustomerSourcesObjectProperty {
+  list
+}
+
+"""The customer's current subscriptions, if any."""
+type Stripe_CustomerSubscriptionsProperty {
+  """Details about each object."""
+  data: [Stripe_Subscription!]!
+
+  """
+  True if this list has another page of items after this one that can be fetched.
+  """
+  has_more: Boolean!
+
+  """
+  String representing the object's type. Objects of the same type share the same value. Always has the value `list`.
+  """
+  object: Stripe_CustomerSubscriptionsObjectProperty!
+
+  """The URL where this list can be accessed."""
+  url: String!
+}
+
+enum Stripe_CustomerSubscriptionsObjectProperty {
+  list
+}
+
+type Stripe_CustomerTax {
+  """
+  Surfaces if automatic tax computation is possible given the current customer location information.
+  """
+  automatic_tax: Stripe_CustomerTaxAutomaticTaxProperty
+
+  """
+  A recent IP address of the customer used for tax reporting and tax location inference.
+  """
+  ip_address: String
+  location: Stripe_CustomerTaxLocation
+}
+
+enum Stripe_CustomerTaxAutomaticTaxProperty {
+  failed
+  not_collecting
+  supported
+  unrecognized_location
+}
+
+type Stripe_CustomerTaxLocation {
+  """The customer's country as identified by Stripe Tax."""
+  country: String
+
+  """The data source used to infer the customer's location."""
+  source: Stripe_CustomerTaxLocationSourceProperty
+
+  """
+  The customer's state, county, province, or region as identified by Stripe Tax.
+  """
+  state: String
+}
+
+enum Stripe_CustomerTaxLocationSourceProperty {
+  billing_address
+  ip_address
+  payment_method
+  shipping_destination
+}
+
+enum Stripe_CustomerTaxExemptProperty {
+  exempt
+  none
+  reverse
+}
+
+"""The customer's tax IDs."""
+type Stripe_CustomerTaxIdsProperty {
+  """Details about each object."""
+  data: [Stripe_TaxId!]!
+
+  """
+  True if this list has another page of items after this one that can be fetched.
+  """
+  has_more: Boolean!
+
+  """
+  String representing the object's type. Objects of the same type share the same value. Always has the value `list`.
+  """
+  object: Stripe_CustomerTaxIdsObjectProperty!
+
+  """The URL where this list can be accessed."""
+  url: String!
+}
+
+enum Stripe_CustomerTaxIdsObjectProperty {
+  list
+}
+
+type Stripe_ListProductsResponse {
+  data: [Stripe_Product]
+
+  """
+  True if this list has another page of items after this one that can be fetched.
+  """
+  has_more: Boolean
+
+  """
+  String representing the object's type. Objects of the same type share the same value. Always has the value `list`.
+  """
+  object: Stripe_ListProductsResponseObjectProperty
+
+  """The URL where this list can be accessed."""
+  url: String
+}
+
+enum Stripe_ListProductsResponseObjectProperty {
+  list
+}
+
+type ProfilePaginatedList {
+  items: [Profile!]!
+  total: Int!
+}
+
+input TSWhereProfileInput {
+  id: TSWhereStringInput
+  name: TSWhereStringInput
+  email: TSWhereStringInput
+  bio: TSWhereStringInput
+  avatar: TSWhereAssetRelationshipInput
+  stripeCustomerId: TSWhereStringInput
+  _shapeId: TSWhereIDInput
+  _id: TSWhereIDInput
+  _version: TSWhereIntegerInput
+  _shapeName: TSWhereStringInput
+  _createdAt: TSWhereDateInput
+  _updatedAt: TSWhereDateInput
+  _schemaVersion: TSWhereNumberInput
+  _status: TSWhereWorkflowInput
+  _contentTypeId: TSWhereIDInput
+  _contentTypeName: TSWhereStringInput
+  AND: [TSWhereProfileInput]
+  OR: [TSWhereProfileInput]
+  NOT: TSWhereProfileInput
+}
+
+"""Asset search results"""
+type AssetSearchResults {
+  results: [Asset!]!
+  total: Int!
+}
+
+"""TsStaticSite search results"""
+type TsStaticSiteSearchResults {
+  results: [TsStaticSite!]!
+  total: Int!
+}
+
+"""Profile search results"""
+type ProfileSearchResults {
+  results: [Profile!]!
+  total: Int!
+}
+
+"""TSSearchable search results"""
+type TSSearchableSearchResults {
+  results: [TSSearchable!]!
+  total: Int!
+}
+
+"""This query allow you to pass context to your queries"""
+type WithContext {
+  taxonomySuggest(
+    shapeNames: [String]
+    shapeIds: [String]
+    contentTypeNames: [String]
+    contentTypeIds: [String]
+    terms: String
+    locale: String
+    enableLocaleFallback: Boolean = true
+
+    """The offset from the first result you want to fetch."""
+    from: Int
+
+    """The maximum number of items to return."""
+    size: Int
+
+    """An elasticsearch style filter. Overrides onlyEnabled."""
+    filter: JSON
+
+    """An list of fields to sort by."""
+    sort: [TSSearchSort]
+  ): TSSuggestionPaginatedList
+
+  """List Versions for a piece of content"""
+  getContentVersion(id: ID!, version: Int!, locale: String, enableLocaleFallback: Boolean = true): TSVersionResponse
+
+  """List Versions for a piece of content"""
+  getContentVersionList(id: ID!, from: Int, size: Int): TSVersionsPaginatedList
+
+  """Get a Asset by ID"""
+  getAsset(_id: ID!, locale: String, enableLocaleFallback: Boolean = true): Asset
+
+  """Returns a list Asset in natural order."""
+  getAssetList(
+    terms: String
+
+    """The offset from the first result you want to fetch."""
+    from: Int
+
+    """The maximum number of items to return."""
+    size: Int
+
+    """An elasticsearch style filter. Overrides onlyEnabled."""
+    filter: JSONObject
+
+    """An list of fields to sort by."""
+    sort: [TSSearchSortInput]
+    locale: String
+    enableLocaleFallback: Boolean = true
+
+    """Filter out content that is not enabled. Defaults to true."""
+    onlyEnabled: Boolean = true
+
+    """
+    The where clause uses the boolean AND, OR, and NOT parameters to construct complex filters based on the values of your fields. It applies an implicit AND to all the top-level keys. To avoid this, use a single OR or NOT key as the only top-level key.
+    """
+    where: TSWhereAssetInput
+  ): AssetPaginatedList
+
+  """Get a TsStaticSite by ID"""
+  getTsStaticSite(_id: ID!, locale: String, enableLocaleFallback: Boolean = true): TsStaticSite
+
+  """Returns a list TsStaticSite in natural order."""
+  getTsStaticSiteList(
+    terms: String
+
+    """The offset from the first result you want to fetch."""
+    from: Int
+
+    """The maximum number of items to return."""
+    size: Int
+
+    """An elasticsearch style filter. Overrides onlyEnabled."""
+    filter: JSONObject
+
+    """An list of fields to sort by."""
+    sort: [TSSearchSortInput]
+    locale: String
+    enableLocaleFallback: Boolean = true
+
+    """Filter out content that is not enabled. Defaults to true."""
+    onlyEnabled: Boolean = true
+
+    """
+    The where clause uses the boolean AND, OR, and NOT parameters to construct complex filters based on the values of your fields. It applies an implicit AND to all the top-level keys. To avoid this, use a single OR or NOT key as the only top-level key.
+    """
+    where: TSWhereTsStaticSiteInput
+  ): TsStaticSitePaginatedList
+
+  """Fetch Stripe products from the API Index."""
+  getIndexedProductList(
+    terms: String
+
+    """The offset from the first result you want to fetch."""
+    from: Int
+
+    """The maximum number of items to return."""
+    size: Int
+
+    """An elasticsearch style filter. Overrides onlyEnabled."""
+    filter: JSONObject
+
+    """An list of fields to sort by."""
+    sort: [TSSearchSortInput]
+    locale: String
+    enableLocaleFallback: Boolean = true
+
+    """Filter out content that is not enabled. Defaults to true."""
+    onlyEnabled: Boolean = true
+
+    """
+    The where clause uses the boolean AND, OR, and NOT parameters to construct complex filters based on the values of your fields. It applies an implicit AND to all the top-level keys. To avoid this, use a single OR or NOT key as the only top-level key.
+    """
+    where: TSWhereStripeProductInput
+  ): Stripe_ProductPaginatedList
+
+  """Get my profile"""
+  getMyProfile: Profile
+
+  """Get my subscriptions"""
+  getMySubscriptions(expand: [String]): [Stripe_Subscription]
+
+  """Get my invoices"""
+  getMyInvoices(expand: [String], status: String, limit: Float, created: JSON, startingAfter: String): [Stripe_Invoice]
+
+  """Get my payments"""
+  getMyPayments(expand: [String], limit: Float, created: JSON, startingAfter: String, endingBefore: String): [Stripe_PaymentIntent]
+
+  """Get Stripe products."""
+  getStripeProducts: Stripe_ListProductsResponse
+
+  """Get a profile by ID"""
+  getProfile(_id: ID!, locale: String, enableLocaleFallback: Boolean = true): Profile
+
+  """Returns a list of profiles in natural order."""
+  getProfileList(
+    terms: String
+
+    """The offset from the first result you want to fetch."""
+    from: Int
+
+    """The maximum number of items to return."""
+    size: Int
+
+    """An elasticsearch style filter. Overrides onlyEnabled."""
+    filter: JSONObject
+
+    """An list of fields to sort by."""
+    sort: [TSSearchSortInput]
+    locale: String
+    enableLocaleFallback: Boolean = true
+
+    """Filter out content that is not enabled. Defaults to true."""
+    onlyEnabled: Boolean = true
+
+    """
+    The where clause uses the boolean AND, OR, and NOT parameters to construct complex filters based on the values of your fields. It applies an implicit AND to all the top-level keys. To avoid this, use a single OR or NOT key as the only top-level key.
+    """
+    where: TSWhereProfileInput
+  ): ProfilePaginatedList
+
+  """
+  <p>Returns a list of your products. The products are returned sorted by creation date, with the most recently created products appearing first.</p>
+  """
+  Stripe_listProducts(active: Boolean, created: JSON, ending_before: String, expand: [String], ids: [String], limit: Int, shippable: Boolean, starting_after: String, url: String): Stripe_ListProductsResponse
+
+  """
+  <p>Retrieves the details of an existing product. Supply the unique product ID from either a product creation request or the product list, and Stripe will return the corresponding product information.</p>
+  """
+  Stripe_getProduct(expand: [String], id: String!): Stripe_Product
+  searchAssetIndex(
+    terms: String
+
+    """The offset from the first result you want to fetch."""
+    from: Int
+
+    """The maximum number of items to return."""
+    size: Int
+
+    """An elasticsearch style filter. Overrides onlyEnabled."""
+    filter: JSONObject
+
+    """An list of fields to sort by."""
+    sort: [TSSearchSortInput]
+    locale: String
+    enableLocaleFallback: Boolean = true
+
+    """
+    The where clause uses the boolean AND, OR, and NOT parameters to construct complex filters based on the values of your fields. It applies an implicit AND to all the top-level keys. To avoid this, use a single OR or NOT key as the only top-level key.
+    """
+    where: TSWhereAssetInput
+  ): AssetSearchResults
+  searchTsStaticSiteIndex(
+    terms: String
+
+    """The offset from the first result you want to fetch."""
+    from: Int
+
+    """The maximum number of items to return."""
+    size: Int
+
+    """An elasticsearch style filter. Overrides onlyEnabled."""
+    filter: JSONObject
+
+    """An list of fields to sort by."""
+    sort: [TSSearchSortInput]
+    locale: String
+    enableLocaleFallback: Boolean = true
+
+    """
+    The where clause uses the boolean AND, OR, and NOT parameters to construct complex filters based on the values of your fields. It applies an implicit AND to all the top-level keys. To avoid this, use a single OR or NOT key as the only top-level key.
+    """
+    where: TSWhereTsStaticSiteInput
+  ): TsStaticSiteSearchResults
+  searchProfileIndex(
+    terms: String
+
+    """The offset from the first result you want to fetch."""
+    from: Int
+
+    """The maximum number of items to return."""
+    size: Int
+
+    """An elasticsearch style filter. Overrides onlyEnabled."""
+    filter: JSONObject
+
+    """An list of fields to sort by."""
+    sort: [TSSearchSortInput]
+    locale: String
+    enableLocaleFallback: Boolean = true
+
+    """
+    The where clause uses the boolean AND, OR, and NOT parameters to construct complex filters based on the values of your fields. It applies an implicit AND to all the top-level keys. To avoid this, use a single OR or NOT key as the only top-level key.
+    """
+    where: TSWhereProfileInput
+  ): ProfileSearchResults
+  search(
+    terms: String
+
+    """The offset from the first result you want to fetch."""
+    from: Int
+
+    """The maximum number of items to return."""
+    size: Int
+
+    """An elasticsearch style filter. Overrides onlyEnabled."""
+    filter: JSONObject
+
+    """An list of fields to sort by."""
+    sort: [TSSearchSortInput]
+    locale: String
+    enableLocaleFallback: Boolean = true
+    shapeNames: [String]
+    shapeIds: [String]
+    contentTypeNames: [String]
+    contentTypeIds: [String]
+
+    """
+    The where clause uses the boolean AND, OR, and NOT parameters to construct complex filters based on the values of your fields. It applies an implicit AND to all the top-level keys. To avoid this, use a single OR or NOT key as the only top-level key.
+    """
+    where: TSWhereInput
+  ): TSSearchableSearchResults
+}
+
+type Mutation {
+  """Initiate upload process for asset(s)"""
+  uploadAssets(projectId: ID, files: [TSFile]!): [Upload]
+
+  """Replace an asset file"""
+  replaceAsset(projectId: ID, _id: ID!, _version: Int!, file: TSFile!): Upload
+
+  """Update Asset"""
+  updateAsset(input: UpdateAssetInput!, clientMutationId: String, structure: [ContentStructureInput], locale: String, enableLocaleFallback: Boolean = true): UpdateAssetResult
+
+  """Create Asset"""
+  createAsset(input: CreateAssetInput!, clientMutationId: String): CreateAssetResult
+
+  """Duplicate Asset"""
+  duplicateAsset(input: DuplicateAssetInput!, clientMutationId: String, locale: String, enableLocaleFallback: Boolean = true): DuplicateAssetResult
+
+  """Delete Asset"""
+  deleteAsset(input: DeleteAssetInput!, clientMutationId: String): DeleteAssetResult
+
+  """Update TsStaticSite"""
+  updateTsStaticSite(input: UpdateTsStaticSiteInput!, clientMutationId: String, structure: [ContentStructureInput], locale: String, enableLocaleFallback: Boolean = true): UpdateTsStaticSiteResult
+
+  """Create TsStaticSite"""
+  createTsStaticSite(input: CreateTsStaticSiteInput!, clientMutationId: String): CreateTsStaticSiteResult
+
+  """Duplicate TsStaticSite"""
+  duplicateTsStaticSite(input: DuplicateTsStaticSiteInput!, clientMutationId: String, locale: String, enableLocaleFallback: Boolean = true): DuplicateTsStaticSiteResult
+
+  """Delete TsStaticSite"""
+  deleteTsStaticSite(input: DeleteTsStaticSiteInput!, clientMutationId: String): DeleteTsStaticSiteResult
+
+  """Upsert my profile."""
+  upsertMyProfile(name: String, bio: String, avatarId: String): Profile
+
+  """Upsert my Stripe customer."""
+  upsertMyCustomer(name: String, description: String, address: Stripe_CustomerAddressPropertyInput): Stripe_Customer
+
+  """Delete a Stripe subscription"""
+  deleteMySubscription(subscriptionId: String!): Stripe_Subscription
+
+  """Create a Stripe checkout session."""
+  createMyCheckoutSession(redirectUrl: String!, mode: String, lineItems: [Stripe_CheckoutSessionLineItemsPropertyInput!]!): Stripe_CheckoutSession
+
+  """Update Profile"""
+  updateProfile(input: UpdateProfileInput!, clientMutationId: String, structure: [ContentStructureInput], locale: String, enableLocaleFallback: Boolean = true): UpdateProfileResult
+
+  """Create Profile"""
+  createProfile(input: CreateProfileInput!, clientMutationId: String): CreateProfileResult
+
+  """Duplicate Profile"""
+  duplicateProfile(input: DuplicateProfileInput!, clientMutationId: String, locale: String, enableLocaleFallback: Boolean = true): DuplicateProfileResult
+
+  """Delete Profile"""
+  deleteProfile(input: DeleteProfileInput!, clientMutationId: String): DeleteProfileResult
+}
+
+"""A project file stored on s3"""
+type Upload {
+  uploadUrl: ID
+  asset: Asset
+}
+
+input TSFile {
+  name: String!
+  type: String!
+}
+
+type UpdateAssetResult {
+  clientMutationId: String
+  result: Asset
+}
+
+"""update Asset input"""
+input UpdateAssetInput {
+  _id: ID!
+  title: String
+  description: String
+  filename: String
+  caption: JSON
+  credit: JSON
+  path: String
+  mimeType: String
+  sourceUrl: String
+  uploadStatus: String
+  _shapeId: String
+  _version: Int
+  _shapeName: String
+  _createdAt: String
+  _createdBy: String
+  _updatedAt: String
+  _updatedBy: String
+  _schemaVersion: Float
+  _enabled: Boolean
+  _enabledAt: String
+  _status: DefaultWorkflow
+  _contentTypeId: String
+  _contentTypeName: String
+  s3Key: String
+}
+
+"""Describes a structural update to an array of data."""
+input ContentStructureInput {
+  """A deep path to the array being updated (e.g. a.b[1].c)."""
+  path: String!
+
+  """
+  An array where the indices represent the to index, and the values represent the from index.For example to transform ["a","b","c","d"] into ["c","a"], this value would be [2,0].
+  """
+  structure: [Int]
+}
+
+type CreateAssetResult {
+  clientMutationId: String
+  result: Asset
+}
+
+"""create Asset input"""
+input CreateAssetInput {
+  title: String
+  description: String
+  filename: String!
+  caption: JSON
+  credit: JSON
+  path: String!
+  mimeType: String
+  sourceUrl: String
+  uploadStatus: String
+  _shapeId: String
+  _id: ID
+  _version: Int
+  _shapeName: String
+  _createdAt: String
+  _createdBy: String
+  _updatedAt: String
+  _updatedBy: String
+  _schemaVersion: Float
+  _enabled: Boolean
+  _enabledAt: String
+  _status: DefaultWorkflow
+  _contentTypeId: String
+  _contentTypeName: String
+  s3Key: String
+}
+
+type DuplicateAssetResult {
+  clientMutationId: String
+  result: Asset
+}
+
+"""duplicate Asset input"""
+input DuplicateAssetInput {
+  _id: ID!
+  title: String
+  description: String
+  filename: String
+  caption: JSON
+  credit: JSON
+  path: String
+  mimeType: String
+  sourceUrl: String
+  uploadStatus: String
+  _shapeId: String
+  _version: Int
+  _shapeName: String
+  _createdAt: String
+  _createdBy: String
+  _updatedAt: String
+  _updatedBy: String
+  _schemaVersion: Float
+  _enabled: Boolean
+  _enabledAt: String
+  _status: DefaultWorkflow
+  _contentTypeId: String
+  _contentTypeName: String
+  s3Key: String
+}
+
+type DeleteAssetResult {
+  clientMutationId: String
+  result: Boolean
+}
+
+"""delete Asset input"""
+input DeleteAssetInput {
+  _id: ID!
+}
+
+type UpdateTsStaticSiteResult {
+  clientMutationId: String
+  result: TsStaticSite
+}
+
+"""update TsStaticSite input"""
+input UpdateTsStaticSiteInput {
+  _id: ID!
+  title: String
+  baseUrl: String
+  provider: String
+  idKey: String
+  secretKey: String
+  destination: String
+  privateAcl: Boolean
+  environmentVariables: [TsStaticSiteEnvironmentVariablesInput]
+  triggers: [TsStaticSiteTriggersInput]
+  templateHash: String
+  _shapeId: String
+  _version: Int
+  _shapeName: String
+  _createdAt: String
+  _createdBy: String
+  _updatedAt: String
+  _updatedBy: String
+  _schemaVersion: Float
+  _enabled: Boolean
+  _enabledAt: String
+  _status: DefaultWorkflow
+  _contentTypeId: String
+  _contentTypeName: String
+}
+
+input TsStaticSiteEnvironmentVariablesInput {
+  name: String
+  value: String
+}
+
+input TsStaticSiteTriggersInput {
+  contentTypeId: String
+  status: String
+}
+
+type CreateTsStaticSiteResult {
+  clientMutationId: String
+  result: TsStaticSite
+}
+
+"""create TsStaticSite input"""
+input CreateTsStaticSiteInput {
+  title: String!
+  baseUrl: String
+  provider: String! = "s3"
+  idKey: String
+  secretKey: String
+  destination: String!
+  privateAcl: Boolean
+  environmentVariables: [TsStaticSiteEnvironmentVariablesInput]
+  triggers: [TsStaticSiteTriggersInput]
+  templateHash: String
+  _shapeId: String
+  _id: ID
+  _version: Int
+  _shapeName: String
+  _createdAt: String
+  _createdBy: String
+  _updatedAt: String
+  _updatedBy: String
+  _schemaVersion: Float
+  _enabled: Boolean
+  _enabledAt: String
+  _status: DefaultWorkflow
+  _contentTypeId: String
+  _contentTypeName: String
+}
+
+type DuplicateTsStaticSiteResult {
+  clientMutationId: String
+  result: TsStaticSite
+}
+
+"""duplicate TsStaticSite input"""
+input DuplicateTsStaticSiteInput {
+  _id: ID!
+  title: String
+  baseUrl: String
+  provider: String
+  idKey: String
+  secretKey: String
+  destination: String
+  privateAcl: Boolean
+  environmentVariables: [TsStaticSiteEnvironmentVariablesInput]
+  triggers: [TsStaticSiteTriggersInput]
+  templateHash: String
+  _shapeId: String
+  _version: Int
+  _shapeName: String
+  _createdAt: String
+  _createdBy: String
+  _updatedAt: String
+  _updatedBy: String
+  _schemaVersion: Float
+  _enabled: Boolean
+  _enabledAt: String
+  _status: DefaultWorkflow
+  _contentTypeId: String
+  _contentTypeName: String
+}
+
+type DeleteTsStaticSiteResult {
+  clientMutationId: String
+  result: Boolean
+}
+
+"""delete TsStaticSite input"""
+input DeleteTsStaticSiteInput {
+  _id: ID!
+}
+
+input Stripe_CustomerAddressPropertyInput {
+  line1: String
+  line2: String
+  city: String
+  country: String
+  postal_code: String
+  state: String
+}
+
+type Stripe_CheckoutSession {
+  """Enables user redeemable promotion codes."""
+  allow_promotion_codes: Boolean
+
+  """Total of all items before discounts or taxes are applied."""
+  amount_subtotal: Int
+
+  """Total of all items after discounts and taxes are applied."""
+  amount_total: Int
+  automatic_tax: Stripe_PaymentPagesCheckoutSessionAutomaticTax
+
+  """
+  Describes whether Checkout should collect the customer's billing address.
+  """
+  billing_address_collection: Stripe_CheckoutSessionBillingAddressCollectionProperty
+
+  """
+  The URL the customer will be directed to if they decide to cancel payment and return to your website.
+  """
+  cancel_url: String
+
+  """
+  A unique string to reference the Checkout Session. This can be a
+  customer ID, a cart ID, or similar, and can be used to reconcile the
+  Session with your internal systems.
+  """
+  client_reference_id: String
+
+  """
+  Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
+  """
+  currency: String
+  customer: Stripe_CheckoutSessionCustomerProperty
+  customer_details: Stripe_PaymentPagesCheckoutSessionCustomerDetails
+
+  """
+  If provided, this value will be used when the Customer object is created.
+  If not provided, customers will be asked to enter their email address.
+  Use this parameter to prefill customer data if you already have an email
+  on file. To access information about the customer once the payment flow is
+  complete, use the `customer` attribute.
+  """
+  customer_email: String
+
+  """
+  Unique identifier for the object. Used to pass to `redirectToCheckout`
+  in Stripe.js.
+  """
+  id: String
+
+  """The line items purchased by the customer."""
+  line_items: Stripe_CheckoutSessionLineItemsProperty
+
+  """
+  Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode.
+  """
+  livemode: Boolean
+
+  """
+  The IETF language tag of the locale Checkout is displayed in. If blank or `auto`, the browser's locale is used.
+  """
+  locale: Stripe_CheckoutSessionLocaleProperty
+
+  """
+  Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format.
+  """
+  metadata: JSONObject
+
+  """The mode of the Checkout Session."""
+  mode: Stripe_CheckoutSessionModeProperty
+
+  """
+  String representing the object's type. Objects of the same type share the same value.
+  """
+  object: Stripe_CheckoutSessionObjectProperty
+  payment_intent: Stripe_CheckoutSessionPaymentIntentProperty
+  payment_method_options: Stripe_CheckoutSessionPaymentMethodOptions
+
+  """
+  A list of the types of payment methods (e.g. card) this Checkout
+  Session is allowed to accept.
+  """
+  payment_method_types: [String]
+
+  """
+  The payment status of the Checkout Session, one of `paid`, `unpaid`, or `no_payment_required`.
+  You can use this value to decide when to fulfill your customer's order.
+  """
+  payment_status: Stripe_CheckoutSessionPaymentStatusProperty
+  setup_intent: Stripe_CheckoutSessionSetupIntentProperty
+  shipping: Stripe_Shipping
+  shipping_address_collection: Stripe_PaymentPagesPaymentPageResourcesShippingAddressCollection
+
+  """
+  Describes the type of transaction being performed by Checkout in order to customize
+  relevant text on the page, such as the submit button. `submit_type` can only be
+  specified on Checkout Sessions in `payment` mode, but not Checkout Sessions
+  in `subscription` or `setup` mode.
+  """
+  submit_type: Stripe_CheckoutSessionSubmitTypeProperty
+  subscription: Stripe_CheckoutSessionSubscriptionProperty
+
+  """
+  The URL the customer will be directed to after the payment or
+  subscription creation is successful.
+  """
+  success_url: String
+  tax_id_collection: Stripe_PaymentPagesCheckoutSessionTaxIdCollection
+  total_details: Stripe_PaymentPagesCheckoutSessionTotalDetails
+
+  """The URL to the Checkout Session."""
+  url: String
+}
+
+type Stripe_PaymentPagesCheckoutSessionAutomaticTax {
+  """Indicates whether automatic tax is enabled for the session"""
+  enabled: Boolean
+
+  """
+  The status of the most recent automated tax calculation for this session.
+  """
+  status: Stripe_PaymentPagesCheckoutSessionAutomaticTaxStatusProperty
+}
+
+enum Stripe_PaymentPagesCheckoutSessionAutomaticTaxStatusProperty {
+  complete
+  failed
+  requires_location_inputs
+}
+
+enum Stripe_CheckoutSessionBillingAddressCollectionProperty {
+  auto
+  required
+}
+
+union Stripe_CheckoutSessionCustomerProperty = WrappedString | Stripe_Customer | Stripe_DeletedCustomer
+
+type Stripe_PaymentPagesCheckoutSessionCustomerDetails {
+  """The customer’s email at time of checkout."""
+  email: String
+
+  """The customer’s tax exempt status at time of checkout."""
+  tax_exempt: Stripe_PaymentPagesCheckoutSessionCustomerDetailsTaxExemptProperty
+
+  """The customer’s tax IDs at time of checkout."""
+  tax_ids: [Stripe_PaymentPagesCheckoutSessionTaxId]
+}
+
+enum Stripe_PaymentPagesCheckoutSessionCustomerDetailsTaxExemptProperty {
+  exempt
+  none
+  reverse
+}
+
+type Stripe_PaymentPagesCheckoutSessionTaxId {
+  """
+  The type of the tax ID, one of `eu_vat`, `br_cnpj`, `br_cpf`, `gb_vat`, `nz_gst`, `au_abn`, `in_gst`, `no_vat`, `za_vat`, `ch_vat`, `mx_rfc`, `sg_uen`, `ru_inn`, `ru_kpp`, `ca_bn`, `hk_br`, `es_cif`, `tw_vat`, `th_vat`, `jp_cn`, `jp_rn`, `li_uid`, `my_itn`, `us_ein`, `kr_brn`, `ca_qst`, `ca_gst_hst`, `ca_pst_bc`, `ca_pst_mb`, `ca_pst_sk`, `my_sst`, `sg_gst`, `ae_trn`, `cl_tin`, `sa_vat`, `id_npwp`, `my_frp`, `il_vat`, or `unknown`
+  """
+  type: Stripe_PaymentPagesCheckoutSessionTaxIdTypeProperty
+
+  """The value of the tax ID."""
+  value: String
+}
+
+enum Stripe_PaymentPagesCheckoutSessionTaxIdTypeProperty {
+  ae_trn
+  au_abn
+  br_cnpj
+  br_cpf
+  ca_bn
+  ca_gst_hst
+  ca_pst_bc
+  ca_pst_mb
+  ca_pst_sk
+  ca_qst
+  ch_vat
+  cl_tin
+  es_cif
+  eu_vat
+  gb_vat
+  hk_br
+  id_npwp
+  il_vat
+  in_gst
+  jp_cn
+  jp_rn
+  kr_brn
+  li_uid
+  mx_rfc
+  my_frp
+  my_itn
+  my_sst
+  no_vat
+  nz_gst
+  ru_inn
+  ru_kpp
+  sa_vat
+  sg_gst
+  sg_uen
+  th_vat
+  tw_vat
+  unknown
+  us_ein
+  za_vat
+}
+
+"""The line items purchased by the customer."""
+type Stripe_CheckoutSessionLineItemsProperty {
+  """Details about each object."""
+  data: [Stripe_Item!]!
+
+  """
+  True if this list has another page of items after this one that can be fetched.
+  """
+  has_more: Boolean!
+
+  """
+  String representing the object's type. Objects of the same type share the same value. Always has the value `list`.
+  """
+  object: Stripe_CheckoutSessionLineItemsObjectProperty!
+
+  """The URL where this list can be accessed."""
+  url: String!
+}
+
+enum Stripe_CheckoutSessionLineItemsObjectProperty {
+  list
+}
+
+enum Stripe_CheckoutSessionLocaleProperty {
+  auto
+  bg
+  cs
+  da
+  de
+  el
+  en
+  enDASHGB
+  es
+  esDASH419
+  et
+  fi
+  fr
+  frDASHCA
+  hr
+  hu
+  id
+  it
+  ja
+  ko
+  lt
+  lv
+  ms
+  mt
+  nb
+  nl
+  pl
+  pt
+  ptDASHBR
+  ro
+  ru
+  sk
+  sl
+  sv
+  th
+  tr
+  vi
+  zh
+  zhDASHHK
+  zhDASHTW
+}
+
+enum Stripe_CheckoutSessionModeProperty {
+  payment
+  setup
+  subscription
+}
+
+enum Stripe_CheckoutSessionObjectProperty {
+  checkoutDOTsession
+}
+
+union Stripe_CheckoutSessionPaymentIntentProperty = WrappedString | Stripe_PaymentIntent
+
+type Stripe_CheckoutSessionPaymentMethodOptions {
+  acss_debit: Stripe_CheckoutAcssDebitPaymentMethodOptions
+  boleto: Stripe_PaymentMethodOptionsBoleto
+  oxxo: Stripe_PaymentMethodOptionsOxxo
+}
+
+type Stripe_CheckoutAcssDebitPaymentMethodOptions {
+  """
+  Currency supported by the bank account. Returned when the Session is in `setup` mode.
+  """
+  currency: Stripe_CheckoutAcssDebitPaymentMethodOptionsCurrencyProperty
+  mandate_options: Stripe_CheckoutAcssDebitMandateOptions
+
+  """Bank account verification method."""
+  verification_method: Stripe_CheckoutAcssDebitPaymentMethodOptionsVerificationMethodProperty
+}
+
+enum Stripe_CheckoutAcssDebitPaymentMethodOptionsCurrencyProperty {
+  cad
+  usd
+}
+
+type Stripe_CheckoutAcssDebitMandateOptions {
+  """A URL for custom mandate text"""
+  custom_mandate_url: String
+
+  """
+  Description of the interval. Only required if 'payment_schedule' parmeter is 'interval' or 'combined'.
+  """
+  interval_description: String
+
+  """Payment schedule for the mandate."""
+  payment_schedule: Stripe_CheckoutAcssDebitMandateOptionsPaymentScheduleProperty
+
+  """Transaction type of the mandate."""
+  transaction_type: Stripe_CheckoutAcssDebitMandateOptionsTransactionTypeProperty
+}
+
+enum Stripe_CheckoutAcssDebitMandateOptionsPaymentScheduleProperty {
+  combined
+  interval
+  sporadic
+}
+
+enum Stripe_CheckoutAcssDebitMandateOptionsTransactionTypeProperty {
+  business
+  personal
+}
+
+enum Stripe_CheckoutAcssDebitPaymentMethodOptionsVerificationMethodProperty {
+  automatic
+  instant
+  microdeposits
+}
+
+enum Stripe_CheckoutSessionPaymentStatusProperty {
+  no_payment_required
+  paid
+  unpaid
+}
+
+union Stripe_CheckoutSessionSetupIntentProperty = WrappedString | Stripe_SetupIntent
+
+type Stripe_PaymentPagesPaymentPageResourcesShippingAddressCollection {
+  """
+  An array of two-letter ISO country codes representing which countries Checkout should provide as options for
+  shipping locations. Unsupported country codes: `AS, CX, CC, CU, HM, IR, KP, MH, FM, NF, MP, PW, SD, SY, UM, VI`.
+  """
+  allowed_countries: [Stripe_PaymentPagesPaymentPageResourcesShippingAddressCollectionAllowedCountriesProperty]
+}
+
+enum Stripe_PaymentPagesPaymentPageResourcesShippingAddressCollectionAllowedCountriesProperty {
+  AC
+  AD
+  AE
+  AF
+  AG
+  AI
+  AL
+  AM
+  AO
+  AQ
+  AR
+  AT
+  AU
+  AW
+  AX
+  AZ
+  BA
+  BB
+  BD
+  BE
+  BF
+  BG
+  BH
+  BI
+  BJ
+  BL
+  BM
+  BN
+  BO
+  BQ
+  BR
+  BS
+  BT
+  BV
+  BW
+  BY
+  BZ
+  CA
+  CD
+  CF
+  CG
+  CH
+  CI
+  CK
+  CL
+  CM
+  CN
+  CO
+  CR
+  CV
+  CW
+  CY
+  CZ
+  DE
+  DJ
+  DK
+  DM
+  DO
+  DZ
+  EC
+  EE
+  EG
+  EH
+  ER
+  ES
+  ET
+  FI
+  FJ
+  FK
+  FO
+  FR
+  GA
+  GB
+  GD
+  GE
+  GF
+  GG
+  GH
+  GI
+  GL
+  GM
+  GN
+  GP
+  GQ
+  GR
+  GS
+  GT
+  GU
+  GW
+  GY
+  HK
+  HN
+  HR
+  HT
+  HU
+  ID
+  IE
+  IL
+  IM
+  IN
+  IO
+  IQ
+  IS
+  IT
+  JE
+  JM
+  JO
+  JP
+  KE
+  KG
+  KH
+  KI
+  KM
+  KN
+  KR
+  KW
+  KY
+  KZ
+  LA
+  LB
+  LC
+  LI
+  LK
+  LR
+  LS
+  LT
+  LU
+  LV
+  LY
+  MA
+  MC
+  MD
+  ME
+  MF
+  MG
+  MK
+  ML
+  MM
+  MN
+  MO
+  MQ
+  MR
+  MS
+  MT
+  MU
+  MV
+  MW
+  MX
+  MY
+  MZ
+  NA
+  NC
+  NE
+  NG
+  NI
+  NL
+  NO
+  NP
+  NR
+  NU
+  NZ
+  OM
+  PA
+  PE
+  PF
+  PG
+  PH
+  PK
+  PL
+  PM
+  PN
+  PR
+  PS
+  PT
+  PY
+  QA
+  RE
+  RO
+  RS
+  RU
+  RW
+  SA
+  SB
+  SC
+  SE
+  SG
+  SH
+  SI
+  SJ
+  SK
+  SL
+  SM
+  SN
+  SO
+  SR
+  SS
+  ST
+  SV
+  SX
+  SZ
+  TA
+  TC
+  TD
+  TF
+  TG
+  TH
+  TJ
+  TK
+  TL
+  TM
+  TN
+  TO
+  TR
+  TT
+  TV
+  TW
+  TZ
+  UA
+  UG
+  US
+  UY
+  UZ
+  VA
+  VC
+  VE
+  VG
+  VN
+  VU
+  WF
+  WS
+  XK
+  YE
+  YT
+  ZA
+  ZM
+  ZW
+  ZZ
+}
+
+enum Stripe_CheckoutSessionSubmitTypeProperty {
+  auto
+  book
+  donate
+  pay
+}
+
+union Stripe_CheckoutSessionSubscriptionProperty = WrappedString | Stripe_Subscription
+
+type Stripe_PaymentPagesCheckoutSessionTaxIdCollection {
+  """Indicates whether tax ID collection is enabled for the session"""
+  enabled: Boolean
+}
+
+type Stripe_PaymentPagesCheckoutSessionTotalDetails {
+  """This is the sum of all the line item discounts."""
+  amount_discount: Int
+
+  """This is the sum of all the line item shipping amounts."""
+  amount_shipping: Int
+
+  """This is the sum of all the line item tax amounts."""
+  amount_tax: Int
+  breakdown: Stripe_PaymentPagesCheckoutSessionTotalDetailsResourceBreakdown
+}
+
+type Stripe_PaymentPagesCheckoutSessionTotalDetailsResourceBreakdown {
+  """The aggregated line item discounts."""
+  discounts: [Stripe_LineItemsDiscountAmount]
+
+  """The aggregated line item tax amounts by rate."""
+  taxes: [Stripe_LineItemsTaxAmount]
+}
+
+input Stripe_CheckoutSessionLineItemsPropertyInput {
+  price: String
+  quantity: Int
+}
+
+type UpdateProfileResult {
+  clientMutationId: String
+  result: Profile
+}
+
+"""update Profile input"""
+input UpdateProfileInput {
+  _id: ID!
+
+  """"""
+  id: String
+
+  """"""
+  name: String
+
+  """"""
+  email: String
+
+  """"""
+  bio: String
+
+  """"""
+  avatar: TSRelationshipInput
+
+  """"""
+  stripeCustomerId: String
+  _shapeId: String
+  _version: Int
+  _shapeName: String
+  _createdAt: String
+  _createdBy: String
+  _updatedAt: String
+  _updatedBy: String
+  _schemaVersion: Float
+  _enabled: Boolean
+  _enabledAt: String
+  _status: DefaultWorkflow
+  _contentTypeId: String
+  _contentTypeName: String
+}
+
+input TSRelationshipInput {
+  shapeId: String
+  shapeName: String
+  contentTypeId: String
+  id: String!
+}
+
+type CreateProfileResult {
+  clientMutationId: String
+  result: Profile
+}
+
+"""create Profile input"""
+input CreateProfileInput {
+  """"""
+  id: String
+
+  """"""
+  name: String
+
+  """"""
+  email: String
+
+  """"""
+  bio: String
+
+  """"""
+  avatar: TSRelationshipInput
+
+  """"""
+  stripeCustomerId: String
+  _shapeId: String
+  _id: ID
+  _version: Int
+  _shapeName: String
+  _createdAt: String
+  _createdBy: String
+  _updatedAt: String
+  _updatedBy: String
+  _schemaVersion: Float
+  _enabled: Boolean
+  _enabledAt: String
+  _status: DefaultWorkflow
+  _contentTypeId: String
+  _contentTypeName: String
+}
+
+type DuplicateProfileResult {
+  clientMutationId: String
+  result: Profile
+}
+
+"""duplicate Profile input"""
+input DuplicateProfileInput {
+  _id: ID!
+
+  """"""
+  id: String
+
+  """"""
+  name: String
+
+  """"""
+  email: String
+
+  """"""
+  bio: String
+
+  """"""
+  avatar: TSRelationshipInput
+
+  """"""
+  stripeCustomerId: String
+  _shapeId: String
+  _version: Int
+  _shapeName: String
+  _createdAt: String
+  _createdBy: String
+  _updatedAt: String
+  _updatedBy: String
+  _schemaVersion: Float
+  _enabled: Boolean
+  _enabledAt: String
+  _status: DefaultWorkflow
+  _contentTypeId: String
+  _contentTypeName: String
+}
+
+type DeleteProfileResult {
+  clientMutationId: String
+  result: Boolean
+}
+
+"""delete Profile input"""
+input DeleteProfileInput {
+  _id: ID!
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "incremental": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "baseUrl": "."
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
Adds dedicated product pages.

As a bonus, adds Typescript config and generates types from TakeShape schema. [I love the smell of dogfood in the morning.](https://www.youtube.com/watch?v=nx5N-4JvVyk)

<img width="1272" alt="Screen Shot 2022-03-25 at 5 44 34 PM" src="https://user-images.githubusercontent.com/6089482/160206327-e0c07831-92c1-41f0-95cc-0ab6ccff1fe4.png">

### Test Steps

1. Checkout branch and run `npm i && npm run dev`
2. Clicking on any product image or name should take you to its dedicated page.