### PR TITLE
Add Stripe invoices as Profile.orders

### DIFF
--- a/.takeshape/pattern/schema.json
+++ b/.takeshape/pattern/schema.json
@@ -2054,6 +2054,47 @@
                 ]
               }
             }
+          },
+          "orders": {
+            "title": "Orders",
+            "description": "",
+            "type": "array",
+            "items": {
+              "@ref": "stripe:Invoice"
+            },
+            "@resolver": {
+              "if": "!isEmpty($source.stripeCustomerId)",
+              "id": "invoices",
+              "name": "rest:get",
+              "service": "stripe",
+              "path": "/v1/invoices",
+              "searchParams": {
+                "ops": [
+                  {
+                    "path": "$",
+                    "mapping": "$args"
+                  },
+                  {
+                    "path": "customer",
+                    "mapping": "$source.stripeCustomerId"
+                  }
+                ],
+                "serialize": {
+                  "defaults": {
+                    "style": "deepObject",
+                    "explode": true
+                  }
+                }
+              },
+              "results": {
+                "ops": [
+                  {
+                    "path": "$",
+                    "mapping": "$resolvers.invoices.data"
+                  }
+                ]
+              }
+            }
           }
         }
       }


### PR DESCRIPTION
### Test Plan (Steps to test):

1. Review pattern changes
1. Run a query and verify results, e.g.,
```graphql
{
  getProfileList {
    items {
      id
      orders {
        id
      }
    }
  }
}
```

### Checklist:

- [x] Create a Test Plan
- [x] Changes Communicated (in commits or above)