### PR TITLE
Fixes cart reducers

### DIFF
--- a/components/cart.tsx
+++ b/components/cart.tsx
@@ -61,7 +61,7 @@ const CartItem = ({ product, onChangeQuantity, onClickRemove }) => {
             <strong>{product.name}</strong>
           </div>
           <Flex sx={{ gap: '1rem', alignItems: 'flex-end', margin: '1rem 0' }}>
-            <Quantity id={product.id} defaultValue={product.quantity} onChange={onChangeQuantity} />
+            <Quantity id={product.id} value={product.quantity} onChange={onChangeQuantity} />
             <Box sx={{ fontSize: '.8em' }}>
               <ProductPrice price={product.price} quantity={product.quantity} />
             </Box>

--- a/components/product/add-to-cart.tsx
+++ b/components/product/add-to-cart.tsx
@@ -59,14 +59,14 @@ export const Subscription = ({ id, currentPrice, recurringPayments, onChange }) 
   );
 };
 
-export const Quantity = ({ id, defaultValue, onChange }) => {
+export const Quantity = ({ id, value, onChange }) => {
   const inputId = `${id}-quantity`;
   return (
     <Flex variant="styles.product.quantity" sx={{ flexWrap: 'wrap' }}>
       <Label variant="styles.inputLabel" htmlFor={inputId}>
         Quantity
       </Label>
-      <Input id={inputId} type="number" min={1} defaultValue={defaultValue ?? 1} onChange={onChange} />
+      <Input id={inputId} type="number" min={1} value={value ?? 1} onChange={onChange} />
     </Flex>
   );
 };
@@ -171,7 +171,7 @@ const AddToCart: React.FC<{ product: Stripe_Product }> = ({ product }) => {
       ) : null}
 
       <Flex sx={{ alignItems: 'flex-end', gap: '1rem' }}>
-        <Quantity id={product.id} defaultValue={quantity} onChange={handleUpdateQuantity} />
+        <Quantity id={product.id} value={quantity} onChange={handleUpdateQuantity} />
         <ProductPrice quantity={quantity} price={price} />
       </Flex>
 

--- a/lib/cart/reducer.ts
+++ b/lib/cart/reducer.ts
@@ -30,9 +30,21 @@ const reducer = (state: CartState, action) => {
         isCartOpen: !state.isCartOpen
       };
     case 'ADD_TO_CART':
+      const items = [...state.items];
+      const itemToAdd = action.payload.cartItem;
+      const itemAlreadyInCart = items.find(
+        (item) => item.id === itemToAdd.id && item.price.recurring === itemToAdd.price.recurring
+      );
+      if (itemAlreadyInCart) {
+        // increase quantity of the item
+        const quantity = itemAlreadyInCart.quantity + itemToAdd.quantity;
+        items[items.indexOf(itemAlreadyInCart)] = { ...itemToAdd, quantity };
+      } else {
+        items.push(itemToAdd);
+      }
       return {
         ...state,
-        items: [...state.items, action.payload.cartItem]
+        items
       };
     case 'REMOVE_FROM_CART': {
       const { cartItemIndex } = action.payload;

--- a/lib/cart/reducer.ts
+++ b/lib/cart/reducer.ts
@@ -1,11 +1,18 @@
-export const initialState = {
+export interface CartState {
+  isCartReady: boolean;
+  isCartOpen: boolean;
+  checkoutResult: any | null;
+  items: any[];
+}
+
+export const initialState: CartState = {
   isCartReady: false,
   isCartOpen: false,
   checkoutResult: null,
   items: []
 };
 
-const reducer = (state, action) => {
+const reducer = (state: CartState, action) => {
   switch (action.type) {
     case 'CART_IS_READY':
       return {

--- a/lib/cart/reducer.ts
+++ b/lib/cart/reducer.ts
@@ -36,10 +36,11 @@ const reducer = (state: CartState, action) => {
       };
     case 'REMOVE_FROM_CART': {
       const { cartItemIndex } = action.payload;
-      state.items.splice(cartItemIndex, 1);
+      const itemsCopy = [...state.items];
+      itemsCopy.splice(cartItemIndex, 1);
       return {
         ...state,
-        items: state.items
+        items: itemsCopy
       };
     }
     case 'UPDATE_CART_ITEM': {

--- a/lib/cart/reducer.ts
+++ b/lib/cart/reducer.ts
@@ -48,11 +48,11 @@ const reducer = (state: CartState, action) => {
       };
     case 'REMOVE_FROM_CART': {
       const { cartItemIndex } = action.payload;
-      const itemsCopy = [...state.items];
-      itemsCopy.splice(cartItemIndex, 1);
+      const items = [...state.items];
+      items.splice(cartItemIndex, 1);
       return {
         ...state,
-        items: itemsCopy
+        items
       };
     }
     case 'UPDATE_CART_ITEM': {


### PR DESCRIPTION
- Fix: Removing item no longer removes subsequent item
- Enhancement: Adding an item already in cart updates quantity
- Enhancement: Converts cart reducer to TS

### Test Steps

1. Add item to cart, then add it again. The quantity in the cart should now be `2`.
1. Add an item with a "One time / Subscribe" option and add both a 1 time purchase and a subscription to your cart. They should remain separate cart items.
1. Remove the first item you added to your cart. Only that item should be removed.